### PR TITLE
Add support for remaining accounts resolution

### DIFF
--- a/.changeset/wild-shoes-beg.md
+++ b/.changeset/wild-shoes-beg.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add support for remaining accounts resolution

--- a/src/nodes/InstructionNode.ts
+++ b/src/nodes/InstructionNode.ts
@@ -4,6 +4,7 @@ import {
   InstructionArgDefault,
   InvalidKinobiTreeError,
   PartialExcept,
+  RemainingAccounts,
   mainCase,
 } from '../shared';
 import {
@@ -38,6 +39,7 @@ export type InstructionNode = {
   readonly docs: string[];
   readonly internal: boolean;
   readonly bytesCreatedOnChain?: BytesCreatedOnChain;
+  readonly remainingAccounts?: RemainingAccounts;
   readonly argDefaults: Record<string, InstructionArgDefault>;
 };
 
@@ -67,6 +69,7 @@ export function instructionNode(input: InstructionNodeInput): InstructionNode {
     docs: input.docs ?? [],
     internal: input.internal ?? false,
     bytesCreatedOnChain: input.bytesCreatedOnChain,
+    remainingAccounts: input.remainingAccounts,
     argDefaults: Object.fromEntries(
       Object.entries(input.argDefaults ?? {}).map(([key, value]) => [
         mainCase(key),

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -467,6 +467,15 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       imports.add(bytes.importFrom, camelCase(bytes.name));
     }
 
+    // Remaining accounts.
+    const { remainingAccounts } = instruction;
+    if (remainingAccounts?.kind === 'resolver') {
+      imports.add(
+        remainingAccounts.importFrom,
+        camelCase(remainingAccounts.name)
+      );
+    }
+
     // canMergeAccountsAndArgs
     let canMergeAccountsAndArgs = false;
     if (!linkedDataArgs && !linkedExtraArgs) {

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -358,8 +358,13 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
     );
     const hasByteResolver =
       instruction.bytesCreatedOnChain?.kind === 'resolver';
+    const hasRemainingAccountsResolver =
+      instruction.remainingAccounts?.kind === 'resolver';
     const hasResolvers =
-      hasArgResolvers || hasAccountResolvers || hasByteResolver;
+      hasArgResolvers ||
+      hasAccountResolvers ||
+      hasByteResolver ||
+      hasRemainingAccountsResolver;
 
     // Resolved inputs.
     const resolvedInputs = visit(
@@ -525,6 +530,7 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         hasArgResolvers,
         hasAccountResolvers,
         hasByteResolver,
+        hasRemainingAccountsResolver,
         hasResolvers,
       })
     );

--- a/src/renderers/js/templates/instructionsPage.njk
+++ b/src/renderers/js/templates/instructionsPage.njk
@@ -48,6 +48,8 @@ export function {{ instruction.name | camelCase }}(
 
   {% include "instructionsPageAccountMetas.njk" %}
 
+  {% include "instructionsPageRemainingAccounts.njk" %}
+
   // Data.
   {% if hasDataArgs %}
     const data = get{{ instruction.dataArgs.name | pascalCase }}Serializer().serialize(resolvedArgs);

--- a/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
+++ b/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
@@ -1,0 +1,14 @@
+{% set remaining = instruction.remainingAccounts %}
+{% if remaining.kind === 'arg' %}
+  // Remaining Accounts.
+  const remainingAccounts = {{ argsObj }}.{{ remaining.name }}.map(address => ([address, {{ "true" if remaining.isWritable else "false" }}]));
+  for (const remainingAccount in remainingAccounts) {
+    addAccountMeta(keys, signers, remainingAccount, false);
+  }
+{% elif remaining.kind === 'resolver' %}
+  // Remaining Accounts.
+  const remainingAccounts = {{ remaining.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId);
+  for (const remainingAccount in remainingAccounts) {
+    addAccountMeta(keys, signers, remainingAccount, false);
+  }
+{% endif %}

--- a/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
+++ b/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
@@ -1,14 +1,14 @@
 {% set remaining = instruction.remainingAccounts %}
+{% macro getArgVar(name, argsObj) -%}
+  {{ 'resolvedArgs' if argsWithDefaults.includes(name) else argsObj }}.{{ name | camelCase }}
+{%- endmacro %}
+
 {% if remaining.kind === 'arg' %}
   // Remaining Accounts.
-  const remainingAccounts = {{ argsObj }}.{{ remaining.name }}.map(address => ([address, {{ "true" if remaining.isWritable else "false" }}]));
-  for (const remainingAccount in remainingAccounts) {
-    addAccountMeta(keys, signers, remainingAccount, false);
-  }
+  const remainingAccounts = {{ getArgVar(remaining.name) }}.map(address => ([address, {{ "true" if remaining.isWritable else "false" }}] as const));
+  remainingAccounts.forEach((remainingAccount) => addAccountMeta(keys, signers, remainingAccount, false));
 {% elif remaining.kind === 'resolver' %}
   // Remaining Accounts.
   const remainingAccounts = {{ remaining.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId);
-  for (const remainingAccount in remainingAccounts) {
-    addAccountMeta(keys, signers, remainingAccount, false);
-  }
+  remainingAccounts.forEach((remainingAccount) => addAccountMeta(keys, signers, remainingAccount, false));
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -92,7 +92,7 @@
       addObjectProperty({{ inputPrefix }} {{ inputDefault }});
     {% endif -%}
   {% endfor %}
-  {% if hasDataArgs or hasByteResolver %}
+  {% if hasDataArgs or hasByteResolver or instruction.remainingAccounts %}
     const resolvedArgs = { ...{{ argsObj }}, ...resolvingArgs };
   {% endif %}
 {% endif %}

--- a/src/shared/RemainingAccounts.ts
+++ b/src/shared/RemainingAccounts.ts
@@ -1,0 +1,37 @@
+import { ImportFrom } from './ImportFrom';
+import { InstructionAccountDefault } from './InstructionDefault';
+import { mainCase } from './utils';
+
+export type RemainingAccounts =
+  | {
+      kind: 'list';
+      accounts: {
+        value: InstructionAccountDefault;
+        isSigner: boolean | 'either';
+        isWritable: boolean;
+      }[];
+    }
+  | { kind: 'arg'; name: string; isWritable: boolean }
+  | { kind: 'resolver'; name: string; importFrom: ImportFrom };
+
+export const remainingAccountsFromList = (
+  accounts: {
+    value: InstructionAccountDefault;
+    isSigner: boolean | 'either';
+    isWritable: boolean;
+  }[]
+): RemainingAccounts => ({ kind: 'list', accounts });
+
+export const remainingAccountsFromArg = (
+  arg: string,
+  isWritable: boolean = false
+): RemainingAccounts => ({ kind: 'arg', name: mainCase(arg), isWritable });
+
+export const remainingAccountsFromResolver = (
+  name: string,
+  importFrom: ImportFrom = 'hooked'
+): RemainingAccounts => ({
+  kind: 'resolver',
+  name: mainCase(name),
+  importFrom,
+});

--- a/src/shared/RemainingAccounts.ts
+++ b/src/shared/RemainingAccounts.ts
@@ -1,26 +1,9 @@
 import { ImportFrom } from './ImportFrom';
-import { InstructionAccountDefault } from './InstructionDefault';
 import { mainCase } from './utils';
 
 export type RemainingAccounts =
-  | {
-      kind: 'list';
-      accounts: {
-        value: InstructionAccountDefault;
-        isSigner: boolean | 'either';
-        isWritable: boolean;
-      }[];
-    }
   | { kind: 'arg'; name: string; isWritable: boolean }
   | { kind: 'resolver'; name: string; importFrom: ImportFrom };
-
-export const remainingAccountsFromList = (
-  accounts: {
-    value: InstructionAccountDefault;
-    isSigner: boolean | 'either';
-    isWritable: boolean;
-  }[]
-): RemainingAccounts => ({ kind: 'list', accounts });
 
 export const remainingAccountsFromArg = (
   arg: string,

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -5,6 +5,7 @@ export * from './BytesCreatedOnChain';
 export * from './GpaField';
 export * from './ImportFrom';
 export * from './InstructionDefault';
+export * from './RemainingAccounts';
 export * from './SizeStrategy';
 export * from './errors';
 export * from './logs';

--- a/test/package/src/generated/instructions/dummy.ts
+++ b/test/package/src/generated/instructions/dummy.ts
@@ -67,12 +67,15 @@ export function getDummyInstructionDataSerializer(
 }
 
 // Extra Args.
-export type DummyInstructionExtraArgs = { identityArg: PublicKey };
+export type DummyInstructionExtraArgs = {
+  identityArg: PublicKey;
+  proof: Array<PublicKey>;
+};
 
 // Args.
 export type DummyInstructionArgs = PickPartial<
   DummyInstructionExtraArgs,
-  'identityArg'
+  'identityArg' | 'proof'
 >;
 
 // Instruction.
@@ -147,6 +150,8 @@ export function dummy(
     'identityArg',
     input.identityArg ?? context.identity.publicKey
   );
+  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
+  const resolvedArgs = { ...input, ...resolvingArgs };
 
   addAccountMeta(keys, signers, resolvedAccounts.edition, true);
   addAccountMeta(keys, signers, resolvedAccounts.mint, false);
@@ -156,6 +161,14 @@ export function dummy(
   addAccountMeta(keys, signers, resolvedAccounts.foo, false);
   addAccountMeta(keys, signers, resolvedAccounts.bar, false);
   addAccountMeta(keys, signers, resolvedAccounts.delegateRecord, false);
+
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.proof.map(
+    (address) => [address, false] as const
+  );
+  remainingAccounts.forEach((remainingAccount) =>
+    addAccountMeta(keys, signers, remainingAccount, false)
+  );
 
   // Data.
   const data = getDummyInstructionDataSerializer().serialize({});

--- a/test/testFile.cjs
+++ b/test/testFile.cjs
@@ -116,7 +116,14 @@ kinobi.update(
           type: k.publicKeyTypeNode(),
           defaultsTo: k.identityDefault(),
         },
+        proof: {
+          type: k.arrayTypeNode(k.publicKeyTypeNode(), {
+            size: k.remainderSize(),
+          }),
+          defaultsTo: k.valueDefault(k.vList([])),
+        },
       },
+      remainingAccounts: k.remainingAccountsFromArg('proof'),
     },
     DeprecatedCreateReservationList: { name: 'CreateReservationList' },
     Transfer: {


### PR DESCRIPTION
Adds two strategy for resolving remaining accounts on a given instruction:
- `arg`, which expects an array of `PublicKey`, `Signer` or both as an (extra) argument, and use that arg to fill remaining accounts.
- `resolver` for custom remaining accounts resolution.

For example, imagine the following example that burns Compressed NFTs and accepts the "Proof" of the leaf to burn as remaining accounts.

```ts
await burn(umi, {
  // ...
}).sendAndConfirm(umi);
```

Given an array of `PublicKey` as the Proof, before this PR we would need to do the following:

```ts
const proofs = [...];

await burn(umi, {
  // ...
})
  .addRemainingAccounts(proofs.map(pubkey) => {
    pubkey,
    isSigner: false,
    isWritable: false,
  })
  .sendAndConfirm(umi);
```

After this PR, we can now pass the proof directly as an extra argument of the burn instruction like so:

```ts
const proofs = [...];

await burn(umi, {
  proofs,
  // ...
}).sendAndConfirm(umi);
```

To make this work, we simply need to tell Kinobi that the remaining accounts of the burn instruction rely on an extra argument called `proof`.

```ts
kinobi.update(
  new k.UpdateInstructionsVisitor({
    burn: {
      args: {
        // Add the "proof" extra argument defaulting to an empty array.
        proof: {
          type: k.arrayTypeNode(k.publicKeyTypeNode(), { size: k.remainderSize() }),
          defaultsTo: k.valueDefault(k.vList([])),
        },
      },
      // Use the "proof" argument to fill remaining accounts.
      remainingAccounts: k.remainingAccountsFromArg('proof'),
    },
  })
);
```