### PR TITLE
Default optional account strategy to program ID

### DIFF
--- a/.changeset/many-penguins-beam.md
+++ b/.changeset/many-penguins-beam.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': minor
+---
+
+Default optional account strategy to program ID

--- a/src/idl/IdlInstruction.ts
+++ b/src/idl/IdlInstruction.ts
@@ -5,6 +5,7 @@ export type IdlInstruction = {
   accounts: IdlInstructionAccount[];
   args: IdlInstructionArg[];
   defaultOptionalAccounts?: boolean;
+  legacyOptionalAccountsStrategy?: boolean;
   discriminant?: IdlInstructionDiscriminant;
   docs?: string[];
 };

--- a/src/nodes/InstructionAccountNode.ts
+++ b/src/nodes/InstructionAccountNode.ts
@@ -39,7 +39,7 @@ export function instructionAccountNode(
 
 export function instructionAccountNodeFromIdl(
   idl: IdlInstructionAccount,
-  useProgramIdForOptionalAccounts = false
+  useProgramIdForOptionalAccounts = true
 ): InstructionAccountNode {
   const isOptional = idl.optional ?? idl.isOptional ?? false;
   return instructionAccountNode({

--- a/src/nodes/InstructionNode.ts
+++ b/src/nodes/InstructionNode.ts
@@ -81,7 +81,7 @@ export function instructionNodeFromIdl(
 ): InstructionNode {
   const idlName = idl.name ?? '';
   const name = mainCase(idlName);
-  const useProgramIdForOptionalAccounts = idl.defaultOptionalAccounts ?? false;
+  const useProgramIdForOptionalAccounts = !idl.legacyOptionalAccountsStrategy;
   let dataArgs = structTypeNodeFromIdl({
     kind: 'struct',
     fields: idl.args ?? [],


### PR DESCRIPTION
As the new shank version will assume.

This is a breaking change so the library should be bumped accordingly.