### PR TITLE
Move default args resolution to builders

### DIFF
--- a/.changeset/brown-chefs-jam.md
+++ b/.changeset/brown-chefs-jam.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Move default args resolution to builders

--- a/src/renderers/rust/GetRustRenderMapVisitor.ts
+++ b/src/renderers/rust/GetRustRenderMapVisitor.ts
@@ -233,9 +233,9 @@ export class GetRustRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         );
         imports.mergeWith(argImports);
         renderValue = value;
-      } else {
-        hasArgs = true;
       }
+        
+      hasArgs = hasArgs || field.defaultsTo?.strategy !== 'omitted';
       hasOptional = hasOptional || field.defaultsTo?.strategy === 'optional';
 
       const name = accountsAndArgsConflicts.includes(field.name)

--- a/src/renderers/rust/GetRustRenderMapVisitor.ts
+++ b/src/renderers/rust/GetRustRenderMapVisitor.ts
@@ -234,7 +234,7 @@ export class GetRustRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         imports.mergeWith(argImports);
         renderValue = value;
       }
-        
+
       hasArgs = hasArgs || field.defaultsTo?.strategy !== 'omitted';
       hasOptional = hasOptional || field.defaultsTo?.strategy === 'optional';
 

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -32,10 +32,6 @@ impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
   #[allow(clippy::clone_on_copy)]
   #[allow(clippy::vec_init_then_push)]
   pub fn invoke_signed(&self, signers_seeds: &[&[&[u8]]]) -> solana_program::entrypoint::ProgramResult {
-    {% if hasArgs === false %}
-    let args = {{ instruction.name | pascalCase }}InstructionArgs::new();
-    {% endif %}
-
     let mut accounts = Vec::with_capacity({{ instruction.accounts.length }});
     {% for account in instruction.accounts %}
       {% if account.isSigner === 'either' %}
@@ -92,11 +88,16 @@ impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
         {% endif %}
       {% endif %}
     {% endfor %}
+    let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();
+    {% if hasArgs %}
+      let mut args = self.__args.try_to_vec().unwrap();
+      data.append(&mut args);
+    {% endif %}
 
     let instruction = solana_program::instruction::Instruction {
       program_id: crate::{{ program.name | snakeCase | upper }}_ID,
       accounts,
-      data: {{ 'self.__' if hasArgs }}args.try_to_vec().unwrap(),
+      data,
     };
     let mut account_infos = Vec::with_capacity({{ instruction.accounts.length }} + 1);
     account_infos.push(self.__program.clone());

--- a/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
@@ -34,6 +34,7 @@ impl<'a> {{ instruction.name | pascalCase }}CpiBuilder<'a> {
   {% for arg in instructionArgs %}
     {% if not arg.default %}
       {{'/// `[optional argument]`\n' if arg.innerOptionType }}
+      {{- "/// `[optional argument, defaults to '" + arg.value + "']`\n" if not arg.innerOptionType and arg.value -}}
       {{- macros.docblock(arg.docs) -}}
       #[inline(always)]
       pub fn {{ arg.name | snakeCase }}(&mut self, {{ arg.name | snakeCase }}: {{ arg.innerOptionType or arg.type }}) -> &mut Self {
@@ -45,24 +46,21 @@ impl<'a> {{ instruction.name | pascalCase }}CpiBuilder<'a> {
   #[allow(clippy::clone_on_copy)]
   pub fn build(&self) -> {{ instruction.name | pascalCase }}Cpi<'a> {
     {% if hasArgs %}
-      let {{ 'mut' if hasOptional }} args = {{ instruction.name | pascalCase }}InstructionArgs::new(
+      let args = {{ instruction.name | pascalCase }}InstructionArgs {
         {% for arg in instructionArgs %}
-          {% if not arg.default and not arg.optional %}
-            self.instruction.{{ arg.name | snakeCase }}.clone(){{ '.expect(\"' + arg.name | snakeCase + ' is not set\")' if not arg.innerOptionType }},
+          {% if not arg.default %}
+            {% if arg.optional %}
+              {% if arg.innerOptionType %}
+                {{ arg.name | snakeCase }}: self.instruction.{{ arg.name | snakeCase }}.clone(),
+              {% else %}
+                {{ arg.name | snakeCase }}: self.instruction.{{ arg.name | snakeCase }}.clone(){{ '.unwrap_or(' + arg.value + ')' if arg.value else '.expect(\"' + arg.name | snakeCase + ' is not set\")' }},
+              {% endif %}
+            {% else %}
+              {{ arg.name | snakeCase }}: self.instruction.{{ arg.name | snakeCase }}.clone(){{ '.expect(\"' + arg.name | snakeCase + ' is not set\")' if not arg.innerOptionType }},
+            {% endif %}
           {% endif %}
         {% endfor %}
-      );
-      {% for arg in instructionArgs %}
-        {% if arg.optional %}
-          {% if arg.innerOptionType %}
-            args.{{ arg.name | snakeCase }} = self.instruction.{{ arg.name | snakeCase }}.clone();
-          {% else %}
-            if let Some({{ arg.name | snakeCase }}) = &self.instruction.{{ arg.name | snakeCase }} {
-              args.{{ arg.name | snakeCase }} = {{ arg.name | snakeCase }}.clone();
-            }
-          {% endif %}
-        {% endif %}
-      {% endfor %}
+      };
     {% endif %}
 
     {{ instruction.name | pascalCase }}Cpi {

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -29,10 +29,6 @@ pub struct {{ instruction.name | pascalCase }} {
 impl {{ instruction.name | pascalCase }} {
   #[allow(clippy::vec_init_then_push)]
   pub fn instruction(&self{{ ', args: ' + instruction.name | pascalCase + 'InstructionArgs' if hasArgs }}) -> solana_program::instruction::Instruction {
-    {% if hasArgs === false %}
-    let args = {{ instruction.name | pascalCase }}InstructionArgs::new();
-    {% endif %}
-
     let mut accounts = Vec::with_capacity({{ instruction.accounts.length }});
     {% for account in instruction.accounts %}
       {% if account.isSigner === 'either' %}
@@ -93,46 +89,56 @@ impl {{ instruction.name | pascalCase }} {
         {% endif %}
       {% endif %}
     {% endfor %}
+    let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();
+    {% if hasArgs %}
+      let mut args = args.try_to_vec().unwrap();
+      data.append(&mut args);
+    {% endif %}
 
     solana_program::instruction::Instruction {
       program_id: crate::{{ program.name | snakeCase | upper }}_ID,
       accounts,
-      data: args.try_to_vec().unwrap(),
+      data,
     }
   }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-{{ 'pub ' if hasArgs }}struct {{ instruction.name | pascalCase }}InstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct {{ instruction.name | pascalCase }}InstructionData {
   {% for arg in instructionArgs %}
-    {{ 'pub ' if not arg.default }}{{ arg.name | snakeCase }}: {{ arg.type }},
+    {% if arg.default %}
+      {{ arg.name | snakeCase }}: {{ arg.type }},
+    {% endif %}
   {% endfor %}
 }
 
-{% for nestedStruct in typeManifest.nestedStructs %}
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-{{ nestedStruct }}
-{% endfor %}
-
-impl {{ instruction.name | pascalCase }}InstructionArgs {
-  pub fn new(
-    {% for arg in instructionArgs %}
-      {% if not arg.default and not arg.optional %}
-        {{ arg.name | snakeCase }}: {{ arg.type }},
-      {% endif %}
-    {% endfor %}
-  ) -> Self {
+impl {{ instruction.name | pascalCase }}InstructionData {
+  fn new() -> Self {
     Self {
       {% for arg in instructionArgs %}
-        {% if arg.default or arg.optional %}
+        {% if arg.default %}
           {{ arg.name | snakeCase }}: {{ arg.value }},
-        {% else %}
-          {{ arg.name | snakeCase }},
         {% endif %}
       {% endfor %}
     }
   }
 }
+
+{% if hasArgs %}
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+pub struct {{ instruction.name | pascalCase }}InstructionArgs {
+  {% for arg in instructionArgs %}
+    {% if not arg.default %}
+      pub {{ arg.name | snakeCase }}: {{ arg.type }},
+    {% endif %}
+  {% endfor %}
+}
+{% endif %}
+
+{% for nestedStruct in typeManifest.nestedStructs %}
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+{{ nestedStruct }}
+{% endfor %}
 
 {% include "instructionsPageBuilder.njk" %}
 

--- a/src/renderers/rust/templates/instructionsPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsPageBuilder.njk
@@ -34,7 +34,8 @@ impl {{ instruction.name | pascalCase }}Builder {
   {% endfor %}
   {% for arg in instructionArgs %}
     {% if not arg.default %}
-      {{'/// `[optional argument]`\n' if arg.innerOptionType }}
+      {{ '/// `[optional argument]`\n' if arg.innerOptionType }}
+      {{- "/// `[optional argument, defaults to '" + arg.value + "']`\n" if not arg.innerOptionType and arg.value -}}
       {{- macros.docblock(arg.docs) -}}
       #[inline(always)]
       pub fn {{ arg.name | snakeCase }}(&mut self, {{ arg.name | snakeCase }}: {{ arg.innerOptionType or arg.type }}) -> &mut Self {
@@ -61,24 +62,21 @@ impl {{ instruction.name | pascalCase }}Builder {
         {% endfor %}
     };
     {% if hasArgs %}
-      let {{ 'mut' if hasOptional }} args = {{ instruction.name | pascalCase }}InstructionArgs::new(
+      let args = {{ instruction.name | pascalCase }}InstructionArgs {
         {% for arg in instructionArgs %}
-          {% if not arg.default and not arg.optional %}
-            self.{{ arg.name | snakeCase }}.clone(){{ '.expect(\"' + arg.name | snakeCase + ' is not set\")' if not arg.innerOptionType }},
+          {% if not arg.default %}
+            {% if arg.optional %}
+              {% if arg.innerOptionType %}
+                {{ arg.name | snakeCase }}: self.{{ arg.name | snakeCase }}.clone(),
+              {% else %}
+                {{ arg.name | snakeCase }}: self.{{ arg.name | snakeCase }}.clone(){{ '.unwrap_or(' + arg.value + ')' if arg.value else '.expect(\"' + arg.name | snakeCase + ' is not set\")' }},
+              {% endif %}
+            {% else %}
+              {{ arg.name | snakeCase }}: self.{{ arg.name | snakeCase }}.clone(){{ '.expect(\"' + arg.name | snakeCase + ' is not set\")' if not arg.innerOptionType }},
+            {% endif %}
           {% endif %}
         {% endfor %}
-      );
-      {% for arg in instructionArgs %}
-        {% if arg.optional %}
-          {% if arg.innerOptionType %}
-            args.{{ arg.name | snakeCase }} = self.{{ arg.name | snakeCase }}.clone();
-          {% else %}
-            if let Some({{ arg.name | snakeCase }}) = &self.{{ arg.name | snakeCase }} {
-              args.{{ arg.name | snakeCase }} = {{ arg.name | snakeCase }}.clone();
-            }
-          {% endif %}
-        {% endif %}
-      {% endfor %}
+      };
     {% endif %}
 
     accounts.instruction({{ 'args' if hasArgs }})

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -31,30 +31,35 @@ impl AddConfigLines {
             self.authority,
             true,
         ));
+        let mut data = AddConfigLinesInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct AddConfigLinesInstructionData {
+    discriminator: [u8; 8],
+}
+
+impl AddConfigLinesInstructionData {
+    fn new() -> Self {
+        Self {
+            discriminator: [223, 50, 224, 227, 151, 8, 115, 106],
         }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct AddConfigLinesInstructionArgs {
-    discriminator: [u8; 8],
     pub index: u32,
     pub config_lines: Vec<ConfigLine>,
-}
-
-impl AddConfigLinesInstructionArgs {
-    pub fn new(index: u32, config_lines: Vec<ConfigLine>) -> Self {
-        Self {
-            discriminator: [223, 50, 224, 227, 151, 8, 115, 106],
-            index,
-            config_lines,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -96,10 +101,10 @@ impl AddConfigLinesBuilder {
             candy_machine: self.candy_machine.expect("candy_machine is not set"),
             authority: self.authority.expect("authority is not set"),
         };
-        let args = AddConfigLinesInstructionArgs::new(
-            self.index.clone().expect("index is not set"),
-            self.config_lines.clone().expect("config_lines is not set"),
-        );
+        let args = AddConfigLinesInstructionArgs {
+            index: self.index.clone().expect("index is not set"),
+            config_lines: self.config_lines.clone().expect("config_lines is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -136,11 +141,14 @@ impl<'a> AddConfigLinesCpi<'a> {
             *self.authority.key,
             true,
         ));
+        let mut data = AddConfigLinesInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());
@@ -199,13 +207,14 @@ impl<'a> AddConfigLinesCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> AddConfigLinesCpi<'a> {
-        let args = AddConfigLinesInstructionArgs::new(
-            self.instruction.index.clone().expect("index is not set"),
-            self.instruction
+        let args = AddConfigLinesInstructionArgs {
+            index: self.instruction.index.clone().expect("index is not set"),
+            config_lines: self
+                .instruction
                 .config_lines
                 .clone()
                 .expect("config_lines is not set"),
-        );
+        };
 
         AddConfigLinesCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -31,8 +31,6 @@ pub struct ApproveCollectionAuthority {
 impl ApproveCollectionAuthority {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = ApproveCollectionAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.collection_authority_record,
@@ -70,22 +68,25 @@ impl ApproveCollectionAuthority {
                 false,
             ));
         }
+        let data = ApproveCollectionAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct ApproveCollectionAuthorityInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct ApproveCollectionAuthorityInstructionData {
     discriminator: u8,
 }
 
-impl ApproveCollectionAuthorityInstructionArgs {
-    pub fn new() -> Self {
+impl ApproveCollectionAuthorityInstructionData {
+    fn new() -> Self {
         Self { discriminator: 23 }
     }
 }
@@ -220,8 +221,6 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = ApproveCollectionAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.collection_authority_record.key,
@@ -261,11 +260,14 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
                 false,
             ));
         }
+        let data = ApproveCollectionAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(8 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -87,28 +87,34 @@ impl ApproveUseAuthority {
                 false,
             ));
         }
+        let mut data = ApproveUseAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct ApproveUseAuthorityInstructionData {
+    discriminator: u8,
+}
+
+impl ApproveUseAuthorityInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 20 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct ApproveUseAuthorityInstructionArgs {
-    discriminator: u8,
     pub number_of_uses: u64,
-}
-
-impl ApproveUseAuthorityInstructionArgs {
-    pub fn new(number_of_uses: u64) -> Self {
-        Self {
-            discriminator: 20,
-            number_of_uses,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -233,11 +239,12 @@ impl ApproveUseAuthorityBuilder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             rent: self.rent,
         };
-        let args = ApproveUseAuthorityInstructionArgs::new(
-            self.number_of_uses
+        let args = ApproveUseAuthorityInstructionArgs {
+            number_of_uses: self
+                .number_of_uses
                 .clone()
                 .expect("number_of_uses is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -334,11 +341,16 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
                 false,
             ));
         }
+        let mut data = ApproveUseAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(11 + 1);
         account_infos.push(self.__program.clone());
@@ -480,12 +492,13 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> ApproveUseAuthorityCpi<'a> {
-        let args = ApproveUseAuthorityInstructionArgs::new(
-            self.instruction
+        let args = ApproveUseAuthorityInstructionArgs {
+            number_of_uses: self
+                .instruction
                 .number_of_uses
                 .clone()
                 .expect("number_of_uses is not set"),
-        );
+        };
 
         ApproveUseAuthorityCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -57,28 +57,34 @@ impl BubblegumSetCollectionSize {
                 false,
             ));
         }
+        let mut data = BubblegumSetCollectionSizeInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct BubblegumSetCollectionSizeInstructionData {
+    discriminator: u8,
+}
+
+impl BubblegumSetCollectionSizeInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 36 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct BubblegumSetCollectionSizeInstructionArgs {
-    discriminator: u8,
     pub set_collection_size_args: SetCollectionSizeArgs,
-}
-
-impl BubblegumSetCollectionSizeInstructionArgs {
-    pub fn new(set_collection_size_args: SetCollectionSizeArgs) -> Self {
-        Self {
-            discriminator: 36,
-            set_collection_size_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -163,11 +169,12 @@ impl BubblegumSetCollectionSizeBuilder {
             bubblegum_signer: self.bubblegum_signer.expect("bubblegum_signer is not set"),
             collection_authority_record: self.collection_authority_record,
         };
-        let args = BubblegumSetCollectionSizeInstructionArgs::new(
-            self.set_collection_size_args
+        let args = BubblegumSetCollectionSizeInstructionArgs {
+            set_collection_size_args: self
+                .set_collection_size_args
                 .clone()
                 .expect("set_collection_size_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -229,11 +236,16 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
                 false,
             ));
         }
+        let mut data = BubblegumSetCollectionSizeInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(5 + 1);
         account_infos.push(self.__program.clone());
@@ -327,12 +339,13 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> BubblegumSetCollectionSizeCpi<'a> {
-        let args = BubblegumSetCollectionSizeInstructionArgs::new(
-            self.instruction
+        let args = BubblegumSetCollectionSizeInstructionArgs {
+            set_collection_size_args: self
+                .instruction
                 .set_collection_size_args
                 .clone()
                 .expect("set_collection_size_args is not set"),
-        );
+        };
 
         BubblegumSetCollectionSizeCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -93,28 +93,32 @@ impl Burn {
                 false,
             ));
         }
+        let mut data = BurnInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct BurnInstructionData {
+    discriminator: u8,
+}
+
+impl BurnInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 44 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct BurnInstructionArgs {
-    discriminator: u8,
     pub burn_args: BurnArgs,
-}
-
-impl BurnInstructionArgs {
-    pub fn new(burn_args: BurnArgs) -> Self {
-        Self {
-            discriminator: 44,
-            burn_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -230,7 +234,9 @@ impl BurnBuilder {
             authorization_rules: self.authorization_rules,
             authorization_rules_program: self.authorization_rules_program,
         };
-        let args = BurnInstructionArgs::new(self.burn_args.clone().expect("burn_args is not set"));
+        let args = BurnInstructionArgs {
+            burn_args: self.burn_args.clone().expect("burn_args is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -330,11 +336,14 @@ impl<'a> BurnCpi<'a> {
                 false,
             ));
         }
+        let mut data = BurnInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(9 + 1);
         account_infos.push(self.__program.clone());
@@ -469,12 +478,13 @@ impl<'a> BurnCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> BurnCpi<'a> {
-        let args = BurnInstructionArgs::new(
-            self.instruction
+        let args = BurnInstructionArgs {
+            burn_args: self
+                .instruction
                 .burn_args
                 .clone()
                 .expect("burn_args is not set"),
-        );
+        };
 
         BurnCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -35,8 +35,6 @@ pub struct BurnEditionNft {
 impl BurnEditionNft {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = BurnEditionNftInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(10);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -77,22 +75,23 @@ impl BurnEditionNft {
             self.spl_token_program,
             false,
         ));
+        let data = BurnEditionNftInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct BurnEditionNftInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct BurnEditionNftInstructionData {
     discriminator: u8,
 }
 
-impl BurnEditionNftInstructionArgs {
-    pub fn new() -> Self {
+impl BurnEditionNftInstructionData {
+    fn new() -> Self {
         Self { discriminator: 37 }
     }
 }
@@ -271,8 +270,6 @@ impl<'a> BurnEditionNftCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = BurnEditionNftInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(10);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -314,11 +311,12 @@ impl<'a> BurnEditionNftCpi<'a> {
             *self.spl_token_program.key,
             false,
         ));
+        let data = BurnEditionNftInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(10 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -29,8 +29,6 @@ pub struct BurnNft {
 impl BurnNft {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = BurnNftInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(7);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -65,22 +63,23 @@ impl BurnNft {
                 false,
             ));
         }
+        let data = BurnNftInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct BurnNftInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct BurnNftInstructionData {
     discriminator: u8,
 }
 
-impl BurnNftInstructionArgs {
-    pub fn new() -> Self {
+impl BurnNftInstructionData {
+    fn new() -> Self {
         Self { discriminator: 29 }
     }
 }
@@ -203,8 +202,6 @@ impl<'a> BurnNftCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = BurnNftInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(7);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -241,11 +238,12 @@ impl<'a> BurnNftCpi<'a> {
                 false,
             ));
         }
+        let data = BurnNftInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(7 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -31,8 +31,6 @@ pub struct CloseEscrowAccount {
 impl CloseEscrowAccount {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = CloseEscrowAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.escrow,
@@ -64,22 +62,25 @@ impl CloseEscrowAccount {
             self.sysvar_instructions,
             false,
         ));
+        let data = CloseEscrowAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct CloseEscrowAccountInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CloseEscrowAccountInstructionData {
     discriminator: u8,
 }
 
-impl CloseEscrowAccountInstructionArgs {
-    pub fn new() -> Self {
+impl CloseEscrowAccountInstructionData {
+    fn new() -> Self {
         Self { discriminator: 39 }
     }
 }
@@ -205,8 +206,6 @@ impl<'a> CloseEscrowAccountCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = CloseEscrowAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.escrow.key,
@@ -240,11 +239,14 @@ impl<'a> CloseEscrowAccountCpi<'a> {
             *self.sysvar_instructions.key,
             false,
         ));
+        let data = CloseEscrowAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(8 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -21,8 +21,6 @@ pub struct ConvertMasterEditionV1ToV2 {
 impl ConvertMasterEditionV1ToV2 {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = ConvertMasterEditionV1ToV2InstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(3);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.master_edition,
@@ -36,22 +34,25 @@ impl ConvertMasterEditionV1ToV2 {
             self.printing_mint,
             false,
         ));
+        let data = ConvertMasterEditionV1ToV2InstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct ConvertMasterEditionV1ToV2InstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct ConvertMasterEditionV1ToV2InstructionData {
     discriminator: u8,
 }
 
-impl ConvertMasterEditionV1ToV2InstructionArgs {
-    pub fn new() -> Self {
+impl ConvertMasterEditionV1ToV2InstructionData {
+    fn new() -> Self {
         Self { discriminator: 12 }
     }
 }
@@ -120,8 +121,6 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = ConvertMasterEditionV1ToV2InstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(3);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.master_edition.key,
@@ -135,11 +134,14 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
             *self.printing_mint.key,
             false,
         ));
+        let data = ConvertMasterEditionV1ToV2InstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(3 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -33,8 +33,6 @@ pub struct CreateEscrowAccount {
 impl CreateEscrowAccount {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = CreateEscrowAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(9);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.escrow,
@@ -76,22 +74,25 @@ impl CreateEscrowAccount {
                 false,
             ));
         }
+        let data = CreateEscrowAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct CreateEscrowAccountInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateEscrowAccountInstructionData {
     discriminator: u8,
 }
 
-impl CreateEscrowAccountInstructionArgs {
-    pub fn new() -> Self {
+impl CreateEscrowAccountInstructionData {
+    fn new() -> Self {
         Self { discriminator: 38 }
     }
 }
@@ -228,8 +229,6 @@ impl<'a> CreateEscrowAccountCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = CreateEscrowAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(9);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.escrow.key,
@@ -274,11 +273,14 @@ impl<'a> CreateEscrowAccountCpi<'a> {
                 false,
             ));
         }
+        let data = CreateEscrowAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(9 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -36,39 +36,37 @@ impl CreateFrequencyRule {
             self.system_program,
             false,
         ));
+        let mut data = CreateFrequencyRuleInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_AUTH_RULES_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateFrequencyRuleInstructionData {
+    discriminator: u8,
+}
+
+impl CreateFrequencyRuleInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 2 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct CreateFrequencyRuleInstructionArgs {
-    discriminator: u8,
     pub rule_set_name: String,
     pub freq_rule_name: String,
     pub last_update: i64,
     pub period: i64,
-}
-
-impl CreateFrequencyRuleInstructionArgs {
-    pub fn new(
-        rule_set_name: String,
-        freq_rule_name: String,
-        last_update: i64,
-        period: i64,
-    ) -> Self {
-        Self {
-            discriminator: 2,
-            rule_set_name,
-            freq_rule_name,
-            last_update,
-            period,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -134,16 +132,18 @@ impl CreateFrequencyRuleBuilder {
                 .system_program
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
         };
-        let args = CreateFrequencyRuleInstructionArgs::new(
-            self.rule_set_name
+        let args = CreateFrequencyRuleInstructionArgs {
+            rule_set_name: self
+                .rule_set_name
                 .clone()
                 .expect("rule_set_name is not set"),
-            self.freq_rule_name
+            freq_rule_name: self
+                .freq_rule_name
                 .clone()
                 .expect("freq_rule_name is not set"),
-            self.last_update.clone().expect("last_update is not set"),
-            self.period.clone().expect("period is not set"),
-        );
+            last_update: self.last_update.clone().expect("last_update is not set"),
+            period: self.period.clone().expect("period is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -186,11 +186,16 @@ impl<'a> CreateFrequencyRuleCpi<'a> {
             *self.system_program.key,
             false,
         ));
+        let mut data = CreateFrequencyRuleInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_AUTH_RULES_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(3 + 1);
         account_infos.push(self.__program.clone());
@@ -271,21 +276,24 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> CreateFrequencyRuleCpi<'a> {
-        let args = CreateFrequencyRuleInstructionArgs::new(
-            self.instruction
+        let args = CreateFrequencyRuleInstructionArgs {
+            rule_set_name: self
+                .instruction
                 .rule_set_name
                 .clone()
                 .expect("rule_set_name is not set"),
-            self.instruction
+            freq_rule_name: self
+                .instruction
                 .freq_rule_name
                 .clone()
                 .expect("freq_rule_name is not set"),
-            self.instruction
+            last_update: self
+                .instruction
                 .last_update
                 .clone()
                 .expect("last_update is not set"),
-            self.instruction.period.clone().expect("period is not set"),
-        );
+            period: self.instruction.period.clone().expect("period is not set"),
+        };
 
         CreateFrequencyRuleCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -71,28 +71,34 @@ impl CreateMasterEdition {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
+        let mut data = CreateMasterEditionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateMasterEditionInstructionData {
+    discriminator: u8,
+}
+
+impl CreateMasterEditionInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 10 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct CreateMasterEditionInstructionArgs {
-    discriminator: u8,
     pub create_master_edition_args: CreateMasterEditionArgs,
-}
-
-impl CreateMasterEditionInstructionArgs {
-    pub fn new(create_master_edition_args: CreateMasterEditionArgs) -> Self {
-        Self {
-            discriminator: 10,
-            create_master_edition_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -198,11 +204,12 @@ impl CreateMasterEditionBuilder {
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
-        let args = CreateMasterEditionInstructionArgs::new(
-            self.create_master_edition_args
+        let args = CreateMasterEditionInstructionArgs {
+            create_master_edition_args: self
+                .create_master_edition_args
                 .clone()
                 .expect("create_master_edition_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -281,11 +288,16 @@ impl<'a> CreateMasterEditionCpi<'a> {
             *self.rent.key,
             false,
         ));
+        let mut data = CreateMasterEditionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(9 + 1);
         account_infos.push(self.__program.clone());
@@ -411,12 +423,13 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> CreateMasterEditionCpi<'a> {
-        let args = CreateMasterEditionInstructionArgs::new(
-            self.instruction
+        let args = CreateMasterEditionInstructionArgs {
+            create_master_edition_args: self
+                .instruction
                 .create_master_edition_args
                 .clone()
                 .expect("create_master_edition_args is not set"),
-        );
+        };
 
         CreateMasterEditionCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -78,28 +78,34 @@ impl CreateMasterEditionV3 {
                 false,
             ));
         }
+        let mut data = CreateMasterEditionV3InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateMasterEditionV3InstructionData {
+    discriminator: u8,
+}
+
+impl CreateMasterEditionV3InstructionData {
+    fn new() -> Self {
+        Self { discriminator: 17 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct CreateMasterEditionV3InstructionArgs {
-    discriminator: u8,
     pub create_master_edition_args: CreateMasterEditionArgs,
-}
-
-impl CreateMasterEditionV3InstructionArgs {
-    pub fn new(create_master_edition_args: CreateMasterEditionArgs) -> Self {
-        Self {
-            discriminator: 17,
-            create_master_edition_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -204,11 +210,12 @@ impl CreateMasterEditionV3Builder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             rent: self.rent,
         };
-        let args = CreateMasterEditionV3InstructionArgs::new(
-            self.create_master_edition_args
+        let args = CreateMasterEditionV3InstructionArgs {
+            create_master_edition_args: self
+                .create_master_edition_args
                 .clone()
                 .expect("create_master_edition_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -293,11 +300,16 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
                 false,
             ));
         }
+        let mut data = CreateMasterEditionV3InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(9 + 1);
         account_infos.push(self.__program.clone());
@@ -426,12 +438,13 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> CreateMasterEditionV3Cpi<'a> {
-        let args = CreateMasterEditionV3InstructionArgs::new(
-            self.instruction
+        let args = CreateMasterEditionV3InstructionArgs {
+            create_master_edition_args: self
+                .instruction
                 .create_master_edition_args
                 .clone()
                 .expect("create_master_edition_args is not set"),
-        );
+        };
 
         CreateMasterEditionV3Cpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -66,30 +66,35 @@ impl CreateMetadataAccountV2 {
                 false,
             ));
         }
+        let mut data = CreateMetadataAccountV2InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateMetadataAccountV2InstructionData {
+    discriminator: u8,
+}
+
+impl CreateMetadataAccountV2InstructionData {
+    fn new() -> Self {
+        Self { discriminator: 16 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct CreateMetadataAccountV2InstructionArgs {
-    discriminator: u8,
     pub data: DataV2,
     pub is_mutable: bool,
-}
-
-impl CreateMetadataAccountV2InstructionArgs {
-    pub fn new(data: DataV2, is_mutable: bool) -> Self {
-        Self {
-            discriminator: 16,
-            data,
-            is_mutable,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -179,10 +184,10 @@ impl CreateMetadataAccountV2Builder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             rent: self.rent,
         };
-        let args = CreateMetadataAccountV2InstructionArgs::new(
-            self.data.clone().expect("data is not set"),
-            self.is_mutable.clone().expect("is_mutable is not set"),
-        );
+        let args = CreateMetadataAccountV2InstructionArgs {
+            data: self.data.clone().expect("data is not set"),
+            is_mutable: self.is_mutable.clone().expect("is_mutable is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -255,11 +260,16 @@ impl<'a> CreateMetadataAccountV2Cpi<'a> {
                 false,
             ));
         }
+        let mut data = CreateMetadataAccountV2InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(7 + 1);
         account_infos.push(self.__program.clone());
@@ -369,13 +379,14 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> CreateMetadataAccountV2Cpi<'a> {
-        let args = CreateMetadataAccountV2InstructionArgs::new(
-            self.instruction.data.clone().expect("data is not set"),
-            self.instruction
+        let args = CreateMetadataAccountV2InstructionArgs {
+            data: self.instruction.data.clone().expect("data is not set"),
+            is_mutable: self
+                .instruction
                 .is_mutable
                 .clone()
                 .expect("is_mutable is not set"),
-        );
+        };
 
         CreateMetadataAccountV2Cpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -67,36 +67,36 @@ impl CreateMetadataAccountV3 {
                 false,
             ));
         }
+        let mut data = CreateMetadataAccountV3InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateMetadataAccountV3InstructionData {
+    discriminator: u8,
+}
+
+impl CreateMetadataAccountV3InstructionData {
+    fn new() -> Self {
+        Self { discriminator: 33 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct CreateMetadataAccountV3InstructionArgs {
-    discriminator: u8,
     pub data: DataV2,
     pub is_mutable: bool,
     pub collection_details: Option<CollectionDetails>,
-}
-
-impl CreateMetadataAccountV3InstructionArgs {
-    pub fn new(
-        data: DataV2,
-        is_mutable: bool,
-        collection_details: Option<CollectionDetails>,
-    ) -> Self {
-        Self {
-            discriminator: 33,
-            data,
-            is_mutable,
-            collection_details,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -193,11 +193,11 @@ impl CreateMetadataAccountV3Builder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             rent: self.rent,
         };
-        let args = CreateMetadataAccountV3InstructionArgs::new(
-            self.data.clone().expect("data is not set"),
-            self.is_mutable.clone().expect("is_mutable is not set"),
-            self.collection_details.clone(),
-        );
+        let args = CreateMetadataAccountV3InstructionArgs {
+            data: self.data.clone().expect("data is not set"),
+            is_mutable: self.is_mutable.clone().expect("is_mutable is not set"),
+            collection_details: self.collection_details.clone(),
+        };
 
         accounts.instruction(args)
     }
@@ -270,11 +270,16 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
                 false,
             ));
         }
+        let mut data = CreateMetadataAccountV3InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(7 + 1);
         account_infos.push(self.__program.clone());
@@ -391,14 +396,15 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> CreateMetadataAccountV3Cpi<'a> {
-        let args = CreateMetadataAccountV3InstructionArgs::new(
-            self.instruction.data.clone().expect("data is not set"),
-            self.instruction
+        let args = CreateMetadataAccountV3InstructionArgs {
+            data: self.instruction.data.clone().expect("data is not set"),
+            is_mutable: self
+                .instruction
                 .is_mutable
                 .clone()
                 .expect("is_mutable is not set"),
-            self.instruction.collection_details.clone(),
-        );
+            collection_details: self.instruction.collection_details.clone(),
+        };
 
         CreateMetadataAccountV3Cpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -31,8 +31,6 @@ pub struct CreateReservationList {
 impl CreateReservationList {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = CreateReservationListInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.reservation_list,
@@ -64,22 +62,25 @@ impl CreateReservationList {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
+        let data = CreateReservationListInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct CreateReservationListInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateReservationListInstructionData {
     discriminator: u8,
 }
 
-impl CreateReservationListInstructionArgs {
-    pub fn new() -> Self {
+impl CreateReservationListInstructionData {
+    fn new() -> Self {
         Self { discriminator: 6 }
     }
 }
@@ -208,8 +209,6 @@ impl<'a> CreateReservationListCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = CreateReservationListInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.reservation_list.key,
@@ -243,11 +242,14 @@ impl<'a> CreateReservationListCpi<'a> {
             *self.rent.key,
             false,
         ));
+        let data = CreateReservationListInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(8 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -37,30 +37,33 @@ impl CreateRuleSet {
             self.system_program,
             false,
         ));
+        let mut data = CreateRuleSetInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_AUTH_RULES_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct CreateRuleSetInstructionData {
+    discriminator: u8,
+}
+
+impl CreateRuleSetInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 0 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct CreateRuleSetInstructionArgs {
-    discriminator: u8,
     pub create_args: TaCreateArgs,
     pub rule_set_bump: u8,
-}
-
-impl CreateRuleSetInstructionArgs {
-    pub fn new(create_args: TaCreateArgs, rule_set_bump: u8) -> Self {
-        Self {
-            discriminator: 0,
-            create_args,
-            rule_set_bump,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -114,12 +117,13 @@ impl CreateRuleSetBuilder {
                 .system_program
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
         };
-        let args = CreateRuleSetInstructionArgs::new(
-            self.create_args.clone().expect("create_args is not set"),
-            self.rule_set_bump
+        let args = CreateRuleSetInstructionArgs {
+            create_args: self.create_args.clone().expect("create_args is not set"),
+            rule_set_bump: self
+                .rule_set_bump
                 .clone()
                 .expect("rule_set_bump is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -162,11 +166,14 @@ impl<'a> CreateRuleSetCpi<'a> {
             *self.system_program.key,
             false,
         ));
+        let mut data = CreateRuleSetInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_AUTH_RULES_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(3 + 1);
         account_infos.push(self.__program.clone());
@@ -235,16 +242,18 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> CreateRuleSetCpi<'a> {
-        let args = CreateRuleSetInstructionArgs::new(
-            self.instruction
+        let args = CreateRuleSetInstructionArgs {
+            create_args: self
+                .instruction
                 .create_args
                 .clone()
                 .expect("create_args is not set"),
-            self.instruction
+            rule_set_bump: self
+                .instruction
                 .rule_set_bump
                 .clone()
                 .expect("rule_set_bump is not set"),
-        );
+        };
 
         CreateRuleSetCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -128,28 +128,32 @@ impl Delegate {
                 false,
             ));
         }
+        let mut data = DelegateInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DelegateInstructionData {
+    discriminator: u8,
+}
+
+impl DelegateInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 48 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct DelegateInstructionArgs {
-    discriminator: u8,
     pub delegate_args: DelegateArgs,
-}
-
-impl DelegateInstructionArgs {
-    pub fn new(delegate_args: DelegateArgs) -> Self {
-        Self {
-            discriminator: 48,
-            delegate_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -299,11 +303,12 @@ impl DelegateBuilder {
             authorization_rules_program: self.authorization_rules_program,
             authorization_rules: self.authorization_rules,
         };
-        let args = DelegateInstructionArgs::new(
-            self.delegate_args
+        let args = DelegateInstructionArgs {
+            delegate_args: self
+                .delegate_args
                 .clone()
                 .expect("delegate_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -440,11 +445,14 @@ impl<'a> DelegateCpi<'a> {
                 false,
             ));
         }
+        let mut data = DelegateInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(13 + 1);
         account_infos.push(self.__program.clone());
@@ -626,12 +634,13 @@ impl<'a> DelegateCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> DelegateCpi<'a> {
-        let args = DelegateInstructionArgs::new(
-            self.instruction
+        let args = DelegateInstructionArgs {
+            delegate_args: self
+                .instruction
                 .delegate_args
                 .clone()
                 .expect("delegate_args is not set"),
-        );
+        };
 
         DelegateCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -95,28 +95,34 @@ impl DeprecatedCreateMasterEdition {
             self.one_time_printing_authorization_mint_authority,
             true,
         ));
+        let mut data = DeprecatedCreateMasterEditionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DeprecatedCreateMasterEditionInstructionData {
+    discriminator: u8,
+}
+
+impl DeprecatedCreateMasterEditionInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 2 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct DeprecatedCreateMasterEditionInstructionArgs {
-    discriminator: u8,
     pub create_master_edition_args: CreateMasterEditionArgs,
-}
-
-impl DeprecatedCreateMasterEditionInstructionArgs {
-    pub fn new(create_master_edition_args: CreateMasterEditionArgs) -> Self {
-        Self {
-            discriminator: 2,
-            create_master_edition_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -270,11 +276,12 @@ impl DeprecatedCreateMasterEditionBuilder {
                 .one_time_printing_authorization_mint_authority
                 .expect("one_time_printing_authorization_mint_authority is not set"),
         };
-        let args = DeprecatedCreateMasterEditionInstructionArgs::new(
-            self.create_master_edition_args
+        let args = DeprecatedCreateMasterEditionInstructionArgs {
+            create_master_edition_args: self
+                .create_master_edition_args
                 .clone()
                 .expect("create_master_edition_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -378,11 +385,16 @@ impl<'a> DeprecatedCreateMasterEditionCpi<'a> {
             *self.one_time_printing_authorization_mint_authority.key,
             true,
         ));
+        let mut data = DeprecatedCreateMasterEditionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(13 + 1);
         account_infos.push(self.__program.clone());
@@ -555,12 +567,13 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> DeprecatedCreateMasterEditionCpi<'a> {
-        let args = DeprecatedCreateMasterEditionInstructionArgs::new(
-            self.instruction
+        let args = DeprecatedCreateMasterEditionInstructionArgs {
+            create_master_edition_args: self
+                .instruction
                 .create_master_edition_args
                 .clone()
                 .expect("create_master_edition_args is not set"),
-        );
+        };
 
         DeprecatedCreateMasterEditionCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -47,8 +47,6 @@ pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {
 impl DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(16);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -118,22 +116,25 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {
                 false,
             ));
         }
+        let data = DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
     discriminator: u8,
 }
 
-impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionArgs {
-    pub fn new() -> Self {
+impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
+    fn new() -> Self {
         Self { discriminator: 3 }
     }
 }
@@ -355,8 +356,6 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(16);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -429,11 +428,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
                 false,
             ));
         }
+        let data = DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(16 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -61,28 +61,34 @@ impl DeprecatedMintPrintingTokens {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
+        let mut data = DeprecatedMintPrintingTokensInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DeprecatedMintPrintingTokensInstructionData {
+    discriminator: u8,
+}
+
+impl DeprecatedMintPrintingTokensInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 9 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct DeprecatedMintPrintingTokensInstructionArgs {
-    discriminator: u8,
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
-}
-
-impl DeprecatedMintPrintingTokensInstructionArgs {
-    pub fn new(mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs) -> Self {
-        Self {
-            discriminator: 9,
-            mint_printing_tokens_via_token_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -170,11 +176,12 @@ impl DeprecatedMintPrintingTokensBuilder {
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
-        let args = DeprecatedMintPrintingTokensInstructionArgs::new(
-            self.mint_printing_tokens_via_token_args
+        let args = DeprecatedMintPrintingTokensInstructionArgs {
+            mint_printing_tokens_via_token_args: self
+                .mint_printing_tokens_via_token_args
                 .clone()
                 .expect("mint_printing_tokens_via_token_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -241,11 +248,16 @@ impl<'a> DeprecatedMintPrintingTokensCpi<'a> {
             *self.rent.key,
             false,
         ));
+        let mut data = DeprecatedMintPrintingTokensInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(7 + 1);
         account_infos.push(self.__program.clone());
@@ -356,12 +368,13 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> DeprecatedMintPrintingTokensCpi<'a> {
-        let args = DeprecatedMintPrintingTokensInstructionArgs::new(
-            self.instruction
+        let args = DeprecatedMintPrintingTokensInstructionArgs {
+            mint_printing_tokens_via_token_args: self
+                .instruction
                 .mint_printing_tokens_via_token_args
                 .clone()
                 .expect("mint_printing_tokens_via_token_args is not set"),
-        );
+        };
 
         DeprecatedMintPrintingTokensCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -72,28 +72,34 @@ impl DeprecatedMintPrintingTokensViaToken {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.rent, false,
         ));
+        let mut data = DeprecatedMintPrintingTokensViaTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DeprecatedMintPrintingTokensViaTokenInstructionData {
+    discriminator: u8,
+}
+
+impl DeprecatedMintPrintingTokensViaTokenInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 8 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
-    discriminator: u8,
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
-}
-
-impl DeprecatedMintPrintingTokensViaTokenInstructionArgs {
-    pub fn new(mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs) -> Self {
-        Self {
-            discriminator: 8,
-            mint_printing_tokens_via_token_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -199,11 +205,12 @@ impl DeprecatedMintPrintingTokensViaTokenBuilder {
                 "SysvarRent111111111111111111111111111111111"
             )),
         };
-        let args = DeprecatedMintPrintingTokensViaTokenInstructionArgs::new(
-            self.mint_printing_tokens_via_token_args
+        let args = DeprecatedMintPrintingTokensViaTokenInstructionArgs {
+            mint_printing_tokens_via_token_args: self
+                .mint_printing_tokens_via_token_args
                 .clone()
                 .expect("mint_printing_tokens_via_token_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -282,11 +289,16 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpi<'a> {
             *self.rent.key,
             false,
         ));
+        let mut data = DeprecatedMintPrintingTokensViaTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(9 + 1);
         account_infos.push(self.__program.clone());
@@ -417,12 +429,13 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> DeprecatedMintPrintingTokensViaTokenCpi<'a> {
-        let args = DeprecatedMintPrintingTokensViaTokenInstructionArgs::new(
-            self.instruction
+        let args = DeprecatedMintPrintingTokensViaTokenInstructionArgs {
+            mint_printing_tokens_via_token_args: self
+                .instruction
                 .mint_printing_tokens_via_token_args
                 .clone()
                 .expect("mint_printing_tokens_via_token_args is not set"),
-        );
+        };
 
         DeprecatedMintPrintingTokensViaTokenCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -38,39 +38,37 @@ impl DeprecatedSetReservationList {
             self.resource,
             true,
         ));
+        let mut data = DeprecatedSetReservationListInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DeprecatedSetReservationListInstructionData {
+    discriminator: u8,
+}
+
+impl DeprecatedSetReservationListInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 5 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct DeprecatedSetReservationListInstructionArgs {
-    discriminator: u8,
     pub reservations: Vec<Reservation>,
     pub total_reservation_spots: Option<u64>,
     pub offset: u64,
     pub total_spot_offset: u64,
-}
-
-impl DeprecatedSetReservationListInstructionArgs {
-    pub fn new(
-        reservations: Vec<Reservation>,
-        total_reservation_spots: Option<u64>,
-        offset: u64,
-        total_spot_offset: u64,
-    ) -> Self {
-        Self {
-            discriminator: 5,
-            reservations,
-            total_reservation_spots,
-            offset,
-            total_spot_offset,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -138,14 +136,15 @@ impl DeprecatedSetReservationListBuilder {
             reservation_list: self.reservation_list.expect("reservation_list is not set"),
             resource: self.resource.expect("resource is not set"),
         };
-        let args = DeprecatedSetReservationListInstructionArgs::new(
-            self.reservations.clone().expect("reservations is not set"),
-            self.total_reservation_spots.clone(),
-            self.offset.clone().expect("offset is not set"),
-            self.total_spot_offset
+        let args = DeprecatedSetReservationListInstructionArgs {
+            reservations: self.reservations.clone().expect("reservations is not set"),
+            total_reservation_spots: self.total_reservation_spots.clone(),
+            offset: self.offset.clone().expect("offset is not set"),
+            total_spot_offset: self
+                .total_spot_offset
                 .clone()
                 .expect("total_spot_offset is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -188,11 +187,16 @@ impl<'a> DeprecatedSetReservationListCpi<'a> {
             *self.resource.key,
             true,
         ));
+        let mut data = DeprecatedSetReservationListInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(3 + 1);
         account_infos.push(self.__program.clone());
@@ -277,18 +281,20 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> DeprecatedSetReservationListCpi<'a> {
-        let args = DeprecatedSetReservationListInstructionArgs::new(
-            self.instruction
+        let args = DeprecatedSetReservationListInstructionArgs {
+            reservations: self
+                .instruction
                 .reservations
                 .clone()
                 .expect("reservations is not set"),
-            self.instruction.total_reservation_spots.clone(),
-            self.instruction.offset.clone().expect("offset is not set"),
-            self.instruction
+            total_reservation_spots: self.instruction.total_reservation_spots.clone(),
+            offset: self.instruction.offset.clone().expect("offset is not set"),
+            total_spot_offset: self
+                .instruction
                 .total_spot_offset
                 .clone()
                 .expect("total_spot_offset is not set"),
-        );
+        };
 
         DeprecatedSetReservationListCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -30,8 +30,6 @@ pub struct Dummy {
 impl Dummy {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = DummyInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.edition,
@@ -73,22 +71,23 @@ impl Dummy {
             self.delegate_record,
             false,
         ));
+        let data = DummyInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct DummyInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct DummyInstructionData {
     discriminator: [u8; 8],
 }
 
-impl DummyInstructionArgs {
-    pub fn new() -> Self {
+impl DummyInstructionData {
+    fn new() -> Self {
         Self {
             discriminator: [167, 117, 211, 79, 251, 254, 47, 135],
         }
@@ -209,8 +208,6 @@ impl<'a> DummyCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = DummyInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.edition.key,
@@ -256,11 +253,12 @@ impl<'a> DummyCpi<'a> {
             *self.delegate_record.key,
             false,
         ));
+        let data = DummyInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(8 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -25,8 +25,6 @@ pub struct FreezeDelegatedAccount {
 impl FreezeDelegatedAccount {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = FreezeDelegatedAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(5);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.delegate,
@@ -47,22 +45,25 @@ impl FreezeDelegatedAccount {
             self.token_program,
             false,
         ));
+        let data = FreezeDelegatedAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct FreezeDelegatedAccountInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct FreezeDelegatedAccountInstructionData {
     discriminator: u8,
 }
 
-impl FreezeDelegatedAccountInstructionArgs {
-    pub fn new() -> Self {
+impl FreezeDelegatedAccountInstructionData {
+    fn new() -> Self {
         Self { discriminator: 26 }
     }
 }
@@ -153,8 +154,6 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = FreezeDelegatedAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(5);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.delegate.key,
@@ -176,11 +175,14 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
             *self.token_program.key,
             false,
         ));
+        let data = FreezeDelegatedAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(5 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -48,8 +48,6 @@ pub struct MintFromCandyMachine {
 impl MintFromCandyMachine {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = MintFromCandyMachineInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(17);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.candy_machine,
@@ -118,22 +116,25 @@ impl MintFromCandyMachine {
             self.recent_slothashes,
             false,
         ));
+        let data = MintFromCandyMachineInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct MintFromCandyMachineInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct MintFromCandyMachineInstructionData {
     discriminator: [u8; 8],
 }
 
-impl MintFromCandyMachineInstructionArgs {
-    pub fn new() -> Self {
+impl MintFromCandyMachineInstructionData {
+    fn new() -> Self {
         Self {
             discriminator: [51, 57, 225, 47, 182, 146, 137, 166],
         }
@@ -375,8 +376,6 @@ impl<'a> MintFromCandyMachineCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = MintFromCandyMachineInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(17);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.candy_machine.key,
@@ -446,11 +445,14 @@ impl<'a> MintFromCandyMachineCpi<'a> {
             *self.recent_slothashes.key,
             false,
         ));
+        let data = MintFromCandyMachineInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(17 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -109,31 +109,35 @@ impl MintNewEditionFromMasterEditionViaToken {
                 false,
             ));
         }
+        let mut data = MintNewEditionFromMasterEditionViaTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct MintNewEditionFromMasterEditionViaTokenInstructionData {
+    discriminator: u8,
+}
+
+impl MintNewEditionFromMasterEditionViaTokenInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 11 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
-    discriminator: u8,
     pub mint_new_edition_from_master_edition_via_token_args:
         MintNewEditionFromMasterEditionViaTokenArgs,
-}
-
-impl MintNewEditionFromMasterEditionViaTokenInstructionArgs {
-    pub fn new(
-        mint_new_edition_from_master_edition_via_token_args: MintNewEditionFromMasterEditionViaTokenArgs,
-    ) -> Self {
-        Self {
-            discriminator: 11,
-            mint_new_edition_from_master_edition_via_token_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -295,11 +299,12 @@ impl MintNewEditionFromMasterEditionViaTokenBuilder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             rent: self.rent,
         };
-        let args = MintNewEditionFromMasterEditionViaTokenInstructionArgs::new(
-            self.mint_new_edition_from_master_edition_via_token_args
+        let args = MintNewEditionFromMasterEditionViaTokenInstructionArgs {
+            mint_new_edition_from_master_edition_via_token_args: self
+                .mint_new_edition_from_master_edition_via_token_args
                 .clone()
                 .expect("mint_new_edition_from_master_edition_via_token_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -414,11 +419,16 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
                 false,
             ));
         }
+        let mut data = MintNewEditionFromMasterEditionViaTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(14 + 1);
         account_infos.push(self.__program.clone());
@@ -609,12 +619,13 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
-        let args = MintNewEditionFromMasterEditionViaTokenInstructionArgs::new(
-            self.instruction
+        let args = MintNewEditionFromMasterEditionViaTokenInstructionArgs {
+            mint_new_edition_from_master_edition_via_token_args: self
+                .instruction
                 .mint_new_edition_from_master_edition_via_token_args
                 .clone()
                 .expect("mint_new_edition_from_master_edition_via_token_args is not set"),
-        );
+        };
 
         MintNewEditionFromMasterEditionViaTokenCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -126,31 +126,35 @@ impl MintNewEditionFromMasterEditionViaVaultProxy {
                 false,
             ));
         }
+        let mut data = MintNewEditionFromMasterEditionViaVaultProxyInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
+    discriminator: u8,
+}
+
+impl MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 13 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
-    discriminator: u8,
     pub mint_new_edition_from_master_edition_via_token_args:
         MintNewEditionFromMasterEditionViaTokenArgs,
-}
-
-impl MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
-    pub fn new(
-        mint_new_edition_from_master_edition_via_token_args: MintNewEditionFromMasterEditionViaTokenArgs,
-    ) -> Self {
-        Self {
-            discriminator: 13,
-            mint_new_edition_from_master_edition_via_token_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -349,11 +353,12 @@ impl MintNewEditionFromMasterEditionViaVaultProxyBuilder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             rent: self.rent,
         };
-        let args = MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs::new(
-            self.mint_new_edition_from_master_edition_via_token_args
+        let args = MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
+            mint_new_edition_from_master_edition_via_token_args: self
+                .mint_new_edition_from_master_edition_via_token_args
                 .clone()
                 .expect("mint_new_edition_from_master_edition_via_token_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -486,11 +491,16 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
                 false,
             ));
         }
+        let mut data = MintNewEditionFromMasterEditionViaVaultProxyInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(17 + 1);
         account_infos.push(self.__program.clone());
@@ -711,12 +721,13 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
-        let args = MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs::new(
-            self.instruction
+        let args = MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
+            mint_new_edition_from_master_edition_via_token_args: self
+                .instruction
                 .mint_new_edition_from_master_edition_via_token_args
                 .clone()
                 .expect("mint_new_edition_from_master_edition_via_token_args is not set"),
-        );
+        };
 
         MintNewEditionFromMasterEditionViaVaultProxyCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -17,29 +17,28 @@ pub struct PuffMetadata {
 impl PuffMetadata {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = PuffMetadataInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(1);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
             false,
         ));
+        let data = PuffMetadataInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct PuffMetadataInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct PuffMetadataInstructionData {
     discriminator: u8,
 }
 
-impl PuffMetadataInstructionArgs {
-    pub fn new() -> Self {
+impl PuffMetadataInstructionData {
+    fn new() -> Self {
         Self { discriminator: 14 }
     }
 }
@@ -88,18 +87,17 @@ impl<'a> PuffMetadataCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = PuffMetadataInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(1);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
             false,
         ));
+        let data = PuffMetadataInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(1 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -19,8 +19,6 @@ pub struct RemoveCreatorVerification {
 impl RemoveCreatorVerification {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = RemoveCreatorVerificationInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(2);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -30,22 +28,25 @@ impl RemoveCreatorVerification {
             self.creator,
             true,
         ));
+        let data = RemoveCreatorVerificationInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct RemoveCreatorVerificationInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct RemoveCreatorVerificationInstructionData {
     discriminator: u8,
 }
 
-impl RemoveCreatorVerificationInstructionArgs {
-    pub fn new() -> Self {
+impl RemoveCreatorVerificationInstructionData {
+    fn new() -> Self {
         Self { discriminator: 28 }
     }
 }
@@ -104,8 +105,6 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = RemoveCreatorVerificationInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(2);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -115,11 +114,14 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
             *self.creator.key,
             true,
         ));
+        let data = RemoveCreatorVerificationInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -128,28 +128,32 @@ impl Revoke {
                 false,
             ));
         }
+        let mut data = RevokeInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct RevokeInstructionData {
+    discriminator: u8,
+}
+
+impl RevokeInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 49 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct RevokeInstructionArgs {
-    discriminator: u8,
     pub revoke_args: RevokeArgs,
-}
-
-impl RevokeInstructionArgs {
-    pub fn new(revoke_args: RevokeArgs) -> Self {
-        Self {
-            discriminator: 49,
-            revoke_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -299,8 +303,9 @@ impl RevokeBuilder {
             authorization_rules_program: self.authorization_rules_program,
             authorization_rules: self.authorization_rules,
         };
-        let args =
-            RevokeInstructionArgs::new(self.revoke_args.clone().expect("revoke_args is not set"));
+        let args = RevokeInstructionArgs {
+            revoke_args: self.revoke_args.clone().expect("revoke_args is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -437,11 +442,14 @@ impl<'a> RevokeCpi<'a> {
                 false,
             ));
         }
+        let mut data = RevokeInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(13 + 1);
         account_infos.push(self.__program.clone());
@@ -623,12 +631,13 @@ impl<'a> RevokeCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> RevokeCpi<'a> {
-        let args = RevokeInstructionArgs::new(
-            self.instruction
+        let args = RevokeInstructionArgs {
+            revoke_args: self
+                .instruction
                 .revoke_args
                 .clone()
                 .expect("revoke_args is not set"),
-        );
+        };
 
         RevokeCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -25,8 +25,6 @@ pub struct RevokeCollectionAuthority {
 impl RevokeCollectionAuthority {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = RevokeCollectionAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(5);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.collection_authority_record,
@@ -47,22 +45,25 @@ impl RevokeCollectionAuthority {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.mint, false,
         ));
+        let data = RevokeCollectionAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct RevokeCollectionAuthorityInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct RevokeCollectionAuthorityInstructionData {
     discriminator: u8,
 }
 
-impl RevokeCollectionAuthorityInstructionArgs {
-    pub fn new() -> Self {
+impl RevokeCollectionAuthorityInstructionData {
+    fn new() -> Self {
         Self { discriminator: 24 }
     }
 }
@@ -164,8 +165,6 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = RevokeCollectionAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(5);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.collection_authority_record.key,
@@ -187,11 +186,14 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
             *self.mint.key,
             false,
         ));
+        let data = RevokeCollectionAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(5 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -33,8 +33,6 @@ pub struct RevokeUseAuthority {
 impl RevokeUseAuthority {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = RevokeUseAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(9);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.use_authority_record,
@@ -75,22 +73,25 @@ impl RevokeUseAuthority {
                 false,
             ));
         }
+        let data = RevokeUseAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct RevokeUseAuthorityInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct RevokeUseAuthorityInstructionData {
     discriminator: u8,
 }
 
-impl RevokeUseAuthorityInstructionArgs {
-    pub fn new() -> Self {
+impl RevokeUseAuthorityInstructionData {
+    fn new() -> Self {
         Self { discriminator: 21 }
     }
 }
@@ -234,8 +235,6 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = RevokeUseAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(9);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.use_authority_record.key,
@@ -279,11 +278,14 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
                 false,
             ));
         }
+        let data = RevokeUseAuthorityInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(9 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -31,8 +31,6 @@ pub struct SetAndVerifyCollection {
 impl SetAndVerifyCollection {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = SetAndVerifyCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -72,22 +70,25 @@ impl SetAndVerifyCollection {
                 false,
             ));
         }
+        let data = SetAndVerifyCollectionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SetAndVerifyCollectionInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetAndVerifyCollectionInstructionData {
     discriminator: u8,
 }
 
-impl SetAndVerifyCollectionInstructionArgs {
-    pub fn new() -> Self {
+impl SetAndVerifyCollectionInstructionData {
+    fn new() -> Self {
         Self { discriminator: 25 }
     }
 }
@@ -226,8 +227,6 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = SetAndVerifyCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -268,11 +267,14 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
                 false,
             ));
         }
+        let data = SetAndVerifyCollectionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(8 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -31,8 +31,6 @@ pub struct SetAndVerifySizedCollectionItem {
 impl SetAndVerifySizedCollectionItem {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = SetAndVerifySizedCollectionItemInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -72,22 +70,25 @@ impl SetAndVerifySizedCollectionItem {
                 false,
             ));
         }
+        let data = SetAndVerifySizedCollectionItemInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SetAndVerifySizedCollectionItemInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetAndVerifySizedCollectionItemInstructionData {
     discriminator: u8,
 }
 
-impl SetAndVerifySizedCollectionItemInstructionArgs {
-    pub fn new() -> Self {
+impl SetAndVerifySizedCollectionItemInstructionData {
+    fn new() -> Self {
         Self { discriminator: 32 }
     }
 }
@@ -226,8 +227,6 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = SetAndVerifySizedCollectionItemInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(8);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -268,11 +267,14 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
                 false,
             ));
         }
+        let data = SetAndVerifySizedCollectionItemInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(8 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -31,28 +31,34 @@ impl SetAuthority {
             self.authority,
             true,
         ));
+        let mut data = SetAuthorityInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetAuthorityInstructionData {
+    discriminator: [u8; 8],
+}
+
+impl SetAuthorityInstructionData {
+    fn new() -> Self {
+        Self {
+            discriminator: [133, 250, 37, 21, 110, 163, 26, 121],
         }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct SetAuthorityInstructionArgs {
-    discriminator: [u8; 8],
     pub new_authority: Pubkey,
-}
-
-impl SetAuthorityInstructionArgs {
-    pub fn new(new_authority: Pubkey) -> Self {
-        Self {
-            discriminator: [133, 250, 37, 21, 110, 163, 26, 121],
-            new_authority,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -88,11 +94,12 @@ impl SetAuthorityBuilder {
             candy_machine: self.candy_machine.expect("candy_machine is not set"),
             authority: self.authority.expect("authority is not set"),
         };
-        let args = SetAuthorityInstructionArgs::new(
-            self.new_authority
+        let args = SetAuthorityInstructionArgs {
+            new_authority: self
+                .new_authority
                 .clone()
                 .expect("new_authority is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -129,11 +136,14 @@ impl<'a> SetAuthorityCpi<'a> {
             *self.authority.key,
             true,
         ));
+        let mut data = SetAuthorityInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());
@@ -186,12 +196,13 @@ impl<'a> SetAuthorityCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> SetAuthorityCpi<'a> {
-        let args = SetAuthorityInstructionArgs::new(
-            self.instruction
+        let args = SetAuthorityInstructionArgs {
+            new_authority: self
+                .instruction
                 .new_authority
                 .clone()
                 .expect("new_authority is not set"),
-        );
+        };
 
         SetAuthorityCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -42,8 +42,6 @@ pub struct SetCollection {
 impl SetCollection {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = SetCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(14);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.candy_machine,
@@ -100,22 +98,23 @@ impl SetCollection {
             self.system_program,
             false,
         ));
+        let data = SetCollectionInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SetCollectionInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetCollectionInstructionData {
     discriminator: [u8; 8],
 }
 
-impl SetCollectionInstructionArgs {
-    pub fn new() -> Self {
+impl SetCollectionInstructionData {
+    fn new() -> Self {
         Self {
             discriminator: [192, 254, 206, 76, 168, 182, 59, 223],
         }
@@ -328,8 +327,6 @@ impl<'a> SetCollectionCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = SetCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(14);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.candy_machine.key,
@@ -387,11 +384,12 @@ impl<'a> SetCollectionCpi<'a> {
             *self.system_program.key,
             false,
         ));
+        let data = SetCollectionInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(14 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -51,28 +51,34 @@ impl SetCollectionSize {
                 false,
             ));
         }
+        let mut data = SetCollectionSizeInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetCollectionSizeInstructionData {
+    discriminator: u8,
+}
+
+impl SetCollectionSizeInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 34 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct SetCollectionSizeInstructionArgs {
-    discriminator: u8,
     pub set_collection_size_args: SetCollectionSizeArgs,
-}
-
-impl SetCollectionSizeInstructionArgs {
-    pub fn new(set_collection_size_args: SetCollectionSizeArgs) -> Self {
-        Self {
-            discriminator: 34,
-            set_collection_size_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -146,11 +152,12 @@ impl SetCollectionSizeBuilder {
             collection_mint: self.collection_mint.expect("collection_mint is not set"),
             collection_authority_record: self.collection_authority_record,
         };
-        let args = SetCollectionSizeInstructionArgs::new(
-            self.set_collection_size_args
+        let args = SetCollectionSizeInstructionArgs {
+            set_collection_size_args: self
+                .set_collection_size_args
                 .clone()
                 .expect("set_collection_size_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -206,11 +213,16 @@ impl<'a> SetCollectionSizeCpi<'a> {
                 false,
             ));
         }
+        let mut data = SetCollectionSizeInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(4 + 1);
         account_infos.push(self.__program.clone());
@@ -293,12 +305,13 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> SetCollectionSizeCpi<'a> {
-        let args = SetCollectionSizeInstructionArgs::new(
-            self.instruction
+        let args = SetCollectionSizeInstructionArgs {
+            set_collection_size_args: self
+                .instruction
                 .set_collection_size_args
                 .clone()
                 .expect("set_collection_size_args is not set"),
-        );
+        };
 
         SetCollectionSizeCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -20,8 +20,6 @@ pub struct SetMintAuthority {
 impl SetMintAuthority {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = SetMintAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(3);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.candy_machine,
@@ -35,22 +33,23 @@ impl SetMintAuthority {
             self.mint_authority,
             true,
         ));
+        let data = SetMintAuthorityInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SetMintAuthorityInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetMintAuthorityInstructionData {
     discriminator: [u8; 8],
 }
 
-impl SetMintAuthorityInstructionArgs {
-    pub fn new() -> Self {
+impl SetMintAuthorityInstructionData {
+    fn new() -> Self {
         Self {
             discriminator: [67, 127, 155, 187, 100, 174, 103, 121],
         }
@@ -118,8 +117,6 @@ impl<'a> SetMintAuthorityCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = SetMintAuthorityInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(3);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.candy_machine.key,
@@ -133,11 +130,12 @@ impl<'a> SetMintAuthorityCpi<'a> {
             *self.mint_authority.key,
             true,
         ));
+        let data = SetMintAuthorityInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(3 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -23,8 +23,6 @@ pub struct SetTokenStandard {
 impl SetTokenStandard {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = SetTokenStandardInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(4);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -47,22 +45,23 @@ impl SetTokenStandard {
                 false,
             ));
         }
+        let data = SetTokenStandardInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SetTokenStandardInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SetTokenStandardInstructionData {
     discriminator: u8,
 }
 
-impl SetTokenStandardInstructionArgs {
-    pub fn new() -> Self {
+impl SetTokenStandardInstructionData {
+    fn new() -> Self {
         Self { discriminator: 35 }
     }
 }
@@ -145,8 +144,6 @@ impl<'a> SetTokenStandardCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = SetTokenStandardInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(4);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -171,11 +168,12 @@ impl<'a> SetTokenStandardCpi<'a> {
                 false,
             ));
         }
+        let data = SetTokenStandardInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(4 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -19,8 +19,6 @@ pub struct SignMetadata {
 impl SignMetadata {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = SignMetadataInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(2);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -30,22 +28,23 @@ impl SignMetadata {
             self.creator,
             true,
         ));
+        let data = SignMetadataInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SignMetadataInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct SignMetadataInstructionData {
     discriminator: u8,
 }
 
-impl SignMetadataInstructionArgs {
-    pub fn new() -> Self {
+impl SignMetadataInstructionData {
+    fn new() -> Self {
         Self { discriminator: 7 }
     }
 }
@@ -104,8 +103,6 @@ impl<'a> SignMetadataCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = SignMetadataInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(2);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -115,11 +112,12 @@ impl<'a> SignMetadataCpi<'a> {
             *self.creator.key,
             true,
         ));
+        let data = SignMetadataInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -25,8 +25,6 @@ pub struct ThawDelegatedAccount {
 impl ThawDelegatedAccount {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = ThawDelegatedAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(5);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.delegate,
@@ -47,22 +45,25 @@ impl ThawDelegatedAccount {
             self.token_program,
             false,
         ));
+        let data = ThawDelegatedAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct ThawDelegatedAccountInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct ThawDelegatedAccountInstructionData {
     discriminator: u8,
 }
 
-impl ThawDelegatedAccountInstructionArgs {
-    pub fn new() -> Self {
+impl ThawDelegatedAccountInstructionData {
+    fn new() -> Self {
         Self { discriminator: 27 }
     }
 }
@@ -153,8 +154,6 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = ThawDelegatedAccountInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(5);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.delegate.key,
@@ -176,11 +175,14 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
             *self.token_program.key,
             false,
         ));
+        let data = ThawDelegatedAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(5 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -102,28 +102,34 @@ impl TransferOutOfEscrow {
                 false,
             ));
         }
+        let mut data = TransferOutOfEscrowInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct TransferOutOfEscrowInstructionData {
+    discriminator: u8,
+}
+
+impl TransferOutOfEscrowInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 40 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct TransferOutOfEscrowInstructionArgs {
-    discriminator: u8,
     pub amount: u64,
-}
-
-impl TransferOutOfEscrowInstructionArgs {
-    pub fn new(amount: u64) -> Self {
-        Self {
-            discriminator: 40,
-            amount,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -261,9 +267,9 @@ impl TransferOutOfEscrowBuilder {
             )),
             authority: self.authority,
         };
-        let args = TransferOutOfEscrowInstructionArgs::new(
-            self.amount.clone().expect("amount is not set"),
-        );
+        let args = TransferOutOfEscrowInstructionArgs {
+            amount: self.amount.clone().expect("amount is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -373,11 +379,16 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
                 false,
             ));
         }
+        let mut data = TransferOutOfEscrowInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(13 + 1);
         account_infos.push(self.__program.clone());
@@ -553,9 +564,9 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> TransferOutOfEscrowCpi<'a> {
-        let args = TransferOutOfEscrowInstructionArgs::new(
-            self.instruction.amount.clone().expect("amount is not set"),
-        );
+        let args = TransferOutOfEscrowInstructionArgs {
+            amount: self.instruction.amount.clone().expect("amount is not set"),
+        };
 
         TransferOutOfEscrowCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -27,8 +27,6 @@ pub struct UnverifyCollection {
 impl UnverifyCollection {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = UnverifyCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(6);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -61,22 +59,25 @@ impl UnverifyCollection {
                 false,
             ));
         }
+        let data = UnverifyCollectionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct UnverifyCollectionInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UnverifyCollectionInstructionData {
     discriminator: u8,
 }
 
-impl UnverifyCollectionInstructionArgs {
-    pub fn new() -> Self {
+impl UnverifyCollectionInstructionData {
+    fn new() -> Self {
         Self { discriminator: 22 }
     }
 }
@@ -192,8 +193,6 @@ impl<'a> UnverifyCollectionCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = UnverifyCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(6);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -226,11 +225,14 @@ impl<'a> UnverifyCollectionCpi<'a> {
                 false,
             ));
         }
+        let data = UnverifyCollectionInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(6 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -29,8 +29,6 @@ pub struct UnverifySizedCollectionItem {
 impl UnverifySizedCollectionItem {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = UnverifySizedCollectionItemInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(7);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -66,22 +64,25 @@ impl UnverifySizedCollectionItem {
                 false,
             ));
         }
+        let data = UnverifySizedCollectionItemInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct UnverifySizedCollectionItemInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UnverifySizedCollectionItemInstructionData {
     discriminator: u8,
 }
 
-impl UnverifySizedCollectionItemInstructionArgs {
-    pub fn new() -> Self {
+impl UnverifySizedCollectionItemInstructionData {
+    fn new() -> Self {
         Self { discriminator: 31 }
     }
 }
@@ -207,8 +208,6 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = UnverifySizedCollectionItemInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(7);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -245,11 +244,14 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
                 false,
             ));
         }
+        let data = UnverifySizedCollectionItemInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(7 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -31,28 +31,36 @@ impl UpdateCandyMachine {
             self.authority,
             true,
         ));
+        let mut data = UpdateCandyMachineInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UpdateCandyMachineInstructionData {
+    discriminator: [u8; 8],
+}
+
+impl UpdateCandyMachineInstructionData {
+    fn new() -> Self {
+        Self {
+            discriminator: [219, 200, 88, 176, 158, 63, 253, 127],
         }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UpdateCandyMachineInstructionArgs {
-    discriminator: [u8; 8],
     pub data: CandyMachineData,
-}
-
-impl UpdateCandyMachineInstructionArgs {
-    pub fn new(data: CandyMachineData) -> Self {
-        Self {
-            discriminator: [219, 200, 88, 176, 158, 63, 253, 127],
-            data,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -88,8 +96,9 @@ impl UpdateCandyMachineBuilder {
             candy_machine: self.candy_machine.expect("candy_machine is not set"),
             authority: self.authority.expect("authority is not set"),
         };
-        let args =
-            UpdateCandyMachineInstructionArgs::new(self.data.clone().expect("data is not set"));
+        let args = UpdateCandyMachineInstructionArgs {
+            data: self.data.clone().expect("data is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -126,11 +135,16 @@ impl<'a> UpdateCandyMachineCpi<'a> {
             *self.authority.key,
             true,
         ));
+        let mut data = UpdateCandyMachineInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());
@@ -183,9 +197,9 @@ impl<'a> UpdateCandyMachineCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> UpdateCandyMachineCpi<'a> {
-        let args = UpdateCandyMachineInstructionArgs::new(
-            self.instruction.data.clone().expect("data is not set"),
-        );
+        let args = UpdateCandyMachineInstructionArgs {
+            data: self.instruction.data.clone().expect("data is not set"),
+        };
 
         UpdateCandyMachineCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -33,18 +33,33 @@ impl UpdateMetadataAccount {
             self.update_authority,
             true,
         ));
+        let mut data = UpdateMetadataAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UpdateMetadataAccountInstructionData {
+    discriminator: u8,
+}
+
+impl UpdateMetadataAccountInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 1 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UpdateMetadataAccountInstructionArgs {
-    discriminator: u8,
     pub data: Option<UpdateMetadataAccountInstructionDataData>,
     pub update_authority_arg: Option<Pubkey>,
     pub primary_sale_happened: Option<bool>,
@@ -57,21 +72,6 @@ pub struct UpdateMetadataAccountInstructionDataData {
     pub uri: String,
     pub seller_fee_basis_points: u16,
     pub creators: Option<Vec<Creator>>,
-}
-
-impl UpdateMetadataAccountInstructionArgs {
-    pub fn new(
-        data: Option<UpdateMetadataAccountInstructionDataData>,
-        update_authority_arg: Option<Pubkey>,
-        primary_sale_happened: Option<bool>,
-    ) -> Self {
-        Self {
-            discriminator: 1,
-            data,
-            update_authority_arg,
-            primary_sale_happened,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -127,11 +127,11 @@ impl UpdateMetadataAccountBuilder {
             metadata: self.metadata.expect("metadata is not set"),
             update_authority: self.update_authority.expect("update_authority is not set"),
         };
-        let args = UpdateMetadataAccountInstructionArgs::new(
-            self.data.clone(),
-            self.update_authority_arg.clone(),
-            self.primary_sale_happened.clone(),
-        );
+        let args = UpdateMetadataAccountInstructionArgs {
+            data: self.data.clone(),
+            update_authority_arg: self.update_authority_arg.clone(),
+            primary_sale_happened: self.primary_sale_happened.clone(),
+        };
 
         accounts.instruction(args)
     }
@@ -168,11 +168,16 @@ impl<'a> UpdateMetadataAccountCpi<'a> {
             *self.update_authority.key,
             true,
         ));
+        let mut data = UpdateMetadataAccountInstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());
@@ -242,11 +247,11 @@ impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> UpdateMetadataAccountCpi<'a> {
-        let args = UpdateMetadataAccountInstructionArgs::new(
-            self.instruction.data.clone(),
-            self.instruction.update_authority_arg.clone(),
-            self.instruction.primary_sale_happened.clone(),
-        );
+        let args = UpdateMetadataAccountInstructionArgs {
+            data: self.instruction.data.clone(),
+            update_authority_arg: self.instruction.update_authority_arg.clone(),
+            primary_sale_happened: self.instruction.primary_sale_happened.clone(),
+        };
 
         UpdateMetadataAccountCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -33,39 +33,37 @@ impl UpdateMetadataAccountV2 {
             self.update_authority,
             true,
         ));
+        let mut data = UpdateMetadataAccountV2InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UpdateMetadataAccountV2InstructionData {
+    discriminator: u8,
+}
+
+impl UpdateMetadataAccountV2InstructionData {
+    fn new() -> Self {
+        Self { discriminator: 15 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UpdateMetadataAccountV2InstructionArgs {
-    discriminator: u8,
     pub data: Option<DataV2>,
     pub update_authority_arg: Option<Pubkey>,
     pub primary_sale_happened: Option<bool>,
     pub is_mutable: Option<bool>,
-}
-
-impl UpdateMetadataAccountV2InstructionArgs {
-    pub fn new(
-        data: Option<DataV2>,
-        update_authority_arg: Option<Pubkey>,
-        primary_sale_happened: Option<bool>,
-        is_mutable: Option<bool>,
-    ) -> Self {
-        Self {
-            discriminator: 15,
-            data,
-            update_authority_arg,
-            primary_sale_happened,
-            is_mutable,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -128,12 +126,12 @@ impl UpdateMetadataAccountV2Builder {
             metadata: self.metadata.expect("metadata is not set"),
             update_authority: self.update_authority.expect("update_authority is not set"),
         };
-        let args = UpdateMetadataAccountV2InstructionArgs::new(
-            self.data.clone(),
-            self.update_authority_arg.clone(),
-            self.primary_sale_happened.clone(),
-            self.is_mutable.clone(),
-        );
+        let args = UpdateMetadataAccountV2InstructionArgs {
+            data: self.data.clone(),
+            update_authority_arg: self.update_authority_arg.clone(),
+            primary_sale_happened: self.primary_sale_happened.clone(),
+            is_mutable: self.is_mutable.clone(),
+        };
 
         accounts.instruction(args)
     }
@@ -170,11 +168,16 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
             *self.update_authority.key,
             true,
         ));
+        let mut data = UpdateMetadataAccountV2InstructionData::new()
+            .try_to_vec()
+            .unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());
@@ -251,12 +254,12 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> UpdateMetadataAccountV2Cpi<'a> {
-        let args = UpdateMetadataAccountV2InstructionArgs::new(
-            self.instruction.data.clone(),
-            self.instruction.update_authority_arg.clone(),
-            self.instruction.primary_sale_happened.clone(),
-            self.instruction.is_mutable.clone(),
-        );
+        let args = UpdateMetadataAccountV2InstructionArgs {
+            data: self.instruction.data.clone(),
+            update_authority_arg: self.instruction.update_authority_arg.clone(),
+            primary_sale_happened: self.instruction.primary_sale_happened.clone(),
+            is_mutable: self.instruction.is_mutable.clone(),
+        };
 
         UpdateMetadataAccountV2Cpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -21,8 +21,6 @@ pub struct UpdatePrimarySaleHappenedViaToken {
 impl UpdatePrimarySaleHappenedViaToken {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = UpdatePrimarySaleHappenedViaTokenInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(3);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -34,22 +32,25 @@ impl UpdatePrimarySaleHappenedViaToken {
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
             self.token, false,
         ));
+        let data = UpdatePrimarySaleHappenedViaTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct UpdatePrimarySaleHappenedViaTokenInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UpdatePrimarySaleHappenedViaTokenInstructionData {
     discriminator: u8,
 }
 
-impl UpdatePrimarySaleHappenedViaTokenInstructionArgs {
-    pub fn new() -> Self {
+impl UpdatePrimarySaleHappenedViaTokenInstructionData {
+    fn new() -> Self {
         Self { discriminator: 4 }
     }
 }
@@ -118,8 +119,6 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = UpdatePrimarySaleHappenedViaTokenInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(3);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -133,11 +132,14 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
             *self.token.key,
             false,
         ));
+        let data = UpdatePrimarySaleHappenedViaTokenInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(3 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -122,19 +122,35 @@ impl UpdateV1 {
                 false,
             ));
         }
+        let mut data = UpdateV1InstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
+        }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UpdateV1InstructionData {
+    discriminator: u8,
+    update_v1_discriminator: u8,
+}
+
+impl UpdateV1InstructionData {
+    fn new() -> Self {
+        Self {
+            discriminator: 43,
+            update_v1_discriminator: 0,
         }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UpdateV1InstructionArgs {
-    discriminator: u8,
-    update_v1_discriminator: u8,
     pub authorization_data: Option<AuthorizationData>,
     pub new_update_authority: Option<Pubkey>,
     pub data: Option<UpdateV1InstructionDataData>,
@@ -156,39 +172,6 @@ pub struct UpdateV1InstructionDataData {
     pub uri: String,
     pub seller_fee_basis_points: u16,
     pub creators: Option<Vec<Creator>>,
-}
-
-impl UpdateV1InstructionArgs {
-    pub fn new(
-        authorization_data: Option<AuthorizationData>,
-        new_update_authority: Option<Pubkey>,
-        data: Option<UpdateV1InstructionDataData>,
-        primary_sale_happened: Option<bool>,
-        is_mutable: Option<bool>,
-        collection: Option<Collection>,
-        uses: Option<Uses>,
-        collection_details: Option<CollectionDetails>,
-        programmable_config: Option<ProgrammableConfig>,
-        delegate_state: Option<DelegateState>,
-        authority_type: AuthorityType,
-    ) -> Self {
-        Self {
-            discriminator: 43,
-            update_v1_discriminator: 0,
-            authorization_data,
-            new_update_authority,
-            data,
-            primary_sale_happened,
-            is_mutable,
-            token_standard: Some(TokenStandard::NonFungible),
-            collection,
-            uses,
-            collection_details,
-            programmable_config,
-            delegate_state,
-            authority_type,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -388,22 +371,23 @@ impl UpdateV1Builder {
             authorization_rules_program: self.authorization_rules_program,
             authorization_rules: self.authorization_rules,
         };
-        let mut args = UpdateV1InstructionArgs::new(
-            self.authorization_data.clone(),
-            self.new_update_authority.clone(),
-            self.data.clone(),
-            self.primary_sale_happened.clone(),
-            self.is_mutable.clone(),
-            self.collection.clone(),
-            self.uses.clone(),
-            self.collection_details.clone(),
-            self.programmable_config.clone(),
-            self.delegate_state.clone(),
-            self.authority_type
+        let args = UpdateV1InstructionArgs {
+            authorization_data: self.authorization_data.clone(),
+            new_update_authority: self.new_update_authority.clone(),
+            data: self.data.clone(),
+            primary_sale_happened: self.primary_sale_happened.clone(),
+            is_mutable: self.is_mutable.clone(),
+            token_standard: self.token_standard.clone(),
+            collection: self.collection.clone(),
+            uses: self.uses.clone(),
+            collection_details: self.collection_details.clone(),
+            programmable_config: self.programmable_config.clone(),
+            delegate_state: self.delegate_state.clone(),
+            authority_type: self
+                .authority_type
                 .clone()
                 .expect("authority_type is not set"),
-        );
-        args.token_standard = self.token_standard.clone();
+        };
 
         accounts.instruction(args)
     }
@@ -522,11 +506,14 @@ impl<'a> UpdateV1Cpi<'a> {
                 false,
             ));
         }
+        let mut data = UpdateV1InstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(10 + 1);
         account_infos.push(self.__program.clone());
@@ -755,23 +742,24 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> UpdateV1Cpi<'a> {
-        let mut args = UpdateV1InstructionArgs::new(
-            self.instruction.authorization_data.clone(),
-            self.instruction.new_update_authority.clone(),
-            self.instruction.data.clone(),
-            self.instruction.primary_sale_happened.clone(),
-            self.instruction.is_mutable.clone(),
-            self.instruction.collection.clone(),
-            self.instruction.uses.clone(),
-            self.instruction.collection_details.clone(),
-            self.instruction.programmable_config.clone(),
-            self.instruction.delegate_state.clone(),
-            self.instruction
+        let args = UpdateV1InstructionArgs {
+            authorization_data: self.instruction.authorization_data.clone(),
+            new_update_authority: self.instruction.new_update_authority.clone(),
+            data: self.instruction.data.clone(),
+            primary_sale_happened: self.instruction.primary_sale_happened.clone(),
+            is_mutable: self.instruction.is_mutable.clone(),
+            token_standard: self.instruction.token_standard.clone(),
+            collection: self.instruction.collection.clone(),
+            uses: self.instruction.uses.clone(),
+            collection_details: self.instruction.collection_details.clone(),
+            programmable_config: self.instruction.programmable_config.clone(),
+            delegate_state: self.instruction.delegate_state.clone(),
+            authority_type: self
+                .instruction
                 .authority_type
                 .clone()
                 .expect("authority_type is not set"),
-        );
-        args.token_standard = self.instruction.token_standard.clone();
+        };
 
         UpdateV1Cpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -105,28 +105,32 @@ impl UseAsset {
                 false,
             ));
         }
+        let mut data = UseAssetInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UseAssetInstructionData {
+    discriminator: u8,
+}
+
+impl UseAssetInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 45 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UseAssetInstructionArgs {
-    discriminator: u8,
     pub use_asset_args: UseAssetArgs,
-}
-
-impl UseAssetInstructionArgs {
-    pub fn new(use_asset_args: UseAssetArgs) -> Self {
-        Self {
-            discriminator: 45,
-            use_asset_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -257,11 +261,12 @@ impl UseAssetBuilder {
             authorization_rules: self.authorization_rules,
             authorization_rules_program: self.authorization_rules_program,
         };
-        let args = UseAssetInstructionArgs::new(
-            self.use_asset_args
+        let args = UseAssetInstructionArgs {
+            use_asset_args: self
+                .use_asset_args
                 .clone()
                 .expect("use_asset_args is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -373,11 +378,14 @@ impl<'a> UseAssetCpi<'a> {
                 false,
             ));
         }
+        let mut data = UseAssetInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(11 + 1);
         account_infos.push(self.__program.clone());
@@ -534,12 +542,13 @@ impl<'a> UseAssetCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> UseAssetCpi<'a> {
-        let args = UseAssetInstructionArgs::new(
-            self.instruction
+        let args = UseAssetInstructionArgs {
+            use_asset_args: self
+                .instruction
                 .use_asset_args
                 .clone()
                 .expect("use_asset_args is not set"),
-        );
+        };
 
         UseAssetCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -95,28 +95,32 @@ impl Utilize {
                 false,
             ));
         }
+        let mut data = UtilizeInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct UtilizeInstructionData {
+    discriminator: u8,
+}
+
+impl UtilizeInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 19 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct UtilizeInstructionArgs {
-    discriminator: u8,
     pub number_of_uses: u64,
-}
-
-impl UtilizeInstructionArgs {
-    pub fn new(number_of_uses: u64) -> Self {
-        Self {
-            discriminator: 19,
-            number_of_uses,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -239,11 +243,12 @@ impl UtilizeBuilder {
             use_authority_record: self.use_authority_record,
             burner: self.burner,
         };
-        let args = UtilizeInstructionArgs::new(
-            self.number_of_uses
+        let args = UtilizeInstructionArgs {
+            number_of_uses: self
+                .number_of_uses
                 .clone()
                 .expect("number_of_uses is not set"),
-        );
+        };
 
         accounts.instruction(args)
     }
@@ -348,11 +353,14 @@ impl<'a> UtilizeCpi<'a> {
                 false,
             ));
         }
+        let mut data = UtilizeInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(11 + 1);
         account_infos.push(self.__program.clone());
@@ -503,12 +511,13 @@ impl<'a> UtilizeCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> UtilizeCpi<'a> {
-        let args = UtilizeInstructionArgs::new(
-            self.instruction
+        let args = UtilizeInstructionArgs {
+            number_of_uses: self
+                .instruction
                 .number_of_uses
                 .clone()
                 .expect("number_of_uses is not set"),
-        );
+        };
 
         UtilizeCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -118,32 +118,34 @@ impl Validate {
                 false,
             ));
         }
+        let mut data = ValidateInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_AUTH_RULES_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct ValidateInstructionData {
+    discriminator: u8,
+}
+
+impl ValidateInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 1 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct ValidateInstructionArgs {
-    discriminator: u8,
     pub rule_set_name: String,
     pub operation: Operation,
     pub payload: Payload,
-}
-
-impl ValidateInstructionArgs {
-    pub fn new(rule_set_name: String, operation: Operation, payload: Payload) -> Self {
-        Self {
-            discriminator: 1,
-            rule_set_name,
-            operation,
-            payload,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -323,13 +325,14 @@ impl ValidateBuilder {
             opt_rule_nonsigner4: self.opt_rule_nonsigner4,
             opt_rule_nonsigner5: self.opt_rule_nonsigner5,
         };
-        let args = ValidateInstructionArgs::new(
-            self.rule_set_name
+        let args = ValidateInstructionArgs {
+            rule_set_name: self
+                .rule_set_name
                 .clone()
                 .expect("rule_set_name is not set"),
-            self.operation.clone().expect("operation is not set"),
-            self.payload.clone().expect("payload is not set"),
-        );
+            operation: self.operation.clone().expect("operation is not set"),
+            payload: self.payload.clone().expect("payload is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -452,11 +455,14 @@ impl<'a> ValidateCpi<'a> {
                 false,
             ));
         }
+        let mut data = ValidateInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_AUTH_RULES_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(13 + 1);
         account_infos.push(self.__program.clone());
@@ -671,20 +677,23 @@ impl<'a> ValidateCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> ValidateCpi<'a> {
-        let args = ValidateInstructionArgs::new(
-            self.instruction
+        let args = ValidateInstructionArgs {
+            rule_set_name: self
+                .instruction
                 .rule_set_name
                 .clone()
                 .expect("rule_set_name is not set"),
-            self.instruction
+            operation: self
+                .instruction
                 .operation
                 .clone()
                 .expect("operation is not set"),
-            self.instruction
+            payload: self
+                .instruction
                 .payload
                 .clone()
                 .expect("payload is not set"),
-        );
+        };
 
         ValidateCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -63,28 +63,32 @@ impl Verify {
                 false,
             ));
         }
+        let mut data = VerifyInstructionData::new().try_to_vec().unwrap();
+        let mut args = args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
+    }
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+struct VerifyInstructionData {
+    discriminator: u8,
+}
+
+impl VerifyInstructionData {
+    fn new() -> Self {
+        Self { discriminator: 47 }
     }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 pub struct VerifyInstructionArgs {
-    discriminator: u8,
     pub verify_args: VerifyArgs,
-}
-
-impl VerifyInstructionArgs {
-    pub fn new(verify_args: VerifyArgs) -> Self {
-        Self {
-            discriminator: 47,
-            verify_args,
-        }
-    }
 }
 
 /// Instruction builder.
@@ -159,8 +163,9 @@ impl VerifyBuilder {
             authorization_rules: self.authorization_rules,
             authorization_rules_program: self.authorization_rules_program,
         };
-        let args =
-            VerifyInstructionArgs::new(self.verify_args.clone().expect("verify_args is not set"));
+        let args = VerifyInstructionArgs {
+            verify_args: self.verify_args.clone().expect("verify_args is not set"),
+        };
 
         accounts.instruction(args)
     }
@@ -229,11 +234,14 @@ impl<'a> VerifyCpi<'a> {
                 false,
             ));
         }
+        let mut data = VerifyInstructionData::new().try_to_vec().unwrap();
+        let mut args = self.__args.try_to_vec().unwrap();
+        data.append(&mut args);
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: self.__args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(5 + 1);
         account_infos.push(self.__program.clone());
@@ -324,12 +332,13 @@ impl<'a> VerifyCpiBuilder<'a> {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn build(&self) -> VerifyCpi<'a> {
-        let args = VerifyInstructionArgs::new(
-            self.instruction
+        let args = VerifyInstructionArgs {
+            verify_args: self
+                .instruction
                 .verify_args
                 .clone()
                 .expect("verify_args is not set"),
-        );
+        };
 
         VerifyCpi {
             __program: self.instruction.__program,

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -27,8 +27,6 @@ pub struct VerifyCollection {
 impl VerifyCollection {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = VerifyCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(6);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -53,22 +51,23 @@ impl VerifyCollection {
             self.collection_master_edition_account,
             false,
         ));
+        let data = VerifyCollectionInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct VerifyCollectionInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct VerifyCollectionInstructionData {
     discriminator: u8,
 }
 
-impl VerifyCollectionInstructionArgs {
-    pub fn new() -> Self {
+impl VerifyCollectionInstructionData {
+    fn new() -> Self {
         Self { discriminator: 18 }
     }
 }
@@ -180,8 +179,6 @@ impl<'a> VerifyCollectionCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = VerifyCollectionInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(6);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -207,11 +204,12 @@ impl<'a> VerifyCollectionCpi<'a> {
             *self.collection_master_edition_account.key,
             false,
         ));
+        let data = VerifyCollectionInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(6 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -29,8 +29,6 @@ pub struct VerifySizedCollectionItem {
 impl VerifySizedCollectionItem {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = VerifySizedCollectionItemInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(7);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.metadata,
@@ -66,22 +64,25 @@ impl VerifySizedCollectionItem {
                 false,
             ));
         }
+        let data = VerifySizedCollectionItemInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct VerifySizedCollectionItemInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct VerifySizedCollectionItemInstructionData {
     discriminator: u8,
 }
 
-impl VerifySizedCollectionItemInstructionArgs {
-    pub fn new() -> Self {
+impl VerifySizedCollectionItemInstructionData {
+    fn new() -> Self {
         Self { discriminator: 30 }
     }
 }
@@ -207,8 +208,6 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = VerifySizedCollectionItemInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(7);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.metadata.key,
@@ -245,11 +244,14 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
                 false,
             ));
         }
+        let data = VerifySizedCollectionItemInstructionData::new()
+            .try_to_vec()
+            .unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_TOKEN_METADATA_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(7 + 1);
         account_infos.push(self.__program.clone());

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -18,8 +18,6 @@ pub struct Withdraw {
 impl Withdraw {
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let args = WithdrawInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(2);
         accounts.push(solana_program::instruction::AccountMeta::new(
             self.candy_machine,
@@ -29,22 +27,23 @@ impl Withdraw {
             self.authority,
             true,
         ));
+        let data = WithdrawInstructionData::new().try_to_vec().unwrap();
 
         solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct WithdrawInstructionArgs {
+#[derive(BorshDeserialize, BorshSerialize)]
+struct WithdrawInstructionData {
     discriminator: [u8; 8],
 }
 
-impl WithdrawInstructionArgs {
-    pub fn new() -> Self {
+impl WithdrawInstructionData {
+    fn new() -> Self {
         Self {
             discriminator: [183, 18, 70, 156, 148, 109, 161, 34],
         }
@@ -103,8 +102,6 @@ impl<'a> WithdrawCpi<'a> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = WithdrawInstructionArgs::new();
-
         let mut accounts = Vec::with_capacity(2);
         accounts.push(solana_program::instruction::AccountMeta::new(
             *self.candy_machine.key,
@@ -114,11 +111,12 @@ impl<'a> WithdrawCpi<'a> {
             *self.authority.key,
             true,
         ));
+        let data = WithdrawInstructionData::new().try_to_vec().unwrap();
 
         let instruction = solana_program::instruction::Instruction {
             program_id: crate::MPL_CANDY_MACHINE_CORE_ID,
             accounts,
-            data: args.try_to_vec().unwrap(),
+            data,
         };
         let mut account_infos = Vec::with_capacity(2 + 1);
         account_infos.push(self.__program.clone());


### PR DESCRIPTION
This PR moves the default args resolution of the Rust renderer to the instruction builders. This way, the generated `*InstructionArgs` structs can be easily used on a client since it does not have any private fields – e.g.,:
```rust
let args = TransferV1InstructionArgs {
   amount: 10,
   authorization_data: Some(AuthorizationData { ... }),
};
```
instead of:
```rust
// currently cannot create the struct directly since the
// instruction discriminator is a "private" field
let mut args = TransferV1InstructionArgs::new();
args.amount = 10;
args.authorization_data = Some(AuthorizationData { ... });
```

In the current version, the `discriminator` is a private field of the structure and a "constructor" function `new(...)` is needed.