### PR TITLE
Improve account size and rust error traits

### DIFF
--- a/.changeset/fast-rats-impress.md
+++ b/.changeset/fast-rats-impress.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Allow account size to be null

--- a/.changeset/many-hairs-buy.md
+++ b/.changeset/many-hairs-buy.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Simplify rust error enum traits

--- a/src/nodes/AccountNode.ts
+++ b/src/nodes/AccountNode.ts
@@ -23,7 +23,7 @@ export type AccountNode = {
   readonly idlName: string;
   readonly docs: string[];
   readonly internal: boolean;
-  readonly size?: number;
+  readonly size?: number | null;
   readonly seeds: AccountSeed[];
   readonly discriminator?: AccountDiscriminator;
 };

--- a/src/renderers/js/templates/accountsPage.njk
+++ b/src/renderers/js/templates/accountsPage.njk
@@ -80,7 +80,7 @@ export function get{{ account.name | pascalCase }}GpaBuilder(context: Pick<Conte
   ;
 }
 
-{% if account.size !== undefined %}
+{% if account.size != null %}
 export function get{{ account.name | pascalCase }}Size(): number {
   return {{ account.size }};
 }

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -12,9 +12,9 @@
 {{ nestedStruct }}
 {% endfor %}
 
-{% if account.size !== undefined or seeds.length > 0 %}
+{% if account.size != null or seeds.length > 0 %}
 impl {{ account.name | pascalCase }} {
-  {% if account.size !== undefined %}
+  {% if account.size != null %}
     pub const LEN: usize = {{ account.size }};
   {% endif %}
 

--- a/src/renderers/rust/templates/errorsPage.njk
+++ b/src/renderers/rust/templates/errorsPage.njk
@@ -2,22 +2,15 @@
 
 {% block main %}
 
-use num_derive::FromPrimitive;
-use thiserror::Error;
+use spl_program_error::*;
 
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error]
 pub enum {{ program.name | pascalCase }}Error {
 {% for error in errors | sort(false, false, 'code') %}
     /// 0x{{ error.code.toString(16) | upper }} - {{ error.message }}
     #[error("{{ error.message }}")]
     {{ error.name | pascalCase }},
 {% endfor %}
-}
-
-impl solana_program::program_error::PrintProgramError for {{ program.name | pascalCase }}Error {
-    fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
-    }
 }
 
 {% endblock %}

--- a/test/packages/rust/Cargo.lock
+++ b/test/packages/rust/Cargo.lock
@@ -710,10 +710,8 @@ version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
  "kaigan",
- "num-derive",
- "num-traits",
  "solana-program",
- "thiserror",
+ "spl-program-error",
 ]
 
 [[package]]
@@ -812,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1095,9 +1093,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
 dependencies = [
  "serde_derive",
 ]
@@ -1113,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1293,6 +1291,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af92f74cd3b0fdfda59fef4b571a92123e4df0f67cc43f73163975d31118ef82"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-program-error-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173f3cc506847882189b3a5b67299f617fed2f9730f122dd197b82e1e213dee5"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 

--- a/test/packages/rust/Cargo.toml
+++ b/test/packages/rust/Cargo.toml
@@ -5,12 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = "^1.10"
 borsh = ">= 0.9"
 kaigan = ">= 0.1"
-num-derive = "^0.3"
-num-traits = "^0.2"
-thiserror = "~1.0"
+solana-program = "^1.14"
+spl-program-error = ">= 0.1.0"
 
 [lib]
 crate-type = ["lib"]

--- a/test/packages/rust/src/generated/errors/mpl_candy_machine_core.rs
+++ b/test/packages/rust/src/generated/errors/mpl_candy_machine_core.rs
@@ -5,10 +5,9 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use num_derive::FromPrimitive;
-use thiserror::Error;
+use spl_program_error::*;
 
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error]
 pub enum MplCandyMachineCoreError {
     /// 0x1770 - Account does not have correct owner
     #[error("Account does not have correct owner")]
@@ -73,10 +72,4 @@ pub enum MplCandyMachineCoreError {
     /// 0x1784 - Not all config lines were added to the candy machine
     #[error("Not all config lines were added to the candy machine")]
     NotFullyLoaded,
-}
-
-impl solana_program::program_error::PrintProgramError for MplCandyMachineCoreError {
-    fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
-    }
 }

--- a/test/packages/rust/src/generated/errors/mpl_token_auth_rules.rs
+++ b/test/packages/rust/src/generated/errors/mpl_token_auth_rules.rs
@@ -5,10 +5,9 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use num_derive::FromPrimitive;
-use thiserror::Error;
+use spl_program_error::*;
 
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error]
 pub enum MplTokenAuthRulesError {
     /// 0x0 - Numerical Overflow
     #[error("Numerical Overflow")]
@@ -55,10 +54,4 @@ pub enum MplTokenAuthRulesError {
     /// 0xE - Borsh Serialization Error
     #[error("Borsh Serialization Error")]
     BorshSerializationError,
-}
-
-impl solana_program::program_error::PrintProgramError for MplTokenAuthRulesError {
-    fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
-    }
 }

--- a/test/packages/rust/src/generated/errors/mpl_token_metadata.rs
+++ b/test/packages/rust/src/generated/errors/mpl_token_metadata.rs
@@ -5,10 +5,9 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use num_derive::FromPrimitive;
-use thiserror::Error;
+use spl_program_error::*;
 
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[spl_program_error]
 pub enum MplTokenMetadataError {
     /// 0x0 - Failed to unpack instruction data
     #[error("Failed to unpack instruction data")]
@@ -467,10 +466,4 @@ pub enum MplTokenMetadataError {
     /// 0x96 - Invalid delegate role for transfer
     #[error("Invalid delegate role for transfer")]
     InvalidDelegateRoleForTransfer,
-}
-
-impl solana_program::program_error::PrintProgramError for MplTokenMetadataError {
-    fn print<E>(&self) {
-        solana_program::msg!(&self.to_string());
-    }
 }


### PR DESCRIPTION
This PR includes two improvements to renderers:
1. Allow the account size property to be set to `null`
2. Simplify the traits definition for generate Rust errors enum