### PR TITLE
Add program errors length test

### DIFF
--- a/.changeset/brave-crabs-shave.md
+++ b/.changeset/brave-crabs-shave.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add program errors length test

--- a/src/renderers/rust/GetRustRenderMapVisitor.ts
+++ b/src/renderers/rust/GetRustRenderMapVisitor.ts
@@ -114,16 +114,18 @@ export class GetRustRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       return renderMap;
     }
 
-    renderMap
-      .mergeWith(
-        ...nodes
-          .getAllInstructionsWithSubs(
-            program,
-            !this.options.renderParentInstructions
-          )
-          .map((ix) => visit(ix, this))
-      )
-      .add(
+    renderMap.mergeWith(
+      ...nodes
+        .getAllInstructionsWithSubs(
+          program,
+          !this.options.renderParentInstructions
+        )
+        .map((ix) => visit(ix, this))
+    );
+
+    // Errors.
+    if (program.errors.length > 0) {
+      renderMap.add(
         `errors/${snakeCase(name)}.rs`,
         this.render('errorsPage.njk', {
           imports: new RustImportMap().toString(this.options.dependencyMap),
@@ -134,6 +136,8 @@ export class GetRustRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
           })),
         })
       );
+    }
+
     this.program = null;
     return renderMap;
   }

--- a/src/renderers/rust/templates/errorsMod.njk
+++ b/src/renderers/rust/templates/errorsMod.njk
@@ -3,11 +3,15 @@
 {% block main %}
 
 {% for program in programsToExport | sort(false, false, 'name') %}
-pub mod {{ program.name | snakeCase }};
+  {% if program.errors.length > 0 %}
+    pub mod {{ program.name | snakeCase }};
+  {% endif %}
 {% endfor %}
 
 {% for program in programsToExport | sort(false, false, 'name') %}
-pub use self::{{ program.name | snakeCase }}::{{ program.name | pascalCase }}Error;
+  {% if program.errors.length > 0 %}
+    pub use self::{{ program.name | snakeCase }}::{{ program.name | pascalCase }}Error;
+  {% endif %}
 {% endfor %}
 
 {% endblock %}


### PR DESCRIPTION
This PR adds a length test on the program errors to avoid exporting empty error enums.