### PR TITLE
Instruction input resolution refactoring

### DIFF
--- a/.changeset/big-emus-glow.md
+++ b/.changeset/big-emus-glow.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': minor
+---
+
+Remove deprecated signatures in JS renderer

--- a/.changeset/big-queens-exist.md
+++ b/.changeset/big-queens-exist.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': minor
+---
+
+Refactor instruction input resolution so it's more intuitive and easier to maintain

--- a/.changeset/pink-bats-type.md
+++ b/.changeset/pink-bats-type.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': minor
+---
+
+More isOptionalStrategy from instructionAccountNode to instructionNode as "optionalAccountStrategy"

--- a/.changeset/young-shrimps-repair.md
+++ b/.changeset/young-shrimps-repair.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': minor
+---
+
+Remove programId account default when optionalAccountStrategy is programId already

--- a/src/nodes/InstructionAccountNode.ts
+++ b/src/nodes/InstructionAccountNode.ts
@@ -1,10 +1,5 @@
 import { IdlInstructionAccount } from '../idl';
-import {
-  InstructionAccountDefault,
-  PartialExcept,
-  mainCase,
-  programIdDefault,
-} from '../shared';
+import { InstructionAccountDefault, PartialExcept, mainCase } from '../shared';
 import type { Node } from './Node';
 
 export type InstructionAccountNode = {
@@ -14,7 +9,6 @@ export type InstructionAccountNode = {
   readonly isWritable: boolean;
   readonly isSigner: boolean | 'either';
   readonly isOptional: boolean;
-  readonly isOptionalStrategy: 'omitted' | 'programId';
   readonly docs: string[];
   readonly defaultsTo?: InstructionAccountDefault;
 };
@@ -33,15 +27,13 @@ export function instructionAccountNode(
     isWritable: input.isWritable,
     isSigner: input.isSigner,
     isOptional: input.isOptional ?? false,
-    isOptionalStrategy: input.isOptionalStrategy ?? 'programId',
     docs: input.docs ?? [],
     defaultsTo: input.defaultsTo,
   } as InstructionAccountNode;
 }
 
 export function instructionAccountNodeFromIdl(
-  idl: IdlInstructionAccount,
-  useProgramIdForOptionalAccounts = true
+  idl: IdlInstructionAccount
 ): InstructionAccountNode {
   const isOptional = idl.optional ?? idl.isOptional ?? false;
   const desc = idl.desc ? [idl.desc] : undefined;
@@ -50,14 +42,7 @@ export function instructionAccountNodeFromIdl(
     isWritable: idl.isMut ?? false,
     isSigner: idl.isOptionalSigner ? 'either' : idl.isSigner ?? false,
     isOptional,
-    isOptionalStrategy: useProgramIdForOptionalAccounts
-      ? 'programId'
-      : 'omitted',
     docs: idl.docs ?? desc ?? [],
-    defaultsTo:
-      isOptional && useProgramIdForOptionalAccounts
-        ? programIdDefault()
-        : undefined,
   });
 }
 

--- a/src/nodes/InstructionNode.ts
+++ b/src/nodes/InstructionNode.ts
@@ -41,6 +41,7 @@ export type InstructionNode = {
   readonly bytesCreatedOnChain?: BytesCreatedOnChain;
   readonly remainingAccounts?: RemainingAccounts;
   readonly argDefaults: Record<string, InstructionArgDefault>;
+  readonly optionalAccountStrategy: 'omitted' | 'programId';
 };
 
 export type InstructionNodeInput = Omit<
@@ -76,6 +77,7 @@ export function instructionNode(input: InstructionNodeInput): InstructionNode {
         value,
       ])
     ),
+    optionalAccountStrategy: input.optionalAccountStrategy ?? 'programId',
   } as InstructionNode;
 }
 
@@ -111,6 +113,9 @@ export function instructionNodeFromIdl(
       name: `${name}InstructionData`,
       struct: dataArgs,
     }),
+    optionalAccountStrategy: useProgramIdForOptionalAccounts
+      ? 'programId'
+      : 'omitted',
   });
 }
 

--- a/src/nodes/InstructionNode.ts
+++ b/src/nodes/InstructionNode.ts
@@ -86,7 +86,6 @@ export function instructionNodeFromIdl(
 ): InstructionNode {
   const idlName = idl.name ?? '';
   const name = mainCase(idlName);
-  const useProgramIdForOptionalAccounts = !idl.legacyOptionalAccountsStrategy;
   let dataArgs = structTypeNodeFromIdl({
     kind: 'struct',
     fields: idl.args ?? [],
@@ -107,15 +106,15 @@ export function instructionNodeFromIdl(
     idlName,
     docs: idl.docs ?? [],
     accounts: (idl.accounts ?? []).map((account) =>
-      instructionAccountNodeFromIdl(account, useProgramIdForOptionalAccounts)
+      instructionAccountNodeFromIdl(account)
     ),
     dataArgs: instructionDataArgsNode({
       name: `${name}InstructionData`,
       struct: dataArgs,
     }),
-    optionalAccountStrategy: useProgramIdForOptionalAccounts
-      ? 'programId'
-      : 'omitted',
+    optionalAccountStrategy: idl.legacyOptionalAccountsStrategy
+      ? 'omitted'
+      : 'programId',
   });
 }
 

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -377,7 +377,13 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         const { seeds } = input.defaultsTo;
         Object.keys(seeds).forEach((seed: string) => {
           const seedValue = seeds[seed];
-          if (seedValue.kind !== 'value') return;
+          if (seedValue.kind !== 'value') {
+            imports.add(
+              'shared',
+              seedValue.kind === 'account' ? 'expectPublicKey' : 'expectSome'
+            );
+            return;
+          }
           const valueManifest = renderJavaScriptValueNode(seedValue.value);
           (seedValue as any).render = valueManifest.render;
           imports.mergeWith(valueManifest.imports);
@@ -387,6 +393,15 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         const valueManifest = renderJavaScriptValueNode(defaultsTo.value);
         (defaultsTo as any).render = valueManifest.render;
         imports.mergeWith(valueManifest.imports);
+      } else if (input.defaultsTo?.kind === 'account') {
+        imports.add(
+          'shared',
+          input.kind === 'account' ? 'expectSome' : 'expectPublicKey'
+        );
+      } else if (input.defaultsTo?.kind === 'arg') {
+        imports.add('shared', ['expectSome']);
+      } else if (input.defaultsTo?.kind === 'accountBump') {
+        imports.add('shared', ['expectPda']);
       }
       return input;
     });

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -387,7 +387,7 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       return { ...input, render: renderedInput.render };
     });
     const resolvedInputsWithDefaults = resolvedInputs.filter(
-      (input) => input.kind !== 'account' || input.defaultsTo !== undefined
+      (input) => input.defaultsTo !== undefined && input.render !== ''
     );
     const argsWithDefaults = resolvedInputsWithDefaults
       .filter((input) => input.kind === 'arg')

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -421,7 +421,7 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       imports.add('shared', ['ResolvedAccounts']);
     }
     if (accounts.length > 0) {
-      imports.add('shared', ['addAccountMeta']);
+      imports.add('shared', ['addAccountMetas']);
     }
 
     // Data Args.

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -416,7 +416,7 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
     });
     imports.mergeWith(this.getInstructionAccountImports(accounts));
     if (accounts.length > 0) {
-      imports.add('shared', 'addAccountMeta');
+      imports.add('shared', ['addAccountMeta', 'ResolvedAccounts']);
     }
 
     // Data Args.

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -393,8 +393,8 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
     const resolvedInputsWithDefaults = resolvedInputs.filter(
       (input) => input.kind !== 'account' || input.defaultsTo !== undefined
     );
-    if (resolvedInputsWithDefaults.length > 0) {
-      imports.add('shared', 'addObjectProperty');
+    if (hasResolvedAccounts) {
+      imports.add('shared', ['ResolvedAccountsWithIndices']);
     }
     const accountsWithDefaults = resolvedInputsWithDefaults
       .filter((input) => input.kind === 'account')
@@ -417,9 +417,6 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       };
     });
     imports.mergeWith(this.getInstructionAccountImports(accounts));
-    if (hasResolvedAccounts) {
-      imports.add('shared', ['ResolvedAccounts']);
-    }
     if (accounts.length > 0) {
       imports.add('shared', ['addAccountMetas']);
     }

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -365,6 +365,8 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       hasAccountResolvers ||
       hasByteResolver ||
       hasRemainingAccountsResolver;
+    const hasResolvedAccounts = hasAccounts || hasResolvers;
+    const hasResolvedArgs = hasDataArgs || hasArgDefaults || hasResolvers;
 
     // Resolved inputs.
     const resolvedInputs = visit(
@@ -415,8 +417,11 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       };
     });
     imports.mergeWith(this.getInstructionAccountImports(accounts));
+    if (hasResolvedAccounts) {
+      imports.add('shared', ['ResolvedAccounts']);
+    }
     if (accounts.length > 0) {
-      imports.add('shared', ['addAccountMeta', 'ResolvedAccounts']);
+      imports.add('shared', ['addAccountMeta']);
     }
 
     // Data Args.
@@ -532,6 +537,8 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         hasByteResolver,
         hasRemainingAccountsResolver,
         hasResolvers,
+        hasResolvedAccounts,
+        hasResolvedArgs,
       })
     );
   }

--- a/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
+++ b/src/renderers/js/GetJavaScriptRenderMapVisitor.ts
@@ -325,13 +325,19 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
 
   visitInstruction(instruction: nodes.InstructionNode): RenderMap {
     // Imports.
-    const imports = new JavaScriptImportMap().add('umi', [
-      'AccountMeta',
-      'Context',
-      'Signer',
-      'TransactionBuilder',
-      'transactionBuilder',
-    ]);
+    const imports = new JavaScriptImportMap()
+      .add('umi', [
+        'AccountMeta',
+        'Context',
+        'Signer',
+        'TransactionBuilder',
+        'transactionBuilder',
+      ])
+      .add('shared', [
+        'ResolvedAccount',
+        'ResolvedAccountsWithIndices',
+        'getAccountMetasAndSigners',
+      ]);
 
     // Instruction helpers.
     const hasAccounts = instruction.accounts.length > 0;
@@ -365,7 +371,6 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       hasAccountResolvers ||
       hasByteResolver ||
       hasRemainingAccountsResolver;
-    const hasResolvedAccounts = hasAccounts || hasResolvers;
     const hasResolvedArgs = hasDataArgs || hasArgDefaults || hasResolvers;
 
     // Resolved inputs.
@@ -408,9 +413,6 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
     const resolvedInputsWithDefaults = resolvedInputs.filter(
       (input) => input.kind !== 'account' || input.defaultsTo !== undefined
     );
-    if (hasResolvedAccounts) {
-      imports.add('shared', ['ResolvedAccountsWithIndices']);
-    }
     const accountsWithDefaults = resolvedInputsWithDefaults
       .filter((input) => input.kind === 'account')
       .map((input) => input.name);
@@ -432,9 +434,6 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
       };
     });
     imports.mergeWith(this.getInstructionAccountImports(accounts));
-    if (accounts.length > 0) {
-      imports.add('shared', ['addAccountMetas']);
-    }
 
     // Data Args.
     const linkedDataArgs = !!instruction.dataArgs.link;
@@ -549,7 +548,6 @@ export class GetJavaScriptRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         hasByteResolver,
         hasRemainingAccountsResolver,
         hasResolvers,
-        hasResolvedAccounts,
         hasResolvedArgs,
       })
     );

--- a/src/renderers/js/RenderJavaScriptInstructionDefaults.ts
+++ b/src/renderers/js/RenderJavaScriptInstructionDefaults.ts
@@ -1,0 +1,147 @@
+import { camelCase, pascalCase } from '../../shared';
+import { ResolvedInstructionInput } from '../../visitors';
+import { JavaScriptImportMap } from './JavaScriptImportMap';
+import { renderJavaScriptValueNode } from './RenderJavaScriptValueNode';
+
+export function renderJavaScriptInstructionDefaults(
+  input: ResolvedInstructionInput,
+  optionalAccountStrategy: 'programId' | 'omitted'
+): {
+  imports: JavaScriptImportMap;
+  render: string;
+} {
+  const imports = new JavaScriptImportMap();
+  if (!input.defaultsTo) {
+    return { imports, render: '' };
+  }
+
+  const { defaultsTo } = input;
+  const render = (
+    defaultValue: string,
+    isWritable?: boolean
+  ): {
+    imports: JavaScriptImportMap;
+    render: string;
+  } => {
+    const inputName = camelCase(input.name);
+    if (input.kind === 'account' && defaultsTo.kind === 'resolver') {
+      return {
+        imports,
+        render: `resolvedAccounts.${inputName} = { ...resolvedAccounts.${inputName}, ...${defaultValue} };`,
+      };
+    }
+    if (input.kind === 'account' && isWritable === undefined) {
+      return {
+        imports,
+        render: `resolvedAccounts.${inputName}.value = ${defaultValue};`,
+      };
+    }
+    if (input.kind === 'account') {
+      return {
+        imports,
+        render:
+          `resolvedAccounts.${inputName}.value = ${defaultValue};\n` +
+          `resolvedAccounts.${inputName}.isWritable = ${
+            isWritable ? 'true' : 'false'
+          }`,
+      };
+    }
+    return {
+      imports,
+      render: `resolvedArgs.${inputName} = ${defaultValue};`,
+    };
+  };
+
+  switch (defaultsTo.kind) {
+    case 'account':
+      const name = camelCase(defaultsTo.name);
+      if (input.kind === 'account') {
+        imports.add('shared', 'expectSome');
+        return render(`expectSome(resolvedAccounts.${name}.value)`);
+      }
+      imports.add('shared', 'expectPublicKey');
+      return render(`expectPublicKey(resolvedAccounts.${name}.value)`);
+    case 'pda':
+      const pdaFunction = `find${pascalCase(defaultsTo.pdaAccount)}Pda`;
+      const pdaImportFrom =
+        defaultsTo.importFrom === 'generated'
+          ? 'generatedAccounts'
+          : defaultsTo.importFrom;
+      imports.add(pdaImportFrom, pdaFunction);
+      const pdaArgs = ['context'];
+      const pdaSeeds = Object.keys(defaultsTo.seeds).map(
+        (seed: string): string => {
+          const seedValue = defaultsTo.seeds[seed];
+          if (seedValue.kind === 'account') {
+            imports.add('shared', 'expectPublicKey');
+            return `${seed}: expectPublicKey(resolvedAccounts.${camelCase(
+              seedValue.name
+            )}.value)`;
+          }
+          if (seedValue.kind === 'arg') {
+            imports.add('shared', 'expectSome');
+            return `${seed}: expectSome(resolvedArgs.${camelCase(
+              seedValue.name
+            )})`;
+          }
+          const valueManifest = renderJavaScriptValueNode(seedValue.value);
+          imports.mergeWith(valueManifest.imports);
+          return `${seed}: ${valueManifest.render}`;
+        }
+      );
+      if (pdaSeeds.length > 0) {
+        pdaArgs.push(`{ ${pdaSeeds.join(', ')} }`);
+      }
+      return render(`${pdaFunction}(${pdaArgs.join(', ')})`);
+    case 'publicKey':
+      imports.add('umi', 'publicKey');
+      return render(`publicKey('${defaultsTo.publicKey}')`);
+    case 'program':
+      return render(
+        `context.programs.getPublicKey('${defaultsTo.program.name}', '${defaultsTo.program.publicKey}')`,
+        false
+      );
+    case 'programId':
+      if (
+        optionalAccountStrategy === 'programId' &&
+        input.kind === 'account' &&
+        input.isOptional
+      ) {
+        return { imports, render: '' };
+      }
+      return render('programId', false);
+    case 'identity':
+      if (input.kind === 'account' && input.isSigner !== false) {
+        return render('context.identity');
+      }
+      return render('context.identity.publicKey');
+    case 'payer':
+      if (input.kind === 'account' && input.isSigner !== false) {
+        return render('context.payer');
+      }
+      return render('context.payer.publicKey');
+    case 'accountBump':
+      imports.add('shared', 'expectPda');
+      return render(
+        `expectPda(resolvedAccounts.${camelCase(defaultsTo.name)}.value)[1]`
+      );
+    case 'arg':
+      imports.add('shared', 'expectSome');
+      return render(`expectSome(resolvedArgs.${camelCase(defaultsTo.name)})`);
+    case 'value':
+      const valueManifest = renderJavaScriptValueNode(defaultsTo.value);
+      imports.mergeWith(valueManifest.imports);
+      return render(valueManifest.render);
+    case 'resolver':
+      const resolverName = camelCase(defaultsTo.name);
+      const isWritable =
+        input.kind === 'account' && input.isWritable ? 'true' : 'false';
+      imports.add(defaultsTo.importFrom, resolverName);
+      return render(
+        `${resolverName}(context, resolvedAccounts, resolvedArgs, programId, ${isWritable})`
+      );
+    default:
+      const neverDefault: never = defaultsTo;
+      throw new Error(`Unexpected value type ${(neverDefault as any).kind}`);
+  }
+}

--- a/src/renderers/js/templates/accountsPage.njk
+++ b/src/renderers/js/templates/accountsPage.njk
@@ -16,11 +16,8 @@
   {{ macros.exportSerializer(account.name | pascalCase + 'AccountData', typeManifest) }}
 {% endif %}
 
-/** @deprecated Use `deserialize{{ account.name | pascalCase }}(rawAccount)` without any context instead. */
-export function deserialize{{ account.name | pascalCase }}(context: object, rawAccount: RpcAccount): {{ account.name | pascalCase }};
-export function deserialize{{ account.name | pascalCase }}(rawAccount: RpcAccount): {{ account.name | pascalCase }};
-export function deserialize{{ account.name | pascalCase }}(context: RpcAccount | object, rawAccount?: RpcAccount): {{ account.name | pascalCase }} {
-  return deserializeAccount(rawAccount ?? context as RpcAccount, get{{ account.name | pascalCase }}AccountDataSerializer());
+export function deserialize{{ account.name | pascalCase }}(rawAccount: RpcAccount): {{ account.name | pascalCase }} {
+  return deserializeAccount(rawAccount, get{{ account.name | pascalCase }}AccountDataSerializer());
 }
 
 export async function fetch{{ account.name | pascalCase }}(

--- a/src/renderers/js/templates/instructionsPage.njk
+++ b/src/renderers/js/templates/instructionsPage.njk
@@ -52,7 +52,7 @@ export function {{ instruction.name | camelCase }}(
 
   // Data.
   {% if hasDataArgs %}
-    const data = get{{ instruction.dataArgs.name | pascalCase }}Serializer().serialize(resolvedArgs);
+    const data = get{{ instruction.dataArgs.name | pascalCase }}Serializer().serialize(resolvedArgs as {{ instruction.name | pascalCase + 'InstructionDataArgs' }});
   {% elif hasData %}
     const data = get{{ instruction.dataArgs.name | pascalCase }}Serializer().serialize({});
   {% else %}

--- a/src/renderers/js/templates/instructionsPage.njk
+++ b/src/renderers/js/templates/instructionsPage.njk
@@ -38,17 +38,30 @@ export function {{ instruction.name | camelCase }}(
     {% endif %}
   {% endif %}
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey('{{ program.name | camelCase }}', '{{ program.publicKey }}');
 
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    {% for account in accounts %}
+      {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
+    {% endfor %}
+  };
+
+  {% if hasResolvedArgs %}
+    // Arguments.
+    const resolvedArgs: {{ instruction.name | pascalCase + 'InstructionArgs' }} = { ...{{ argsObj }} };
+  {% endif %}
+
   {% include "instructionsPageResolvedInputs.njk" %}
 
-  {% include "instructionsPageAccountMetas.njk" %}
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(resolvedAccounts).sort((a,b) => a.index - b.index);
 
   {% include "instructionsPageRemainingAccounts.njk" %}
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(orderedAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
 
   // Data.
   {% if hasDataArgs %}

--- a/src/renderers/js/templates/instructionsPageAccountMetas.njk
+++ b/src/renderers/js/templates/instructionsPageAccountMetas.njk
@@ -1,3 +1,3 @@
-{% for account in accounts %}
-  addAccountMeta(keys, signers, resolvedAccounts.{{ account.name | camelCase }}, {{ 'true' if account.resolvedIsOptional else 'false' }});
-{% endfor %}
+{% if accounts.length > 0 %}
+  addAccountMetas(keys, signers, resolvedAccounts, {{ instruction.optionalAccountStrategy }});
+{% endif %}

--- a/src/renderers/js/templates/instructionsPageAccountMetas.njk
+++ b/src/renderers/js/templates/instructionsPageAccountMetas.njk
@@ -1,3 +1,3 @@
 {% if accounts.length > 0 %}
-  addAccountMetas(keys, signers, resolvedAccounts, {{ instruction.optionalAccountStrategy }});
+  addAccountMetas(keys, signers, resolvedAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageAccountMetas.njk
+++ b/src/renderers/js/templates/instructionsPageAccountMetas.njk
@@ -1,3 +1,3 @@
 {% if accounts.length > 0 %}
-  addAccountMetas(keys, signers, resolvedAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
+  addAccountMetas(keys, signers, Object.values(resolvedAccounts).sort((a,b) => a.index - b.index), "{{ instruction.optionalAccountStrategy }}", programId);
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageAccountMetas.njk
+++ b/src/renderers/js/templates/instructionsPageAccountMetas.njk
@@ -1,3 +1,0 @@
-{% if accounts.length > 0 %}
-  addAccountMetas(keys, signers, Object.values(resolvedAccounts).sort((a,b) => a.index - b.index), "{{ instruction.optionalAccountStrategy }}", programId);
-{% endif %}

--- a/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
+++ b/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
@@ -1,14 +1,9 @@
-{% set remaining = instruction.remainingAccounts %}
-{% macro getArgVar(name, argsObj) -%}
-  {{ 'resolvedArgs' if argsWithDefaults.includes(name) else argsObj }}.{{ name | camelCase }}
-{%- endmacro %}
-
-{% if remaining.kind === 'arg' %}
+{% if instruction.remainingAccounts.kind === 'arg' %}
   // Remaining Accounts.
-  const remainingAccounts = resolvedArgs.{{ remaining.name | camelCase }}.map((value, index) => ({ index, value, isWritable: {{ "true" if remaining.isWritable else "false" }} }));
-  addAccountMetas(keys, signers, remainingAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
-{% elif remaining.kind === 'resolver' %}
+  const remainingAccounts = resolvedArgs.{{ instruction.remainingAccounts.name | camelCase }}.map((value, index) => ({ index, value, isWritable: {{ "true" if instruction.remainingAccounts.isWritable else "false" }} }));
+  orderedAccounts.push(...remainingAccounts);
+{% elif instruction.remainingAccounts.kind === 'resolver' %}
   // Remaining Accounts.
-  const remainingAccounts = {{ remaining.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId);
-  addAccountMetas(keys, signers, remainingAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
+  const remainingAccounts = {{ instruction.remainingAccounts.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId);
+  orderedAccounts.push(...remainingAccounts);
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
+++ b/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
@@ -6,9 +6,9 @@
 {% if remaining.kind === 'arg' %}
   // Remaining Accounts.
   const remainingAccounts = resolvedArgs.{{ remaining.name | camelCase }}.map((value, index) => ({ index, value, isWritable: {{ "true" if remaining.isWritable else "false" }} }));
-  addAccountMetas(keys, signers, remainingAccounts, {{ instruction.optionalAccountStrategy }});
+  addAccountMetas(keys, signers, remainingAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
 {% elif remaining.kind === 'resolver' %}
   // Remaining Accounts.
   const remainingAccounts = {{ remaining.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId);
-  addAccountMetas(keys, signers, remainingAccounts, {{ instruction.optionalAccountStrategy }});
+  addAccountMetas(keys, signers, remainingAccounts, "{{ instruction.optionalAccountStrategy }}", programId);
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
+++ b/src/renderers/js/templates/instructionsPageRemainingAccounts.njk
@@ -5,10 +5,10 @@
 
 {% if remaining.kind === 'arg' %}
   // Remaining Accounts.
-  const remainingAccounts = {{ getArgVar(remaining.name, argsObj) }}.map(address => ([address, {{ "true" if remaining.isWritable else "false" }}] as const));
-  remainingAccounts.forEach((remainingAccount) => addAccountMeta(keys, signers, remainingAccount, false));
+  const remainingAccounts = resolvedArgs.{{ remaining.name | camelCase }}.map((value, index) => ({ index, value, isWritable: {{ "true" if remaining.isWritable else "false" }} }));
+  addAccountMetas(keys, signers, remainingAccounts, {{ instruction.optionalAccountStrategy }});
 {% elif remaining.kind === 'resolver' %}
   // Remaining Accounts.
   const remainingAccounts = {{ remaining.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId);
-  remainingAccounts.forEach((remainingAccount) => addAccountMeta(keys, signers, remainingAccount, false));
+  addAccountMetas(keys, signers, remainingAccounts, {{ instruction.optionalAccountStrategy }});
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,13 +1,11 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
   {% if hasResolvedAccounts %}
-    const resolvedAccounts: ResolvedAccountsWithIndices = Object.fromEntries(
-      [
-        {% for account in accounts %}
-          ["{{ account.name | camelCase }}", {{ accountsObj }}.{{ account.name | camelCase }}, {{ 'true' if account.isWritable else 'false' }}],
-        {% endfor %}
-      ].map(([name, value, isWritable], index) => ([name, { index, isWritable, value: value ?? null }]))
-    )
+    const resolvedAccounts: ResolvedAccountsWithIndices = {};
+    {% for account in accounts %}
+      resolvedAccounts.{{ account.name | camelCase }} = { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: null };
+      resolvedAccounts.{{ account.name | camelCase }}.value = {{ accountsObj }}.{{ account.name | camelCase }} ?? null;
+    {% endfor %}
   {% endif %}
   {% if hasResolvedArgs %}
     const resolvedArgs = { ...{{ argsObj }} } as {{ instruction.name | pascalCase + 'InstructionArgs' }}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,21 +1,21 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
   {% if hasResolvedAccounts %}
-    const resolvedAccounts = {
+    const resolvedAccounts: ResolvedAccountsWithIndices = {
       {% for account in accounts %}
-        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }} as boolean, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
+        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
       {% endfor %}
-    } satisfies ResolvedAccountsWithIndices;
+    };
   {% endif %}
   {% if hasResolvedArgs %}
-    const resolvedArgs = { ...{{ argsObj }} };
+    const resolvedArgs: {{ instruction.name | pascalCase + 'InstructionArgs' }} = { ...{{ argsObj }} };
   {% endif %}
   {% for input in resolvedInputsWithDefaults %}
     {#- Input default value. -#}
     {% if input.defaultsTo.kind === 'account' and input.kind === 'account' %}
-      {% set inputDefault %}resolvedAccounts.{{ input.defaultsTo.name }}.value{% endset %}
+      {% set inputDefault %}expectSome(resolvedAccounts.{{ input.defaultsTo.name }}.value){% endset %}
     {% elif input.defaultsTo.kind === 'account' %}
-      {% set inputDefault %}publicKey(resolvedAccounts.{{ input.defaultsTo.name }}.value, false){% endset %}
+      {% set inputDefault %}expectPublicKey(resolvedAccounts.{{ input.defaultsTo.name }}.value){% endset %}
     {% elif input.defaultsTo.kind === 'pda' %}
       {% set inputDefault -%}
         find{{ input.defaultsTo.pdaAccount | pascalCase }}Pda(context,
@@ -25,9 +25,9 @@
                 {%- if seedValue.kind === 'value' -%}
                   {{ seedKey }}: {{ seedValue.render }},
                 {%- elif seedValue.kind === 'account' -%}
-                  {{ seedKey }}: publicKey(resolvedAccounts.{{ seedValue.name }}.value, false),
+                  {{ seedKey }}: expectPublicKey(resolvedAccounts.{{ seedValue.name }}.value),
                 {%- else -%}
-                  {{ seedKey }}: resolvedArgs.{{ seedValue.name }},
+                  {{ seedKey }}: expectSome(resolvedArgs.{{ seedValue.name }}),
                 {%- endif -%}
               {%- endfor -%}
             }
@@ -51,33 +51,32 @@
     {% elif input.defaultsTo.kind === 'payer' %}
       {% set inputDefault %}context.payer.publicKey{% endset %}
     {% elif input.defaultsTo.kind === 'arg' %}
-      {% set inputDefault %}resolvedArgs.{{ input.defaultsTo.name }}{% endset %}
+      {% set inputDefault %}expectSome(resolvedArgs.{{ input.defaultsTo.name }}){% endset %}
     {% elif input.defaultsTo.kind === 'accountBump' %}
-      {% set inputDefault %}resolvedAccounts.{{ input.defaultsTo.name }}.value[1]{% endset %}
+      {% set inputDefault %}expectPda(resolvedAccounts.{{ input.defaultsTo.name }}.value)[1]{% endset %}
     {% elif input.defaultsTo.kind === 'value' %}
       {% set inputDefault %}{{ input.defaultsTo.render }}{% endset %}
     {% elif input.defaultsTo.kind === 'resolver' %}
       {% set inputDefault %}{{ input.defaultsTo.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId, {{ 'true' if input.isWritable else 'false' }}){% endset %}
-    {% else %}
-      {% set inputDefault %}programId /* Unrecognized default kind [{{ input.defaultsTo.kind }}]. */{% endset %}
-      {% set inputDefaultIsWritable %}false{% endset %}
     {% endif %}
-    {# Add input to resolving object. #}
-    {%- if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
-      if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
-        resolvedAccounts.{{ input.name | camelCase }} = { ...resolvedAccounts.{{ input.name | camelCase }}, ...{{ inputDefault }} };
-      }
-    {% elif input.kind === 'account' %}
-      if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
-        resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
-        {% if inputDefaultIsWritable -%} 
-          resolvedAccounts.{{ input.name | camelCase }}.isWritable = {{ inputDefaultIsWritable }};
-        {% endif %} 
-      }
-    {% else %}
-      if (!resolvedArgs.{{ input.name | camelCase }}) {
-        resolvedArgs.{{ input.name | camelCase }} = {{ inputDefault }};
-      }
+    {# Add input to resolved object. #}
+    {% if inputDefault %}
+      {%- if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
+        if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
+          resolvedAccounts.{{ input.name | camelCase }} = { ...resolvedAccounts.{{ input.name | camelCase }}, ...{{ inputDefault }} };
+        }
+      {% elif input.kind === 'account' %}
+        if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
+          resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
+          {% if inputDefaultIsWritable -%} 
+            resolvedAccounts.{{ input.name | camelCase }}.isWritable = {{ inputDefaultIsWritable }};
+          {% endif %} 
+        }
+      {% else %}
+        if (!resolvedArgs.{{ input.name | camelCase }}) {
+          resolvedArgs.{{ input.name | camelCase }} = {{ inputDefault }};
+        }
+      {% endif -%}
     {% endif -%}
   {% endfor %}
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -29,7 +29,7 @@
     {% elif input.defaultsTo.kind === 'program' %}
       {% set inputDefault %}context.programs.getPublicKey('{{ input.defaultsTo.program.name }}', '{{ input.defaultsTo.program.publicKey }}'){% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
-    {% elif input.defaultsTo.kind === 'programId' %}
+    {% elif input.defaultsTo.kind === 'programId' and not (instruction.optionalAccountStrategy === 'programId' and input.kind === 'account' and input.isOptional) %}
       {% set inputDefault %}programId{% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
     {% elif input.defaultsTo.kind === 'identity' and input.kind === 'account' and input.isSigner !== false %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,44 +1,28 @@
-{% set hasResolvingAccounts = hasAccounts or hasResolvers %}
-{% set hasResolvingArgs = hasDataArgs or hasArgDefaults or hasResolvers %}
-{% macro getAccountVar(name, accountsObj) -%}
-  {% if accountsWithDefaults.includes(name) %}
-    resolvedAccounts.{{ name | camelCase }}[0]
-  {% else %}
-    {{ accountsObj }}.{{ name | camelCase }}
-  {% endif %}
-{%- endmacro %}
-{% macro getArgVar(name, argsObj) -%}
-  {{ 'resolvingArgs' if argsWithDefaults.includes(name) else argsObj }}.{{ name | camelCase }}
-{%- endmacro %}
+{% set hasResolvedAccounts = hasAccounts or hasResolvers %}
+{% set hasResolvedArgs = hasDataArgs or hasArgDefaults or hasResolvers %}
 
-{% if resolvedInputs.length > 0 or hasResolvingAccounts or hasResolvingArgs %}
+{% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
-  {% if hasResolvingAccounts %}
-    const resolvedAccounts = {
-      {% for account in accounts %}
-        {% if not account.hasDefaultValue %}
-          {{ account.name | camelCase }}: [{{ accountsObj }}.{{ account.name | camelCase }}, {{ 'true' if account.isWritable else 'false' }}] as const,
-        {% endif %}
+  {% if hasResolvedAccounts %}
+    const resolvedAccounts: ResolvedAccounts = {
+      {% for (account, index) in accounts %}
+        {{ account.name | camelCase }}: {
+          index: {{ index }},
+          isWritable: {{ 'true' if account.isWritable else 'false' }},
+          value: {{ accountsObj }}.{{ account.name | camelCase }}, 
+        },
       {% endfor %}
     };
   {% endif %}
-  {% if hasResolvingArgs %}
-    const resolvingArgs = {};
+  {% if hasResolvedArgs %}
+    const resolvedArgs: ResolvedArgs<{{ instruction.name | pascalCase + 'InstructionArgs' }}> = { ...{{ argsObj }} };
   {% endif %}
   {% for input in resolvedInputsWithDefaults %}
-    {#- Input prefix. -#}
-    {% if input.kind === 'account' %}
-      {% set inputPrefix %}resolvedAccounts, '{{ input.name | camelCase }}', {{ accountsObj }}.{{ input.name | camelCase }} ? [{{ accountsObj }}.{{ input.name | camelCase }}, {{ 'true' if input.isWritable else 'false' }}] as const : {% endset %}
-      {% set inputDefaultIsWritable %}{{ 'true' if input.isWritable else 'false' }}{% endset %}
-    {% else %}
-      {% set inputPrefix %}resolvingArgs, '{{ input.name | camelCase }}', {{ argsObj }}.{{ input.name | camelCase }} ??{% endset %}
-      {% set inputDefaultIsWritable %}false{% endset %}
-    {% endif %}
     {#- Input default value. -#}
     {% if input.defaultsTo.kind === 'account' and input.kind === 'account' %}
-      {% set inputDefault %}{{ getAccountVar(input.defaultsTo.name, accountsObj) }}{% endset %}
+      {% set inputDefault %}resolvedAccounts.{{ input.defaultsTo.name }}.value{% endset %}
     {% elif input.defaultsTo.kind === 'account' %}
-      {% set inputDefault %}publicKey({{ getAccountVar(input.defaultsTo.name, accountsObj) }}, false){% endset %}
+      {% set inputDefault %}publicKey(resolvedAccounts.{{ input.defaultsTo.name }}.value, false){% endset %}
     {% elif input.defaultsTo.kind === 'pda' %}
       {% set inputDefault -%}
         find{{ input.defaultsTo.pdaAccount | pascalCase }}Pda(context,
@@ -48,9 +32,9 @@
                 {%- if seedValue.kind === 'value' -%}
                   {{ seedKey }}: {{ seedValue.render }},
                 {%- elif seedValue.kind === 'account' -%}
-                  {{ seedKey }}: publicKey({{ getAccountVar(seedValue.name, accountsObj) }}, false),
+                  {{ seedKey }}: publicKey(resolvedAccounts.{{ seedValue.name }}.value, false),
                 {%- else -%}
-                  {{ seedKey }}: {{ getArgVar(seedValue.name, argsObj) }},
+                  {{ seedKey }}: resolvedArgs.{{ seedValue.name }},
                 {%- endif -%}
               {%- endfor -%}
             }
@@ -62,6 +46,9 @@
     {% elif input.defaultsTo.kind === 'program' %}
       {% set inputDefault %}context.programs.getPublicKey('{{ input.defaultsTo.program.name }}', '{{ input.defaultsTo.program.publicKey }}'){% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
+    {% elif input.defaultsTo.kind === 'programId' and input.kind === 'account' and input.isOptionalStrategy === 'programId' %}
+      {% set inputDefault %}undefined{% endset %}
+      {# TODO: Skip this at a higher level? #}
     {% elif input.defaultsTo.kind === 'programId' %}
       {% set inputDefault %}programId{% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
@@ -74,25 +61,29 @@
     {% elif input.defaultsTo.kind === 'payer' %}
       {% set inputDefault %}context.payer.publicKey{% endset %}
     {% elif input.defaultsTo.kind === 'arg' %}
-      {% set inputDefault %}{{ getArgVar(input.defaultsTo.name, argsObj) }}{% endset %}
+      {% set inputDefault %}resolvedArgs.{{ input.defaultsTo.name }}{% endset %}
     {% elif input.defaultsTo.kind === 'accountBump' %}
-      {% set inputDefault %}{{ getAccountVar(input.defaultsTo.name, accountsObj) }}[1]{% endset %}
+      {% set inputDefault %}accountsObj.{{ input.defaultsTo.name }}[1]{% endset %}
     {% elif input.defaultsTo.kind === 'value' %}
       {% set inputDefault %}{{ input.defaultsTo.render }}{% endset %}
     {% elif input.defaultsTo.kind === 'resolver' %}
-      {% set inputDefault %}{{ input.defaultsTo.name | camelCase }}(context, { ...{{ accountsObj }}, ...resolvedAccounts }, { ...{{ argsObj }}, ...resolvingArgs }, programId, {{ inputDefaultIsWritable }}){% endset %}
+      {% set inputDefault %}{{ input.defaultsTo.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId, {{ 'true' if input.isWritable else 'false' }}){% endset %}
     {% else %}
       {% set inputDefault %}programId /* Unrecognized default kind [{{ input.defaultsTo.kind }}]. */{% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
     {% endif %}
     {# Add input to resolving object. #}
-    {%- if input.kind === 'account' and input.defaultsTo.kind !== 'resolver' %}
-      addObjectProperty({{ inputPrefix }} [{{ inputDefault }}, {{ inputDefaultIsWritable }}] as const);
+    {%- if input.kind === 'account' %}
+      if (!{{ accountsObj }}.{{ input.name | camelCase }}) {
+        resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
+        {% if inputDefaultIsWritable %} 
+          resolvedAccounts.{{ input.name | camelCase }}.isWritable = {{ inputDefaultIsWritable }};
+        {% endif %} 
+      }
     {% else %}
-      addObjectProperty({{ inputPrefix }} {{ inputDefault }});
+      if (!{{ argsObj }}.{{ input.name | camelCase }}) {
+        resolvedArgs.{{ input.name | camelCase }}.value = {{ inputDefault }};
+      }
     {% endif -%}
   {% endfor %}
-  {% if hasDataArgs or hasByteResolver or instruction.remainingAccounts %}
-    const resolvedArgs = { ...{{ argsObj }}, ...resolvingArgs };
-  {% endif %}
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,11 +1,13 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
   {% if hasResolvedAccounts %}
-    const resolvedAccounts: ResolvedAccountsWithIndices = {
-      {% for account in accounts %}
-        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
-      {% endfor %}
-    };
+    const resolvedAccounts: ResolvedAccountsWithIndices = Object.fromEntries(
+      [
+        {% for account in accounts %}
+          ["{{ account.name | camelCase }}", {{ accountsObj }}.{{ account.name | camelCase }}, {{ 'true' if account.isWritable else 'false' }}],
+        {% endfor %}
+      ].map(([name, value, isWritable], index) => ([name, { index, isWritable, value: value ?? null }]))
+    )
   {% endif %}
   {% if hasResolvedArgs %}
     const resolvedArgs = { ...{{ argsObj }} } as {{ instruction.name | pascalCase + 'InstructionArgs' }}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,16 +1,9 @@
-{% set hasResolvedAccounts = hasAccounts or hasResolvers %}
-{% set hasResolvedArgs = hasDataArgs or hasArgDefaults or hasResolvers %}
-
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
   {% if hasResolvedAccounts %}
     const resolvedAccounts: ResolvedAccounts = {
-      {% for (account, index) in accounts %}
-        {{ account.name | camelCase }}: {
-          index: {{ index }},
-          isWritable: {{ 'true' if account.isWritable else 'false' }},
-          value: {{ accountsObj }}.{{ account.name | camelCase }}, 
-        },
+      {% for account in accounts %}
+        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} },
       {% endfor %}
     };
   {% endif %}
@@ -76,7 +69,7 @@
     {%- if input.kind === 'account' %}
       if (!{{ accountsObj }}.{{ input.name | camelCase }}) {
         resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
-        {% if inputDefaultIsWritable %} 
+        {% if inputDefaultIsWritable -%} 
           resolvedAccounts.{{ input.name | camelCase }}.isWritable = {{ inputDefaultIsWritable }};
         {% endif %} 
       }

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -3,7 +3,7 @@
   {% if hasResolvedAccounts %}
     const resolvedAccounts: ResolvedAccountsWithIndices = {
       {% for account in accounts %}
-        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} },
+        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
       {% endfor %}
     };
   {% endif %}
@@ -40,7 +40,7 @@
       {% set inputDefault %}context.programs.getPublicKey('{{ input.defaultsTo.program.name }}', '{{ input.defaultsTo.program.publicKey }}'){% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
     {% elif input.defaultsTo.kind === 'programId' and input.kind === 'account' and input.isOptionalStrategy === 'programId' %}
-      {% set inputDefault %}undefined{% endset %}
+      {% set inputDefault %}null{% endset %}
       {# TODO: Skip this at a higher level? #}
     {% elif input.defaultsTo.kind === 'programId' %}
       {% set inputDefault %}programId{% endset %}
@@ -66,7 +66,11 @@
       {% set inputDefaultIsWritable %}false{% endset %}
     {% endif %}
     {# Add input to resolving object. #}
-    {%- if input.kind === 'account' %}
+    {%- if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
+      if (!{{ accountsObj }}.{{ input.name | camelCase }}) {
+        resolvedAccounts.{{ input.name | camelCase }} = { ...resolvedAccounts.{{ input.name | camelCase }}, ...{{ inputDefault }} };
+      }
+    {% elif input.kind === 'account' %}
       if (!{{ accountsObj }}.{{ input.name | camelCase }}) {
         resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
         {% if inputDefaultIsWritable -%} 
@@ -75,7 +79,7 @@
       }
     {% else %}
       if (!{{ argsObj }}.{{ input.name | camelCase }}) {
-        resolvedArgs.{{ input.name | camelCase }}.value = {{ inputDefault }};
+        resolvedArgs.{{ input.name | camelCase }} = {{ inputDefault }};
       }
     {% endif -%}
   {% endfor %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -58,7 +58,7 @@
     {% elif input.defaultsTo.kind === 'arg' %}
       {% set inputDefault %}resolvedArgs.{{ input.defaultsTo.name }}{% endset %}
     {% elif input.defaultsTo.kind === 'accountBump' %}
-      {% set inputDefault %}{{ accountsObj }}.{{ input.defaultsTo.name }}[1]{% endset %}
+      {% set inputDefault %}(resolvedAccounts.{{ input.defaultsTo.name }}.value as Pda)[1]{% endset %}
     {% elif input.defaultsTo.kind === 'value' %}
       {% set inputDefault %}{{ input.defaultsTo.render }}{% endset %}
     {% elif input.defaultsTo.kind === 'resolver' %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -56,7 +56,7 @@
     {% elif input.defaultsTo.kind === 'arg' %}
       {% set inputDefault %}resolvedArgs.{{ input.defaultsTo.name }}{% endset %}
     {% elif input.defaultsTo.kind === 'accountBump' %}
-      {% set inputDefault %}(resolvedAccounts.{{ input.defaultsTo.name }}.value as Pda)[1]{% endset %}
+      {% set inputDefault %}resolvedAccounts.{{ input.defaultsTo.name }}.value[1]{% endset %}
     {% elif input.defaultsTo.kind === 'value' %}
       {% set inputDefault %}{{ input.defaultsTo.render }}{% endset %}
     {% elif input.defaultsTo.kind === 'resolver' %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,15 +1,5 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
-  // Resolved inputs.
-  {% if hasResolvedAccounts %}
-    const resolvedAccounts: ResolvedAccountsWithIndices = {
-      {% for account in accounts %}
-        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
-      {% endfor %}
-    };
-  {% endif %}
-  {% if hasResolvedArgs %}
-    const resolvedArgs: {{ instruction.name | pascalCase + 'InstructionArgs' }} = { ...{{ argsObj }} };
-  {% endif %}
+  // Default values.
   {% for input in resolvedInputsWithDefaults %}
     {#- Input default value. -#}
     {% if input.defaultsTo.kind === 'account' and input.kind === 'account' %}
@@ -60,8 +50,8 @@
       {% set inputDefault %}{{ input.defaultsTo.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId, {{ 'true' if input.isWritable else 'false' }}){% endset %}
     {% endif %}
     {# Add input to resolved object. #}
-    {% if inputDefault %}
-      {%- if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
+    {%- if inputDefault -%}
+      {% if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
         if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
           resolvedAccounts.{{ input.name | camelCase }} = { ...resolvedAccounts.{{ input.name | camelCase }}, ...{{ inputDefault }} };
         }
@@ -76,7 +66,7 @@
         if (!resolvedArgs.{{ input.name | camelCase }}) {
           resolvedArgs.{{ input.name | camelCase }} = {{ inputDefault }};
         }
-      {% endif -%}
-    {% endif -%}
+      {% endif %}
+    {% endif %}
   {% endfor %}
 {% endif %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,14 +1,14 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
   {% if hasResolvedAccounts %}
-    const resolvedAccounts: ResolvedAccountsWithIndices = {};
-    {% for account in accounts %}
-      resolvedAccounts.{{ account.name | camelCase }} = { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: null };
-      resolvedAccounts.{{ account.name | camelCase }}.value = {{ accountsObj }}.{{ account.name | camelCase }} ?? null;
-    {% endfor %}
+    const resolvedAccounts = {
+      {% for account in accounts %}
+        {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }} as boolean, value: {{ accountsObj }}.{{ account.name | camelCase }} ?? null },
+      {% endfor %}
+    } satisfies ResolvedAccountsWithIndices;
   {% endif %}
   {% if hasResolvedArgs %}
-    const resolvedArgs = { ...{{ argsObj }} } as {{ instruction.name | pascalCase + 'InstructionArgs' }}
+    const resolvedArgs = { ...{{ argsObj }} } satisfies {{ instruction.name | pascalCase + 'InstructionArgs' }}
   {% endif %}
   {% for input in resolvedInputsWithDefaults %}
     {#- Input default value. -#}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -8,7 +8,7 @@
     } satisfies ResolvedAccountsWithIndices;
   {% endif %}
   {% if hasResolvedArgs %}
-    const resolvedArgs = { ...{{ argsObj }} } satisfies {{ instruction.name | pascalCase + 'InstructionArgs' }}
+    const resolvedArgs = { ...{{ argsObj }} };
   {% endif %}
   {% for input in resolvedInputsWithDefaults %}
     {#- Input default value. -#}
@@ -39,9 +39,6 @@
     {% elif input.defaultsTo.kind === 'program' %}
       {% set inputDefault %}context.programs.getPublicKey('{{ input.defaultsTo.program.name }}', '{{ input.defaultsTo.program.publicKey }}'){% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}
-    {% elif input.defaultsTo.kind === 'programId' and input.kind === 'account' and input.isOptionalStrategy === 'programId' %}
-      {% set inputDefault %}null{% endset %}
-      {# TODO: Skip this at a higher level? #}
     {% elif input.defaultsTo.kind === 'programId' %}
       {% set inputDefault %}programId{% endset %}
       {% set inputDefaultIsWritable %}false{% endset %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,14 +1,14 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Resolved inputs.
   {% if hasResolvedAccounts %}
-    const resolvedAccounts: ResolvedAccounts = {
+    const resolvedAccounts: ResolvedAccountsWithIndices = {
       {% for account in accounts %}
         {{ account.name | camelCase }}: { index: {{ loop.index0 }}, isWritable: {{ 'true' if account.isWritable else 'false' }}, value: {{ accountsObj }}.{{ account.name | camelCase }} },
       {% endfor %}
     };
   {% endif %}
   {% if hasResolvedArgs %}
-    const resolvedArgs: ResolvedArgs<{{ instruction.name | pascalCase + 'InstructionArgs' }}> = { ...{{ argsObj }} };
+    const resolvedArgs = { ...{{ argsObj }} } as {{ instruction.name | pascalCase + 'InstructionArgs' }}
   {% endif %}
   {% for input in resolvedInputsWithDefaults %}
     {#- Input default value. -#}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,70 +1,14 @@
 {% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
   // Default values.
   {% for input in resolvedInputsWithDefaults %}
-    {#- Input default value. -#}
-    {% if input.defaultsTo.kind === 'account' and input.kind === 'account' %}
-      {% set inputDefault %}expectSome(resolvedAccounts.{{ input.defaultsTo.name }}.value){% endset %}
-    {% elif input.defaultsTo.kind === 'account' %}
-      {% set inputDefault %}expectPublicKey(resolvedAccounts.{{ input.defaultsTo.name }}.value){% endset %}
-    {% elif input.defaultsTo.kind === 'pda' %}
-      {% set inputDefault -%}
-        find{{ input.defaultsTo.pdaAccount | pascalCase }}Pda(context,
-          {%- if (input.defaultsTo.seeds | length) > 0 -%}
-            {
-              {%- for seedKey, seedValue in input.defaultsTo.seeds -%}
-                {%- if seedValue.kind === 'value' -%}
-                  {{ seedKey }}: {{ seedValue.render }},
-                {%- elif seedValue.kind === 'account' -%}
-                  {{ seedKey }}: expectPublicKey(resolvedAccounts.{{ seedValue.name }}.value),
-                {%- else -%}
-                  {{ seedKey }}: expectSome(resolvedArgs.{{ seedValue.name }}),
-                {%- endif -%}
-              {%- endfor -%}
-            }
-          {%- endif -%}
-        )
-      {%- endset %}
-    {% elif input.defaultsTo.kind === 'publicKey' %}
-      {% set inputDefault %}publicKey('{{ input.defaultsTo.publicKey }}'){% endset %}
-    {% elif input.defaultsTo.kind === 'program' %}
-      {% set inputDefault %}context.programs.getPublicKey('{{ input.defaultsTo.program.name }}', '{{ input.defaultsTo.program.publicKey }}'){% endset %}
-      {% set inputDefaultIsWritable %}false{% endset %}
-    {% elif input.defaultsTo.kind === 'programId' and not (instruction.optionalAccountStrategy === 'programId' and input.kind === 'account' and input.isOptional) %}
-      {% set inputDefault %}programId{% endset %}
-      {% set inputDefaultIsWritable %}false{% endset %}
-    {% elif input.defaultsTo.kind === 'identity' and input.kind === 'account' and input.isSigner !== false %}
-      {% set inputDefault %}context.identity{% endset %}
-    {% elif input.defaultsTo.kind === 'identity' %}
-      {% set inputDefault %}context.identity.publicKey{% endset %}
-    {% elif input.defaultsTo.kind === 'payer' and input.kind === 'account' and input.isSigner !== false %}
-      {% set inputDefault %}context.payer{% endset %}
-    {% elif input.defaultsTo.kind === 'payer' %}
-      {% set inputDefault %}context.payer.publicKey{% endset %}
-    {% elif input.defaultsTo.kind === 'arg' %}
-      {% set inputDefault %}expectSome(resolvedArgs.{{ input.defaultsTo.name }}){% endset %}
-    {% elif input.defaultsTo.kind === 'accountBump' %}
-      {% set inputDefault %}expectPda(resolvedAccounts.{{ input.defaultsTo.name }}.value)[1]{% endset %}
-    {% elif input.defaultsTo.kind === 'value' %}
-      {% set inputDefault %}{{ input.defaultsTo.render }}{% endset %}
-    {% elif input.defaultsTo.kind === 'resolver' %}
-      {% set inputDefault %}{{ input.defaultsTo.name | camelCase }}(context, resolvedAccounts, resolvedArgs, programId, {{ 'true' if input.isWritable else 'false' }}){% endset %}
-    {% endif %}
-    {# Add input to resolved object. #}
-    {%- if inputDefault -%}
-      {% if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
+    {%- if input.render -%}
+      {% if input.kind === 'account' %}
         if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
-          resolvedAccounts.{{ input.name | camelCase }} = { ...resolvedAccounts.{{ input.name | camelCase }}, ...{{ inputDefault }} };
-        }
-      {% elif input.kind === 'account' %}
-        if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
-          resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
-          {% if inputDefaultIsWritable -%} 
-            resolvedAccounts.{{ input.name | camelCase }}.isWritable = {{ inputDefaultIsWritable }};
-          {% endif %} 
+          {{ input.render }}
         }
       {% else %}
         if (!resolvedArgs.{{ input.name | camelCase }}) {
-          resolvedArgs.{{ input.name | camelCase }} = {{ inputDefault }};
+          {{ input.render }}
         }
       {% endif %}
     {% endif %}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -58,7 +58,7 @@
     {% elif input.defaultsTo.kind === 'arg' %}
       {% set inputDefault %}resolvedArgs.{{ input.defaultsTo.name }}{% endset %}
     {% elif input.defaultsTo.kind === 'accountBump' %}
-      {% set inputDefault %}accountsObj.{{ input.defaultsTo.name }}[1]{% endset %}
+      {% set inputDefault %}{{ accountsObj }}.{{ input.defaultsTo.name }}[1]{% endset %}
     {% elif input.defaultsTo.kind === 'value' %}
       {% set inputDefault %}{{ input.defaultsTo.render }}{% endset %}
     {% elif input.defaultsTo.kind === 'resolver' %}
@@ -69,18 +69,18 @@
     {% endif %}
     {# Add input to resolving object. #}
     {%- if input.kind === 'account' and input.defaultsTo.kind === 'resolver' %}
-      if (!{{ accountsObj }}.{{ input.name | camelCase }}) {
+      if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
         resolvedAccounts.{{ input.name | camelCase }} = { ...resolvedAccounts.{{ input.name | camelCase }}, ...{{ inputDefault }} };
       }
     {% elif input.kind === 'account' %}
-      if (!{{ accountsObj }}.{{ input.name | camelCase }}) {
+      if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
         resolvedAccounts.{{ input.name | camelCase }}.value = {{ inputDefault }};
         {% if inputDefaultIsWritable -%} 
           resolvedAccounts.{{ input.name | camelCase }}.isWritable = {{ inputDefaultIsWritable }};
         {% endif %} 
       }
     {% else %}
-      if (!{{ argsObj }}.{{ input.name | camelCase }}) {
+      if (!resolvedArgs.{{ input.name | camelCase }}) {
         resolvedArgs.{{ input.name | camelCase }} = {{ inputDefault }};
       }
     {% endif -%}

--- a/src/renderers/js/templates/instructionsPageResolvedInputs.njk
+++ b/src/renderers/js/templates/instructionsPageResolvedInputs.njk
@@ -1,16 +1,14 @@
-{% if resolvedInputs.length > 0 or hasResolvedAccounts or hasResolvedArgs %}
+{% if resolvedInputsWithDefaults.length > 0 %}
   // Default values.
   {% for input in resolvedInputsWithDefaults %}
-    {%- if input.render -%}
-      {% if input.kind === 'account' %}
-        if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
-          {{ input.render }}
-        }
-      {% else %}
-        if (!resolvedArgs.{{ input.name | camelCase }}) {
-          {{ input.render }}
-        }
-      {% endif %}
+    {%- if input.kind === 'account' -%}
+      if (!resolvedAccounts.{{ input.name | camelCase }}.value) {
+        {{ input.render }}
+      }
+    {% else %}
+      if (!resolvedArgs.{{ input.name | camelCase }}) {
+        {{ input.render }}
+      }
     {% endif %}
   {% endfor %}
 {% endif %}

--- a/src/renderers/js/templates/macros.njk
+++ b/src/renderers/js/templates/macros.njk
@@ -28,10 +28,7 @@ export type {{ looseName }} = {{ typeManifest.looseType if typeManifest.strictTy
 {# Export a serializer. #}
 {% macro exportSerializer(name, typeManifest) %}
 {% set looseName = name + 'Args' %}
-/** @deprecated Use `get{{ name }}Serializer()` without any argument instead. */
-export function get{{ name }}Serializer(_context: object): Serializer<{{ looseName }}, {{ name }}>;
-export function get{{ name }}Serializer(): Serializer<{{ looseName }}, {{ name }}>;
-export function get{{ name }}Serializer(_context: object = {}): Serializer<{{ looseName }}, {{ name }}> {
+export function get{{ name }}Serializer(): Serializer<{{ looseName }}, {{ name }}> {
   return {{ typeManifest.serializer }} as Serializer<{{ looseName }}, {{ name }}>;
 }
 {% endmacro %}

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -48,23 +48,16 @@ export function expectPda(
 }
 
 /**
- * Asserts that the given value is a Signer.
- * @internal
- */
-export function expectSigner(
-  value: PublicKey | Pda | Signer | null | undefined
-): Signer {
-  if (!value || !isSigner(value)) {
-    throw new Error('Expected a Signer.');
-  }
-  return value;
-}
-
-/**
  * Defines an instruction account to resolve.
  * @internal
  */
 export type ResolvedAccount<T = PublicKey | Pda | Signer | null> = { isWritable: boolean; value: T; }
+
+/**
+ * Defines a set of instruction account to resolve.
+ * @internal
+ */
+export type ResolvedAccounts = Record<string, ResolvedAccount>;
 
 /**
  * Defines a set of instruction account to resolve with their indices.

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -2,13 +2,63 @@
 {% import "macros.njk" as macros %}
 
 {% block main %}
-import { AccountMeta, isSigner, Pda, publicKey, PublicKey, Signer } from '@metaplex-foundation/umi';
+import { AccountMeta, isSigner, Pda, publicKey, PublicKey, Signer, isPda } from '@metaplex-foundation/umi';
 
 /**
  * Transforms the given object such that the given keys are optional.
  * @internal
  */
 export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/**
+ * Asserts that the given value is not null or undefined.
+ * @internal
+ */
+export function expectSome<T> (value: T | null | undefined): T {
+  if (value == null) {
+    throw new Error('Expected a value but received null or undefined.');
+  }
+  return value;
+}
+
+/**
+ * Asserts that the given value is a PublicKey.
+ * @internal
+ */
+export function expectPublicKey(
+  value: PublicKey | Pda | Signer | null | undefined
+): PublicKey {
+  if (!value) {
+    throw new Error('Expected a PublicKey.');
+  }
+  return publicKey(value, false);
+}
+
+/**
+ * Asserts that the given value is a PDA.
+ * @internal
+ */
+export function expectPda(
+  value: PublicKey | Pda | Signer | null | undefined
+): Pda {
+  if (!value || !Array.isArray(value) || !isPda(value)) {
+    throw new Error('Expected a PDA.');
+  }
+  return value;
+}
+
+/**
+ * Asserts that the given value is a Signer.
+ * @internal
+ */
+export function expectSigner(
+  value: PublicKey | Pda | Signer | null | undefined
+): Signer {
+  if (!value || !isSigner(value)) {
+    throw new Error('Expected a Signer.');
+  }
+  return value;
+}
 
 /**
  * Defines an instruction account to resolve.

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -71,7 +71,7 @@ export type ResolvedAccountsWithIndices = Record<string, ResolvedAccount & { ind
  */
 export function getAccountMetasAndSigners(
   accounts: ResolvedAccount[],
-  isOptionalStrategy: 'omitted' | 'programId',
+  optionalAccountStrategy: 'omitted' | 'programId',
   programId: PublicKey,
 ): [AccountMeta[], Signer[]] {
   const keys: AccountMeta[] = [];
@@ -79,7 +79,7 @@ export function getAccountMetasAndSigners(
 
   accounts.forEach(account => {
     if (!account.value) {
-      if (isOptionalStrategy === 'omitted') return;
+      if (optionalAccountStrategy === 'omitted') return;
       keys.push({ pubkey: programId, isSigner: false, isWritable: false });
       return;
     }

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -11,27 +11,19 @@ import { AccountMeta, isSigner, Pda, publicKey, PublicKey, Signer } from '@metap
 export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 /**
- * Defines an instruction account that is or will be resolved.
+ * Defines an instruction account to resolve.
  * @internal
  */
 export type ResolvedAccount = {
-  index: number;
   isWritable: boolean;
   value: PublicKey | Pda | Signer | undefined;
 }
 
-export type ResolvedAccounts = Record<string, ResolvedAccount>;
-
-export type ResolvedArgs<T extends object> = Record<string, ResolvedAccount>;
-
 /**
- * Helper function that dynamically updates the type of
- * an object as we add more properties to the object.
+ * Defines a set of instruction account to resolve with their indices.
  * @internal
  */
-export function addObjectProperty<T extends object, U extends string, V>(obj: T, key: U, value: V): asserts obj is T & { [K in U]: V } {
-  (obj as any)[key] = value;
-};
+export type ResolvedAccountsWithIndices = Record<string, ResolvedAccount & { index: number }>;
 
 /**
  * Add instruction accounts to the given list of keys and signers.
@@ -40,27 +32,25 @@ export function addObjectProperty<T extends object, U extends string, V>(obj: T,
 export function addAccountMetas(
   keys: AccountMeta[],
   signers: Signer[],
-  accounts: ResolvedAccounts,
+  accounts: ResolvedAccount[],
   isOptionalStrategy: 'omitted' | 'programId',
   programId: PublicKey,
 ): void {
-  accounts
-    .sort((a,b) => a.index - b.index)
-    .forEach(account => {
-      if (!account.value) {
-        if (isOptionalStrategy === 'omitted') return;
-        keys.push({ pubkey: programId, isSigner: false, isWritable: false });
-        return;
-      }
+  accounts.forEach(account => {
+    if (!account.value) {
+      if (isOptionalStrategy === 'omitted') return;
+      keys.push({ pubkey: programId, isSigner: false, isWritable: false });
+      return;
+    }
 
-      if (isSigner(account.value)) {
-        signers.push(account.value);
-      }
-      keys.push({
-        pubkey: publicKey(account.value, false),
-        isSigner: isSigner(account.value),
-        isWritable: account.isWritable,
-      });
+    if (isSigner(account.value)) {
+      signers.push(account.value);
+    }
+    keys.push({
+      pubkey: publicKey(account.value, false),
+      isSigner: isSigner(account.value),
+      isWritable: account.isWritable,
     });
+  });
 };
 {% endblock %}

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -41,7 +41,7 @@ export function addAccountMetas(
   keys: AccountMeta[],
   signers: Signer[],
   accounts: ResolvedAccounts,
-  isOptionalStrategy: 'omitted' | 'programId'
+  isOptionalStrategy: 'omitted' | 'programId',
   programId: PublicKey,
 ): void {
   accounts

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -11,10 +11,18 @@ import { AccountMeta, isSigner, Pda, publicKey, PublicKey, Signer } from '@metap
 export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 /**
- * Defines an instruction account that keeps track of whether it is writable or not.
+ * Defines an instruction account that is or will be resolved.
  * @internal
  */
-export type WithWritable<T extends PublicKey | Pda | Signer | undefined> = readonly [T, boolean];
+export type ResolvedAccount = {
+  index: number;
+  isWritable: boolean;
+  value: PublicKey | Pda | Signer | undefined;
+}
+
+export type ResolvedAccounts = Record<string, ResolvedAccount>;
+
+export type ResolvedArgs<T extends object> = Record<string, ResolvedAccount>;
 
 /**
  * Helper function that dynamically updates the type of
@@ -26,40 +34,33 @@ export function addObjectProperty<T extends object, U extends string, V>(obj: T,
 };
 
 /**
- * Adds an instruction account to the given list of keys and signers.
+ * Add instruction accounts to the given list of keys and signers.
  * @internal
  */
-export function addAccountMeta(
+export function addAccountMetas(
   keys: AccountMeta[],
   signers: Signer[],
-  account: WithWritable<PublicKey | Pda | Signer>,
-  isOptional: false
-): void;
-export function addAccountMeta(
-  keys: AccountMeta[],
-  signers: Signer[],
-  account: WithWritable<PublicKey | Pda | Signer | undefined>,
-  isOptional: true
-): void;
-export function addAccountMeta(
-  keys: AccountMeta[],
-  signers: Signer[],
-  account: WithWritable<PublicKey | Pda | Signer | undefined>,
-  isOptional: boolean
+  accounts: ResolvedAccounts,
+  isOptionalStrategy: 'omitted' | 'programId'
+  programId: PublicKey,
 ): void {
-  if (isOptional && !account[0]) {
-    return;
-  }
-  if (!account[0]) {
-    throw new Error('Expected instruction account to be defined');
-  }
-  if (isSigner(account[0])) {
-    signers.push(account[0]);
-  }
-  keys.push({
-    pubkey: publicKey(account[0], false),
-    isSigner: isSigner(account[0]),
-    isWritable: account[1],
-  });
+  accounts
+    .sort((a,b) => a.index - b.index)
+    .forEach(account => {
+      if (!account.value) {
+        if (isOptionalStrategy === 'omitted') return;
+        keys.push({ pubkey: programId, isSigner: false, isWritable: false });
+        return;
+      }
+
+      if (isSigner(account.value)) {
+        signers.push(account.value);
+      }
+      keys.push({
+        pubkey: publicKey(account.value, false),
+        isSigner: isSigner(account.value),
+        isWritable: account.isWritable,
+      });
+    });
 };
 {% endblock %}

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -66,16 +66,17 @@ export type ResolvedAccounts = Record<string, ResolvedAccount>;
 export type ResolvedAccountsWithIndices = Record<string, ResolvedAccount & { index: number }>;
 
 /**
- * Add instruction accounts to the given list of keys and signers.
+ * Get account metas and signers from resolved accounts.
  * @internal
  */
-export function addAccountMetas(
-  keys: AccountMeta[],
-  signers: Signer[],
+export function getAccountMetasAndSigners(
   accounts: ResolvedAccount[],
   isOptionalStrategy: 'omitted' | 'programId',
   programId: PublicKey,
-): void {
+): [AccountMeta[], Signer[]] {
+  const keys: AccountMeta[] = [];
+  const signers: Signer[] = [];
+
   accounts.forEach(account => {
     if (!account.value) {
       if (isOptionalStrategy === 'omitted') return;
@@ -92,5 +93,7 @@ export function addAccountMetas(
       isWritable: account.isWritable,
     });
   });
+
+  return [keys, signers];
 };
 {% endblock %}

--- a/src/renderers/js/templates/sharedPage.njk
+++ b/src/renderers/js/templates/sharedPage.njk
@@ -14,10 +14,7 @@ export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
  * Defines an instruction account to resolve.
  * @internal
  */
-export type ResolvedAccount = {
-  isWritable: boolean;
-  value: PublicKey | Pda | Signer | undefined;
-}
+export type ResolvedAccount<T = PublicKey | Pda | Signer | null> = { isWritable: boolean; value: T; }
 
 /**
  * Defines a set of instruction account to resolve with their indices.

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -35,7 +35,7 @@ impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
     let mut accounts = Vec::with_capacity({{ instruction.accounts.length }});
     {% for account in instruction.accounts %}
       {% if account.isSigner === 'either' %}
-        {% if account.isOptional and account.isOptionalStrategy === 'programId' %}
+        {% if account.isOptional and instruction.optionalAccountStrategy === 'programId' %}
           if let Some(({{ account.name | snakeCase }}, signer)) = self.{{ account.name | snakeCase }} {
             accounts.push(solana_program::instruction::AccountMeta::{{ 'new' if account.isWritable else 'new_readonly' }}(
               *{{ account.name | snakeCase }}.key,
@@ -61,7 +61,7 @@ impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
           ));
         {% endif %}
       {% else %}
-        {% if account.isOptional and account.isOptionalStrategy === 'programId' %}
+        {% if account.isOptional and instruction.optionalAccountStrategy === 'programId' %}
           if let Some({{ account.name | snakeCase }}) = self.{{ account.name | snakeCase }} {
             accounts.push(solana_program::instruction::AccountMeta::{{ 'new' if account.isWritable else 'new_readonly' }}(
               *{{ account.name | snakeCase }}.key,

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -33,7 +33,7 @@ impl {{ instruction.name | pascalCase }} {
     {% for account in instruction.accounts %}
       {% if account.isSigner === 'either' %}
         {% if account.isOptional %}
-          {% if account.isOptionalStrategy === 'programId' %}
+          {% if instruction.optionalAccountStrategy === 'programId' %}
             if let Some(({{ account.name | snakeCase }}, signer)) = self.{{ account.name | snakeCase }} {
               accounts.push(solana_program::instruction::AccountMeta::{{ 'new' if account.isWritable else 'new_readonly' }}(
                 {{ account.name | snakeCase }},
@@ -61,7 +61,7 @@ impl {{ instruction.name | pascalCase }} {
         {% endif %}
       {% else %}
         {% if account.isOptional %}
-          {% if account.isOptionalStrategy === 'programId' %}
+          {% if instruction.optionalAccountStrategy === 'programId' %}
             if let Some({{ account.name | snakeCase }}) = self.{{ account.name | snakeCase }} {
               accounts.push(solana_program::instruction::AccountMeta::{{ 'new' if account.isWritable else 'new_readonly' }}(
                 {{ account.name | snakeCase }},

--- a/test/packages/js/src/generated/accounts/candyMachine.ts
+++ b/test/packages/js/src/generated/accounts/candyMachine.ts
@@ -68,17 +68,10 @@ export type CandyMachineAccountDataArgs = {
   data: CandyMachineDataArgs;
 };
 
-/** @deprecated Use `getCandyMachineAccountDataSerializer()` without any argument instead. */
-export function getCandyMachineAccountDataSerializer(
-  _context: object
-): Serializer<CandyMachineAccountDataArgs, CandyMachineAccountData>;
 export function getCandyMachineAccountDataSerializer(): Serializer<
   CandyMachineAccountDataArgs,
   CandyMachineAccountData
->;
-export function getCandyMachineAccountDataSerializer(
-  _context: object = {}
-): Serializer<CandyMachineAccountDataArgs, CandyMachineAccountData> {
+> {
   return mapSerializer<
     CandyMachineAccountDataArgs,
     any,
@@ -103,20 +96,8 @@ export function getCandyMachineAccountDataSerializer(
   ) as Serializer<CandyMachineAccountDataArgs, CandyMachineAccountData>;
 }
 
-/** @deprecated Use `deserializeCandyMachine(rawAccount)` without any context instead. */
-export function deserializeCandyMachine(
-  context: object,
-  rawAccount: RpcAccount
-): CandyMachine;
-export function deserializeCandyMachine(rawAccount: RpcAccount): CandyMachine;
-export function deserializeCandyMachine(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
-): CandyMachine {
-  return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
-    getCandyMachineAccountDataSerializer()
-  );
+export function deserializeCandyMachine(rawAccount: RpcAccount): CandyMachine {
+  return deserializeAccount(rawAccount, getCandyMachineAccountDataSerializer());
 }
 
 export async function fetchCandyMachine(

--- a/test/packages/js/src/generated/accounts/collectionAuthorityRecord.ts
+++ b/test/packages/js/src/generated/accounts/collectionAuthorityRecord.ts
@@ -45,20 +45,7 @@ export type CollectionAuthorityRecordAccountDataArgs = {
   updateAuthority: OptionOrNullable<PublicKey>;
 };
 
-/** @deprecated Use `getCollectionAuthorityRecordAccountDataSerializer()` without any argument instead. */
-export function getCollectionAuthorityRecordAccountDataSerializer(
-  _context: object
-): Serializer<
-  CollectionAuthorityRecordAccountDataArgs,
-  CollectionAuthorityRecordAccountData
->;
 export function getCollectionAuthorityRecordAccountDataSerializer(): Serializer<
-  CollectionAuthorityRecordAccountDataArgs,
-  CollectionAuthorityRecordAccountData
->;
-export function getCollectionAuthorityRecordAccountDataSerializer(
-  _context: object = {}
-): Serializer<
   CollectionAuthorityRecordAccountDataArgs,
   CollectionAuthorityRecordAccountData
 > {
@@ -82,20 +69,11 @@ export function getCollectionAuthorityRecordAccountDataSerializer(
   >;
 }
 
-/** @deprecated Use `deserializeCollectionAuthorityRecord(rawAccount)` without any context instead. */
-export function deserializeCollectionAuthorityRecord(
-  context: object,
-  rawAccount: RpcAccount
-): CollectionAuthorityRecord;
 export function deserializeCollectionAuthorityRecord(
   rawAccount: RpcAccount
-): CollectionAuthorityRecord;
-export function deserializeCollectionAuthorityRecord(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): CollectionAuthorityRecord {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getCollectionAuthorityRecordAccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/delegateRecord.ts
+++ b/test/packages/js/src/generated/accounts/delegateRecord.ts
@@ -49,17 +49,10 @@ export type DelegateRecordAccountDataArgs = {
   bump: number;
 };
 
-/** @deprecated Use `getDelegateRecordAccountDataSerializer()` without any argument instead. */
-export function getDelegateRecordAccountDataSerializer(
-  _context: object
-): Serializer<DelegateRecordAccountDataArgs, DelegateRecordAccountData>;
 export function getDelegateRecordAccountDataSerializer(): Serializer<
   DelegateRecordAccountDataArgs,
   DelegateRecordAccountData
->;
-export function getDelegateRecordAccountDataSerializer(
-  _context: object = {}
-): Serializer<DelegateRecordAccountDataArgs, DelegateRecordAccountData> {
+> {
   return mapSerializer<
     DelegateRecordAccountDataArgs,
     any,
@@ -77,20 +70,11 @@ export function getDelegateRecordAccountDataSerializer(
   ) as Serializer<DelegateRecordAccountDataArgs, DelegateRecordAccountData>;
 }
 
-/** @deprecated Use `deserializeDelegateRecord(rawAccount)` without any context instead. */
-export function deserializeDelegateRecord(
-  context: object,
-  rawAccount: RpcAccount
-): DelegateRecord;
 export function deserializeDelegateRecord(
   rawAccount: RpcAccount
-): DelegateRecord;
-export function deserializeDelegateRecord(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): DelegateRecord {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getDelegateRecordAccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/edition.ts
+++ b/test/packages/js/src/generated/accounts/edition.ts
@@ -41,17 +41,10 @@ export type EditionAccountDataArgs = {
   edition: number | bigint;
 };
 
-/** @deprecated Use `getEditionAccountDataSerializer()` without any argument instead. */
-export function getEditionAccountDataSerializer(
-  _context: object
-): Serializer<EditionAccountDataArgs, EditionAccountData>;
 export function getEditionAccountDataSerializer(): Serializer<
   EditionAccountDataArgs,
   EditionAccountData
->;
-export function getEditionAccountDataSerializer(
-  _context: object = {}
-): Serializer<EditionAccountDataArgs, EditionAccountData> {
+> {
   return mapSerializer<EditionAccountDataArgs, any, EditionAccountData>(
     struct<EditionAccountData>(
       [
@@ -65,20 +58,8 @@ export function getEditionAccountDataSerializer(
   ) as Serializer<EditionAccountDataArgs, EditionAccountData>;
 }
 
-/** @deprecated Use `deserializeEdition(rawAccount)` without any context instead. */
-export function deserializeEdition(
-  context: object,
-  rawAccount: RpcAccount
-): Edition;
-export function deserializeEdition(rawAccount: RpcAccount): Edition;
-export function deserializeEdition(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
-): Edition {
-  return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
-    getEditionAccountDataSerializer()
-  );
+export function deserializeEdition(rawAccount: RpcAccount): Edition {
+  return deserializeAccount(rawAccount, getEditionAccountDataSerializer());
 }
 
 export async function fetchEdition(

--- a/test/packages/js/src/generated/accounts/editionMarker.ts
+++ b/test/packages/js/src/generated/accounts/editionMarker.ts
@@ -34,17 +34,10 @@ export type EditionMarkerAccountData = { key: TmKey; ledger: Array<number> };
 
 export type EditionMarkerAccountDataArgs = { ledger: Array<number> };
 
-/** @deprecated Use `getEditionMarkerAccountDataSerializer()` without any argument instead. */
-export function getEditionMarkerAccountDataSerializer(
-  _context: object
-): Serializer<EditionMarkerAccountDataArgs, EditionMarkerAccountData>;
 export function getEditionMarkerAccountDataSerializer(): Serializer<
   EditionMarkerAccountDataArgs,
   EditionMarkerAccountData
->;
-export function getEditionMarkerAccountDataSerializer(
-  _context: object = {}
-): Serializer<EditionMarkerAccountDataArgs, EditionMarkerAccountData> {
+> {
   return mapSerializer<
     EditionMarkerAccountDataArgs,
     any,
@@ -61,18 +54,11 @@ export function getEditionMarkerAccountDataSerializer(
   ) as Serializer<EditionMarkerAccountDataArgs, EditionMarkerAccountData>;
 }
 
-/** @deprecated Use `deserializeEditionMarker(rawAccount)` without any context instead. */
 export function deserializeEditionMarker(
-  context: object,
   rawAccount: RpcAccount
-): EditionMarker;
-export function deserializeEditionMarker(rawAccount: RpcAccount): EditionMarker;
-export function deserializeEditionMarker(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): EditionMarker {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getEditionMarkerAccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/frequencyAccount.ts
+++ b/test/packages/js/src/generated/accounts/frequencyAccount.ts
@@ -52,17 +52,10 @@ export type FrequencyAccountAccountDataArgs = {
   period: number | bigint;
 };
 
-/** @deprecated Use `getFrequencyAccountAccountDataSerializer()` without any argument instead. */
-export function getFrequencyAccountAccountDataSerializer(
-  _context: object
-): Serializer<FrequencyAccountAccountDataArgs, FrequencyAccountAccountData>;
 export function getFrequencyAccountAccountDataSerializer(): Serializer<
   FrequencyAccountAccountDataArgs,
   FrequencyAccountAccountData
->;
-export function getFrequencyAccountAccountDataSerializer(
-  _context: object = {}
-): Serializer<FrequencyAccountAccountDataArgs, FrequencyAccountAccountData> {
+> {
   return mapSerializer<
     FrequencyAccountAccountDataArgs,
     any,
@@ -80,20 +73,11 @@ export function getFrequencyAccountAccountDataSerializer(
   ) as Serializer<FrequencyAccountAccountDataArgs, FrequencyAccountAccountData>;
 }
 
-/** @deprecated Use `deserializeFrequencyAccount(rawAccount)` without any context instead. */
-export function deserializeFrequencyAccount(
-  context: object,
-  rawAccount: RpcAccount
-): FrequencyAccount;
 export function deserializeFrequencyAccount(
   rawAccount: RpcAccount
-): FrequencyAccount;
-export function deserializeFrequencyAccount(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): FrequencyAccount {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getFrequencyAccountAccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/masterEditionV1.ts
+++ b/test/packages/js/src/generated/accounts/masterEditionV1.ts
@@ -55,17 +55,10 @@ export type MasterEditionV1AccountDataArgs = {
   oneTimePrintingAuthorizationMint: PublicKey;
 };
 
-/** @deprecated Use `getMasterEditionV1AccountDataSerializer()` without any argument instead. */
-export function getMasterEditionV1AccountDataSerializer(
-  _context: object
-): Serializer<MasterEditionV1AccountDataArgs, MasterEditionV1AccountData>;
 export function getMasterEditionV1AccountDataSerializer(): Serializer<
   MasterEditionV1AccountDataArgs,
   MasterEditionV1AccountData
->;
-export function getMasterEditionV1AccountDataSerializer(
-  _context: object = {}
-): Serializer<MasterEditionV1AccountDataArgs, MasterEditionV1AccountData> {
+> {
   return mapSerializer<
     MasterEditionV1AccountDataArgs,
     any,
@@ -85,20 +78,11 @@ export function getMasterEditionV1AccountDataSerializer(
   ) as Serializer<MasterEditionV1AccountDataArgs, MasterEditionV1AccountData>;
 }
 
-/** @deprecated Use `deserializeMasterEditionV1(rawAccount)` without any context instead. */
-export function deserializeMasterEditionV1(
-  context: object,
-  rawAccount: RpcAccount
-): MasterEditionV1;
 export function deserializeMasterEditionV1(
   rawAccount: RpcAccount
-): MasterEditionV1;
-export function deserializeMasterEditionV1(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): MasterEditionV1 {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getMasterEditionV1AccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/masterEditionV2.ts
+++ b/test/packages/js/src/generated/accounts/masterEditionV2.ts
@@ -45,17 +45,10 @@ export type MasterEditionV2AccountDataArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-/** @deprecated Use `getMasterEditionV2AccountDataSerializer()` without any argument instead. */
-export function getMasterEditionV2AccountDataSerializer(
-  _context: object
-): Serializer<MasterEditionV2AccountDataArgs, MasterEditionV2AccountData>;
 export function getMasterEditionV2AccountDataSerializer(): Serializer<
   MasterEditionV2AccountDataArgs,
   MasterEditionV2AccountData
->;
-export function getMasterEditionV2AccountDataSerializer(
-  _context: object = {}
-): Serializer<MasterEditionV2AccountDataArgs, MasterEditionV2AccountData> {
+> {
   return mapSerializer<
     MasterEditionV2AccountDataArgs,
     any,
@@ -73,20 +66,11 @@ export function getMasterEditionV2AccountDataSerializer(
   ) as Serializer<MasterEditionV2AccountDataArgs, MasterEditionV2AccountData>;
 }
 
-/** @deprecated Use `deserializeMasterEditionV2(rawAccount)` without any context instead. */
-export function deserializeMasterEditionV2(
-  context: object,
-  rawAccount: RpcAccount
-): MasterEditionV2;
 export function deserializeMasterEditionV2(
   rawAccount: RpcAccount
-): MasterEditionV2;
-export function deserializeMasterEditionV2(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): MasterEditionV2 {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getMasterEditionV2AccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/metadata.ts
+++ b/test/packages/js/src/generated/accounts/metadata.ts
@@ -101,17 +101,10 @@ export type MetadataAccountDataArgs = {
   delegateState: OptionOrNullable<DelegateStateArgs>;
 };
 
-/** @deprecated Use `getMetadataAccountDataSerializer()` without any argument instead. */
-export function getMetadataAccountDataSerializer(
-  _context: object
-): Serializer<MetadataAccountDataArgs, MetadataAccountData>;
 export function getMetadataAccountDataSerializer(): Serializer<
   MetadataAccountDataArgs,
   MetadataAccountData
->;
-export function getMetadataAccountDataSerializer(
-  _context: object = {}
-): Serializer<MetadataAccountDataArgs, MetadataAccountData> {
+> {
   return mapSerializer<MetadataAccountDataArgs, any, MetadataAccountData>(
     struct<MetadataAccountData>(
       [
@@ -139,20 +132,8 @@ export function getMetadataAccountDataSerializer(
   ) as Serializer<MetadataAccountDataArgs, MetadataAccountData>;
 }
 
-/** @deprecated Use `deserializeMetadata(rawAccount)` without any context instead. */
-export function deserializeMetadata(
-  context: object,
-  rawAccount: RpcAccount
-): Metadata;
-export function deserializeMetadata(rawAccount: RpcAccount): Metadata;
-export function deserializeMetadata(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
-): Metadata {
-  return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
-    getMetadataAccountDataSerializer()
-  );
+export function deserializeMetadata(rawAccount: RpcAccount): Metadata {
+  return deserializeAccount(rawAccount, getMetadataAccountDataSerializer());
 }
 
 export async function fetchMetadata(

--- a/test/packages/js/src/generated/accounts/reservationListV1.ts
+++ b/test/packages/js/src/generated/accounts/reservationListV1.ts
@@ -40,20 +40,11 @@ import {
 
 export type ReservationListV1 = Account<ReservationListV1AccountData>;
 
-/** @deprecated Use `deserializeReservationListV1(rawAccount)` without any context instead. */
-export function deserializeReservationListV1(
-  context: object,
-  rawAccount: RpcAccount
-): ReservationListV1;
 export function deserializeReservationListV1(
   rawAccount: RpcAccount
-): ReservationListV1;
-export function deserializeReservationListV1(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): ReservationListV1 {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getReservationListV1AccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/reservationListV2.ts
+++ b/test/packages/js/src/generated/accounts/reservationListV2.ts
@@ -58,17 +58,10 @@ export type ReservationListV2AccountDataArgs = {
   currentReservationSpots: number | bigint;
 };
 
-/** @deprecated Use `getReservationListV2AccountDataSerializer()` without any argument instead. */
-export function getReservationListV2AccountDataSerializer(
-  _context: object
-): Serializer<ReservationListV2AccountDataArgs, ReservationListV2AccountData>;
 export function getReservationListV2AccountDataSerializer(): Serializer<
   ReservationListV2AccountDataArgs,
   ReservationListV2AccountData
->;
-export function getReservationListV2AccountDataSerializer(
-  _context: object = {}
-): Serializer<ReservationListV2AccountDataArgs, ReservationListV2AccountData> {
+> {
   return mapSerializer<
     ReservationListV2AccountDataArgs,
     any,
@@ -92,20 +85,11 @@ export function getReservationListV2AccountDataSerializer(
   >;
 }
 
-/** @deprecated Use `deserializeReservationListV2(rawAccount)` without any context instead. */
-export function deserializeReservationListV2(
-  context: object,
-  rawAccount: RpcAccount
-): ReservationListV2;
 export function deserializeReservationListV2(
   rawAccount: RpcAccount
-): ReservationListV2;
-export function deserializeReservationListV2(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): ReservationListV2 {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getReservationListV2AccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/tokenOwnedEscrow.ts
+++ b/test/packages/js/src/generated/accounts/tokenOwnedEscrow.ts
@@ -50,17 +50,10 @@ export type TokenOwnedEscrowAccountDataArgs = {
   bump: number;
 };
 
-/** @deprecated Use `getTokenOwnedEscrowAccountDataSerializer()` without any argument instead. */
-export function getTokenOwnedEscrowAccountDataSerializer(
-  _context: object
-): Serializer<TokenOwnedEscrowAccountDataArgs, TokenOwnedEscrowAccountData>;
 export function getTokenOwnedEscrowAccountDataSerializer(): Serializer<
   TokenOwnedEscrowAccountDataArgs,
   TokenOwnedEscrowAccountData
->;
-export function getTokenOwnedEscrowAccountDataSerializer(
-  _context: object = {}
-): Serializer<TokenOwnedEscrowAccountDataArgs, TokenOwnedEscrowAccountData> {
+> {
   return mapSerializer<
     TokenOwnedEscrowAccountDataArgs,
     any,
@@ -79,20 +72,11 @@ export function getTokenOwnedEscrowAccountDataSerializer(
   ) as Serializer<TokenOwnedEscrowAccountDataArgs, TokenOwnedEscrowAccountData>;
 }
 
-/** @deprecated Use `deserializeTokenOwnedEscrow(rawAccount)` without any context instead. */
-export function deserializeTokenOwnedEscrow(
-  context: object,
-  rawAccount: RpcAccount
-): TokenOwnedEscrow;
 export function deserializeTokenOwnedEscrow(
   rawAccount: RpcAccount
-): TokenOwnedEscrow;
-export function deserializeTokenOwnedEscrow(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): TokenOwnedEscrow {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getTokenOwnedEscrowAccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/accounts/useAuthorityRecord.ts
+++ b/test/packages/js/src/generated/accounts/useAuthorityRecord.ts
@@ -41,17 +41,7 @@ export type UseAuthorityRecordAccountDataArgs = {
   bump: number;
 };
 
-/** @deprecated Use `getUseAuthorityRecordAccountDataSerializer()` without any argument instead. */
-export function getUseAuthorityRecordAccountDataSerializer(
-  _context: object
-): Serializer<UseAuthorityRecordAccountDataArgs, UseAuthorityRecordAccountData>;
 export function getUseAuthorityRecordAccountDataSerializer(): Serializer<
-  UseAuthorityRecordAccountDataArgs,
-  UseAuthorityRecordAccountData
->;
-export function getUseAuthorityRecordAccountDataSerializer(
-  _context: object = {}
-): Serializer<
   UseAuthorityRecordAccountDataArgs,
   UseAuthorityRecordAccountData
 > {
@@ -75,20 +65,11 @@ export function getUseAuthorityRecordAccountDataSerializer(
   >;
 }
 
-/** @deprecated Use `deserializeUseAuthorityRecord(rawAccount)` without any context instead. */
-export function deserializeUseAuthorityRecord(
-  context: object,
-  rawAccount: RpcAccount
-): UseAuthorityRecord;
 export function deserializeUseAuthorityRecord(
   rawAccount: RpcAccount
-): UseAuthorityRecord;
-export function deserializeUseAuthorityRecord(
-  context: RpcAccount | object,
-  rawAccount?: RpcAccount
 ): UseAuthorityRecord {
   return deserializeAccount(
-    rawAccount ?? (context as RpcAccount),
+    rawAccount,
     getUseAuthorityRecordAccountDataSerializer()
   );
 }

--- a/test/packages/js/src/generated/instructions/approveCollectionAuthority.ts
+++ b/test/packages/js/src/generated/instructions/approveCollectionAuthority.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type ApproveCollectionAuthorityInstructionAccounts = {
@@ -50,20 +54,7 @@ export type ApproveCollectionAuthorityInstructionData = {
 
 export type ApproveCollectionAuthorityInstructionDataArgs = {};
 
-/** @deprecated Use `getApproveCollectionAuthorityInstructionDataSerializer()` without any argument instead. */
-export function getApproveCollectionAuthorityInstructionDataSerializer(
-  _context: object
-): Serializer<
-  ApproveCollectionAuthorityInstructionDataArgs,
-  ApproveCollectionAuthorityInstructionData
->;
 export function getApproveCollectionAuthorityInstructionDataSerializer(): Serializer<
-  ApproveCollectionAuthorityInstructionDataArgs,
-  ApproveCollectionAuthorityInstructionData
->;
-export function getApproveCollectionAuthorityInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   ApproveCollectionAuthorityInstructionDataArgs,
   ApproveCollectionAuthorityInstructionData
 > {
@@ -88,62 +79,63 @@ export function approveCollectionAuthority(
   context: Pick<Context, 'programs' | 'payer'>,
   input: ApproveCollectionAuthorityInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    collectionAuthorityRecord: [input.collectionAuthorityRecord, true] as const,
-    newCollectionAuthority: [input.newCollectionAuthority, false] as const,
-    updateAuthority: [input.updateAuthority, true] as const,
-    metadata: [input.metadata, false] as const,
-    mint: [input.mint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    collectionAuthorityRecord: {
+      index: 0,
+      isWritable: true,
+      value: input.collectionAuthorityRecord ?? null,
+    },
+    newCollectionAuthority: {
+      index: 1,
+      isWritable: false,
+      value: input.newCollectionAuthority ?? null,
+    },
+    updateAuthority: {
+      index: 2,
+      isWritable: true,
+      value: input.updateAuthority ?? null,
+    },
+    payer: { index: 3, isWritable: true, value: input.payer ?? null },
+    metadata: { index: 4, isWritable: false, value: input.metadata ?? null },
+    mint: { index: 5, isWritable: false, value: input.mint ?? null },
+    systemProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 7, isWritable: false, value: input.rent ?? null },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent ? ([input.rent, false] as const) : ([programId, false] as const)
-  );
 
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.newCollectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
 
   // Data.
   const data =

--- a/test/packages/js/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/test/packages/js/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   SetCollectionSizeArgs,
   SetCollectionSizeArgsArgs,
@@ -52,20 +56,7 @@ export type BubblegumSetCollectionSizeInstructionDataArgs = {
   setCollectionSizeArgs: SetCollectionSizeArgsArgs;
 };
 
-/** @deprecated Use `getBubblegumSetCollectionSizeInstructionDataSerializer()` without any argument instead. */
-export function getBubblegumSetCollectionSizeInstructionDataSerializer(
-  _context: object
-): Serializer<
-  BubblegumSetCollectionSizeInstructionDataArgs,
-  BubblegumSetCollectionSizeInstructionData
->;
 export function getBubblegumSetCollectionSizeInstructionDataSerializer(): Serializer<
-  BubblegumSetCollectionSizeInstructionDataArgs,
-  BubblegumSetCollectionSizeInstructionData
->;
-export function getBubblegumSetCollectionSizeInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   BubblegumSetCollectionSizeInstructionDataArgs,
   BubblegumSetCollectionSizeInstructionData
 > {
@@ -98,47 +89,62 @@ export function bubblegumSetCollectionSize(
   input: BubblegumSetCollectionSizeInstructionAccounts &
     BubblegumSetCollectionSizeInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    collectionMetadata: [input.collectionMetadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, true] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    bubblegumSigner: [input.bubblegumSigner, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    collectionMetadata: {
+      index: 0,
+      isWritable: true,
+      value: input.collectionMetadata ?? null,
+    },
+    collectionAuthority: {
+      index: 1,
+      isWritable: true,
+      value: input.collectionAuthority ?? null,
+    },
+    collectionMint: {
+      index: 2,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    bubblegumSigner: {
+      index: 3,
+      isWritable: false,
+      value: input.bubblegumSigner ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 4,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionAuthorityRecord',
-    input.collectionAuthorityRecord
-      ? ([input.collectionAuthorityRecord, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.bubblegumSigner, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Arguments.
+  const resolvedArgs: BubblegumSetCollectionSizeInstructionArgs = { ...input };
+
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.
   const data =
     getBubblegumSetCollectionSizeInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as BubblegumSetCollectionSizeInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/test/packages/js/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -127,8 +127,6 @@ export function bubblegumSetCollectionSize(
   // Arguments.
   const resolvedArgs: BubblegumSetCollectionSizeInstructionArgs = { ...input };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/burn.ts
+++ b/test/packages/js/src/generated/instructions/burn.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { BurnArgs, BurnArgsArgs, getBurnArgsSerializer } from '../types';
 
 // Accounts.
@@ -51,17 +55,10 @@ export type BurnInstructionData = { discriminator: number; burnArgs: BurnArgs };
 
 export type BurnInstructionDataArgs = { burnArgs: BurnArgsArgs };
 
-/** @deprecated Use `getBurnInstructionDataSerializer()` without any argument instead. */
-export function getBurnInstructionDataSerializer(
-  _context: object
-): Serializer<BurnInstructionDataArgs, BurnInstructionData>;
 export function getBurnInstructionDataSerializer(): Serializer<
   BurnInstructionDataArgs,
   BurnInstructionData
->;
-export function getBurnInstructionDataSerializer(
-  _context: object = {}
-): Serializer<BurnInstructionDataArgs, BurnInstructionData> {
+> {
   return mapSerializer<BurnInstructionDataArgs, any, BurnInstructionData>(
     struct<BurnInstructionData>(
       [
@@ -82,77 +79,77 @@ export function burn(
   context: Pick<Context, 'programs'>,
   input: BurnInstructionAccounts & BurnInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    owner: [input.owner, true] as const,
-    mint: [input.mint, true] as const,
-    tokenAccount: [input.tokenAccount, true] as const,
-    masterEditionAccount: [input.masterEditionAccount, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    owner: { index: 1, isWritable: true, value: input.owner ?? null },
+    mint: { index: 2, isWritable: true, value: input.mint ?? null },
+    tokenAccount: {
+      index: 3,
+      isWritable: true,
+      value: input.tokenAccount ?? null,
+    },
+    masterEditionAccount: {
+      index: 4,
+      isWritable: true,
+      value: input.masterEditionAccount ?? null,
+    },
+    splTokenProgram: {
+      index: 5,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
+    collectionMetadata: {
+      index: 6,
+      isWritable: true,
+      value: input.collectionMetadata ?? null,
+    },
+    authorizationRules: {
+      index: 7,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
+    authorizationRulesProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.authorizationRulesProgram ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionMetadata',
-    input.collectionMetadata
-      ? ([input.collectionMetadata, true] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram
-      ? ([input.authorizationRulesProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.owner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEditionAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.authorizationRulesProgram,
-    false
+  // Arguments.
+  const resolvedArgs: BurnInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.splTokenProgram.value) {
+    resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.splTokenProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.
-  const data = getBurnInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getBurnInstructionDataSerializer().serialize(
+    resolvedArgs as BurnInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/burnEditionNft.ts
+++ b/test/packages/js/src/generated/instructions/burnEditionNft.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type BurnEditionNftInstructionAccounts = {
@@ -52,17 +56,7 @@ export type BurnEditionNftInstructionData = { discriminator: number };
 
 export type BurnEditionNftInstructionDataArgs = {};
 
-/** @deprecated Use `getBurnEditionNftInstructionDataSerializer()` without any argument instead. */
-export function getBurnEditionNftInstructionDataSerializer(
-  _context: object
-): Serializer<BurnEditionNftInstructionDataArgs, BurnEditionNftInstructionData>;
 export function getBurnEditionNftInstructionDataSerializer(): Serializer<
-  BurnEditionNftInstructionDataArgs,
-  BurnEditionNftInstructionData
->;
-export function getBurnEditionNftInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   BurnEditionNftInstructionDataArgs,
   BurnEditionNftInstructionData
 > {
@@ -86,64 +80,78 @@ export function burnEditionNft(
   context: Pick<Context, 'programs'>,
   input: BurnEditionNftInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    owner: [input.owner, true] as const,
-    printEditionMint: [input.printEditionMint, true] as const,
-    masterEditionMint: [input.masterEditionMint, false] as const,
-    printEditionTokenAccount: [input.printEditionTokenAccount, true] as const,
-    masterEditionTokenAccount: [
-      input.masterEditionTokenAccount,
-      false,
-    ] as const,
-    masterEditionAccount: [input.masterEditionAccount, true] as const,
-    printEditionAccount: [input.printEditionAccount, true] as const,
-    editionMarkerAccount: [input.editionMarkerAccount, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    owner: { index: 1, isWritable: true, value: input.owner ?? null },
+    printEditionMint: {
+      index: 2,
+      isWritable: true,
+      value: input.printEditionMint ?? null,
+    },
+    masterEditionMint: {
+      index: 3,
+      isWritable: false,
+      value: input.masterEditionMint ?? null,
+    },
+    printEditionTokenAccount: {
+      index: 4,
+      isWritable: true,
+      value: input.printEditionTokenAccount ?? null,
+    },
+    masterEditionTokenAccount: {
+      index: 5,
+      isWritable: false,
+      value: input.masterEditionTokenAccount ?? null,
+    },
+    masterEditionAccount: {
+      index: 6,
+      isWritable: true,
+      value: input.masterEditionAccount ?? null,
+    },
+    printEditionAccount: {
+      index: 7,
+      isWritable: true,
+      value: input.printEditionAccount ?? null,
+    },
+    editionMarkerAccount: {
+      index: 8,
+      isWritable: true,
+      value: input.editionMarkerAccount ?? null,
+    },
+    splTokenProgram: {
+      index: 9,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.owner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printEditionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEditionMint, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.printEditionTokenAccount,
-    false
+  // Default values.
+  if (!resolvedAccounts.splTokenProgram.value) {
+    resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.splTokenProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.masterEditionTokenAccount,
-    false
-  );
-  addAccountMeta(keys, signers, resolvedAccounts.masterEditionAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printEditionAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionMarkerAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
 
   // Data.
   const data = getBurnEditionNftInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/burnNft.ts
+++ b/test/packages/js/src/generated/instructions/burnNft.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type BurnNftInstructionAccounts = {
@@ -46,17 +50,10 @@ export type BurnNftInstructionData = { discriminator: number };
 
 export type BurnNftInstructionDataArgs = {};
 
-/** @deprecated Use `getBurnNftInstructionDataSerializer()` without any argument instead. */
-export function getBurnNftInstructionDataSerializer(
-  _context: object
-): Serializer<BurnNftInstructionDataArgs, BurnNftInstructionData>;
 export function getBurnNftInstructionDataSerializer(): Serializer<
   BurnNftInstructionDataArgs,
   BurnNftInstructionData
->;
-export function getBurnNftInstructionDataSerializer(
-  _context: object = {}
-): Serializer<BurnNftInstructionDataArgs, BurnNftInstructionData> {
+> {
   return mapSerializer<BurnNftInstructionDataArgs, any, BurnNftInstructionData>(
     struct<BurnNftInstructionData>([['discriminator', u8()]], {
       description: 'BurnNftInstructionData',
@@ -70,51 +67,59 @@ export function burnNft(
   context: Pick<Context, 'programs'>,
   input: BurnNftInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    owner: [input.owner, true] as const,
-    mint: [input.mint, true] as const,
-    tokenAccount: [input.tokenAccount, true] as const,
-    masterEditionAccount: [input.masterEditionAccount, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    owner: { index: 1, isWritable: true, value: input.owner ?? null },
+    mint: { index: 2, isWritable: true, value: input.mint ?? null },
+    tokenAccount: {
+      index: 3,
+      isWritable: true,
+      value: input.tokenAccount ?? null,
+    },
+    masterEditionAccount: {
+      index: 4,
+      isWritable: true,
+      value: input.masterEditionAccount ?? null,
+    },
+    splTokenProgram: {
+      index: 5,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
+    collectionMetadata: {
+      index: 6,
+      isWritable: true,
+      value: input.collectionMetadata ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionMetadata',
-    input.collectionMetadata
-      ? ([input.collectionMetadata, true] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.owner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEditionAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
+  // Default values.
+  if (!resolvedAccounts.splTokenProgram.value) {
+    resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.splTokenProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getBurnNftInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/closeEscrowAccount.ts
+++ b/test/packages/js/src/generated/instructions/closeEscrowAccount.ts
@@ -122,7 +122,6 @@ export function closeEscrowAccount(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/test/packages/js/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -94,8 +94,6 @@ export function convertMasterEditionV1ToV2(
     },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/test/packages/js/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type ConvertMasterEditionV1ToV2InstructionAccounts = {
@@ -40,20 +44,7 @@ export type ConvertMasterEditionV1ToV2InstructionData = {
 
 export type ConvertMasterEditionV1ToV2InstructionDataArgs = {};
 
-/** @deprecated Use `getConvertMasterEditionV1ToV2InstructionDataSerializer()` without any argument instead. */
-export function getConvertMasterEditionV1ToV2InstructionDataSerializer(
-  _context: object
-): Serializer<
-  ConvertMasterEditionV1ToV2InstructionDataArgs,
-  ConvertMasterEditionV1ToV2InstructionData
->;
 export function getConvertMasterEditionV1ToV2InstructionDataSerializer(): Serializer<
-  ConvertMasterEditionV1ToV2InstructionDataArgs,
-  ConvertMasterEditionV1ToV2InstructionData
->;
-export function getConvertMasterEditionV1ToV2InstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   ConvertMasterEditionV1ToV2InstructionDataArgs,
   ConvertMasterEditionV1ToV2InstructionData
 > {
@@ -78,25 +69,44 @@ export function convertMasterEditionV1ToV2(
   context: Pick<Context, 'programs'>,
   input: ConvertMasterEditionV1ToV2InstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    masterEdition: [input.masterEdition, true] as const,
-    oneTimeAuth: [input.oneTimeAuth, true] as const,
-    printingMint: [input.printingMint, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    masterEdition: {
+      index: 0,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    oneTimeAuth: {
+      index: 1,
+      isWritable: true,
+      value: input.oneTimeAuth ?? null,
+    },
+    printingMint: {
+      index: 2,
+      isWritable: true,
+      value: input.printingMint ?? null,
+    },
   };
 
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.oneTimeAuth, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printingMint, false);
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data =

--- a/test/packages/js/src/generated/instructions/createEscrowAccount.ts
+++ b/test/packages/js/src/generated/instructions/createEscrowAccount.ts
@@ -125,7 +125,6 @@ export function createEscrowAccount(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/createEscrowAccount.ts
+++ b/test/packages/js/src/generated/instructions/createEscrowAccount.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type CreateEscrowAccountInstructionAccounts = {
@@ -51,20 +55,7 @@ export type CreateEscrowAccountInstructionData = { discriminator: number };
 
 export type CreateEscrowAccountInstructionDataArgs = {};
 
-/** @deprecated Use `getCreateEscrowAccountInstructionDataSerializer()` without any argument instead. */
-export function getCreateEscrowAccountInstructionDataSerializer(
-  _context: object
-): Serializer<
-  CreateEscrowAccountInstructionDataArgs,
-  CreateEscrowAccountInstructionData
->;
 export function getCreateEscrowAccountInstructionDataSerializer(): Serializer<
-  CreateEscrowAccountInstructionDataArgs,
-  CreateEscrowAccountInstructionData
->;
-export function getCreateEscrowAccountInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   CreateEscrowAccountInstructionDataArgs,
   CreateEscrowAccountInstructionData
 > {
@@ -88,70 +79,66 @@ export function createEscrowAccount(
   context: Pick<Context, 'programs' | 'payer'>,
   input: CreateEscrowAccountInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    escrow: [input.escrow, true] as const,
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, false] as const,
-    tokenAccount: [input.tokenAccount, false] as const,
-    edition: [input.edition, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    escrow: { index: 0, isWritable: true, value: input.escrow ?? null },
+    metadata: { index: 1, isWritable: true, value: input.metadata ?? null },
+    mint: { index: 2, isWritable: false, value: input.mint ?? null },
+    tokenAccount: {
+      index: 3,
+      isWritable: false,
+      value: input.tokenAccount ?? null,
+    },
+    edition: { index: 4, isWritable: false, value: input.edition ?? null },
+    payer: { index: 5, isWritable: true, value: input.payer ?? null },
+    systemProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 7,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    authority: { index: 8, isWritable: false, value: input.authority ?? null },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.escrow, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.edition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getCreateEscrowAccountInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/createMasterEdition.ts
+++ b/test/packages/js/src/generated/instructions/createMasterEdition.ts
@@ -158,7 +158,6 @@ export function createMasterEdition(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/createMasterEdition.ts
+++ b/test/packages/js/src/generated/instructions/createMasterEdition.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   CreateMasterEditionArgs,
   CreateMasterEditionArgsArgs,
@@ -61,20 +65,7 @@ export type CreateMasterEditionInstructionDataArgs = {
   createMasterEditionArgs: CreateMasterEditionArgsArgs;
 };
 
-/** @deprecated Use `getCreateMasterEditionInstructionDataSerializer()` without any argument instead. */
-export function getCreateMasterEditionInstructionDataSerializer(
-  _context: object
-): Serializer<
-  CreateMasterEditionInstructionDataArgs,
-  CreateMasterEditionInstructionData
->;
 export function getCreateMasterEditionInstructionDataSerializer(): Serializer<
-  CreateMasterEditionInstructionDataArgs,
-  CreateMasterEditionInstructionData
->;
-export function getCreateMasterEditionInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   CreateMasterEditionInstructionDataArgs,
   CreateMasterEditionInstructionData
 > {
@@ -107,82 +98,85 @@ export function createMasterEdition(
   input: CreateMasterEditionInstructionAccounts &
     CreateMasterEditionInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    edition: [input.edition, true] as const,
-    mint: [input.mint, true] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    metadata: [input.metadata, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    edition: { index: 0, isWritable: true, value: input.edition ?? null },
+    mint: { index: 1, isWritable: true, value: input.mint ?? null },
+    updateAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    mintAuthority: {
+      index: 3,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 4, isWritable: true, value: input.payer ?? null },
+    metadata: { index: 5, isWritable: false, value: input.metadata ?? null },
+    tokenProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 7,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 8, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent
-      ? ([input.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.edition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
+  // Arguments.
+  const resolvedArgs: CreateMasterEditionInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getCreateMasterEditionInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getCreateMasterEditionInstructionDataSerializer().serialize(
+    resolvedArgs as CreateMasterEditionInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/createMasterEditionV3.ts
+++ b/test/packages/js/src/generated/instructions/createMasterEditionV3.ts
@@ -23,7 +23,11 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import { getMasterEditionV2Size } from '../accounts';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   CreateMasterEditionArgs,
   CreateMasterEditionArgsArgs,
@@ -62,20 +66,7 @@ export type CreateMasterEditionV3InstructionDataArgs = {
   createMasterEditionArgs: CreateMasterEditionArgsArgs;
 };
 
-/** @deprecated Use `getCreateMasterEditionV3InstructionDataSerializer()` without any argument instead. */
-export function getCreateMasterEditionV3InstructionDataSerializer(
-  _context: object
-): Serializer<
-  CreateMasterEditionV3InstructionDataArgs,
-  CreateMasterEditionV3InstructionData
->;
 export function getCreateMasterEditionV3InstructionDataSerializer(): Serializer<
-  CreateMasterEditionV3InstructionDataArgs,
-  CreateMasterEditionV3InstructionData
->;
-export function getCreateMasterEditionV3InstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   CreateMasterEditionV3InstructionDataArgs,
   CreateMasterEditionV3InstructionData
 > {
@@ -108,77 +99,79 @@ export function createMasterEditionV3(
   input: CreateMasterEditionV3InstructionAccounts &
     CreateMasterEditionV3InstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    edition: [input.edition, true] as const,
-    mint: [input.mint, true] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    metadata: [input.metadata, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    edition: { index: 0, isWritable: true, value: input.edition ?? null },
+    mint: { index: 1, isWritable: true, value: input.mint ?? null },
+    updateAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    mintAuthority: {
+      index: 3,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 4, isWritable: true, value: input.payer ?? null },
+    metadata: { index: 5, isWritable: true, value: input.metadata ?? null },
+    tokenProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 7,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 8, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent ? ([input.rent, false] as const) : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.edition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
+  // Arguments.
+  const resolvedArgs: CreateMasterEditionV3InstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getCreateMasterEditionV3InstructionDataSerializer().serialize(resolvedArgs);
+  const data = getCreateMasterEditionV3InstructionDataSerializer().serialize(
+    resolvedArgs as CreateMasterEditionV3InstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = getMasterEditionV2Size() + ACCOUNT_HEADER_SIZE;

--- a/test/packages/js/src/generated/instructions/createMetadataAccount.ts
+++ b/test/packages/js/src/generated/instructions/createMetadataAccount.ts
@@ -183,7 +183,6 @@ export function createMetadataAccount(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
   if (!resolvedArgs.metadataBump) {
     resolvedArgs.metadataBump = expectPda(resolvedAccounts.metadata.value)[1];

--- a/test/packages/js/src/generated/instructions/createMetadataAccountV2.ts
+++ b/test/packages/js/src/generated/instructions/createMetadataAccountV2.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { DataV2, DataV2Args, getDataV2Serializer } from '../types';
 
 // Accounts.
@@ -55,20 +59,7 @@ export type CreateMetadataAccountV2InstructionDataArgs = {
   isMutable: boolean;
 };
 
-/** @deprecated Use `getCreateMetadataAccountV2InstructionDataSerializer()` without any argument instead. */
-export function getCreateMetadataAccountV2InstructionDataSerializer(
-  _context: object
-): Serializer<
-  CreateMetadataAccountV2InstructionDataArgs,
-  CreateMetadataAccountV2InstructionData
->;
 export function getCreateMetadataAccountV2InstructionDataSerializer(): Serializer<
-  CreateMetadataAccountV2InstructionDataArgs,
-  CreateMetadataAccountV2InstructionData
->;
-export function getCreateMetadataAccountV2InstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   CreateMetadataAccountV2InstructionDataArgs,
   CreateMetadataAccountV2InstructionData
 > {
@@ -102,63 +93,66 @@ export function createMetadataAccountV2(
   input: CreateMetadataAccountV2InstructionAccounts &
     CreateMetadataAccountV2InstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, false] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    mint: { index: 1, isWritable: false, value: input.mint ?? null },
+    mintAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 3, isWritable: true, value: input.payer ?? null },
+    updateAuthority: {
+      index: 4,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    systemProgram: {
+      index: 5,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 6, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent ? ([input.rent, false] as const) : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
+  // Arguments.
+  const resolvedArgs: CreateMetadataAccountV2InstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getCreateMetadataAccountV2InstructionDataSerializer().serialize(
-      resolvedArgs
-    );
+  const data = getCreateMetadataAccountV2InstructionDataSerializer().serialize(
+    resolvedArgs as CreateMetadataAccountV2InstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/createMetadataAccountV3.ts
+++ b/test/packages/js/src/generated/instructions/createMetadataAccountV3.ts
@@ -15,7 +15,6 @@ import {
   PublicKey,
   Signer,
   TransactionBuilder,
-  publicKey,
   transactionBuilder,
 } from '@metaplex-foundation/umi';
 import {

--- a/test/packages/js/src/generated/instructions/createReservationList.ts
+++ b/test/packages/js/src/generated/instructions/createReservationList.ts
@@ -108,7 +108,6 @@ export function createReservationList(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/createReservationList.ts
+++ b/test/packages/js/src/generated/instructions/createReservationList.ts
@@ -20,7 +20,11 @@ import {
   CreateReservationListInstructionDataArgs,
   getCreateReservationListInstructionDataSerializer,
 } from '../../hooked';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type CreateReservationListInstructionAccounts = {
@@ -52,68 +56,77 @@ export function createReservationList(
   accounts: CreateReservationListInstructionAccounts,
   args: CreateReservationListInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    reservationList: [accounts.reservationList, true] as const,
-    updateAuthority: [accounts.updateAuthority, false] as const,
-    masterEdition: [accounts.masterEdition, false] as const,
-    resource: [accounts.resource, false] as const,
-    metadata: [accounts.metadata, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    reservationList: {
+      index: 0,
+      isWritable: true,
+      value: accounts.reservationList ?? null,
+    },
+    payer: { index: 1, isWritable: false, value: accounts.payer ?? null },
+    updateAuthority: {
+      index: 2,
+      isWritable: false,
+      value: accounts.updateAuthority ?? null,
+    },
+    masterEdition: {
+      index: 3,
+      isWritable: false,
+      value: accounts.masterEdition ?? null,
+    },
+    resource: { index: 4, isWritable: false, value: accounts.resource ?? null },
+    metadata: { index: 5, isWritable: false, value: accounts.metadata ?? null },
+    systemProgram: {
+      index: 6,
+      isWritable: false,
+      value: accounts.systemProgram ?? null,
+    },
+    rent: { index: 7, isWritable: false, value: accounts.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    accounts.payer
-      ? ([accounts.payer, false] as const)
-      : ([context.payer, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    accounts.systemProgram
-      ? ([accounts.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    accounts.rent
-      ? ([accounts.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...args, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.reservationList, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.resource, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
+  // Arguments.
+  const resolvedArgs: CreateReservationListInstructionArgs = { ...args };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getCreateReservationListInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getCreateReservationListInstructionDataSerializer().serialize(
+    resolvedArgs as CreateReservationListInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/createRuleSet.ts
+++ b/test/packages/js/src/generated/instructions/createRuleSet.ts
@@ -21,7 +21,13 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { PickPartial, addAccountMeta, addObjectProperty } from '../shared';
+import {
+  PickPartial,
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  expectPda,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   TaCreateArgs,
   TaCreateArgsArgs,
@@ -50,17 +56,10 @@ export type CreateRuleSetInstructionDataArgs = {
   ruleSetBump: number;
 };
 
-/** @deprecated Use `getCreateRuleSetInstructionDataSerializer()` without any argument instead. */
-export function getCreateRuleSetInstructionDataSerializer(
-  _context: object
-): Serializer<CreateRuleSetInstructionDataArgs, CreateRuleSetInstructionData>;
 export function getCreateRuleSetInstructionDataSerializer(): Serializer<
   CreateRuleSetInstructionDataArgs,
   CreateRuleSetInstructionData
->;
-export function getCreateRuleSetInstructionDataSerializer(
-  _context: object = {}
-): Serializer<CreateRuleSetInstructionDataArgs, CreateRuleSetInstructionData> {
+> {
   return mapSerializer<
     CreateRuleSetInstructionDataArgs,
     any,
@@ -92,54 +91,57 @@ export function createRuleSet(
   context: Pick<Context, 'programs' | 'payer'>,
   input: CreateRuleSetInstructionAccounts & CreateRuleSetInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenAuthRules',
     'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    ruleSetPda: [input.ruleSetPda, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    payer: { index: 0, isWritable: true, value: input.payer ?? null },
+    ruleSetPda: { index: 1, isWritable: true, value: input.ruleSetPda ?? null },
+    systemProgram: {
+      index: 2,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvingArgs,
-    'ruleSetBump',
-    input.ruleSetBump ?? input.ruleSetPda[1]
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.ruleSetPda, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
+  // Arguments.
+  const resolvedArgs: CreateRuleSetInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedArgs.ruleSetBump) {
+    resolvedArgs.ruleSetBump = expectPda(resolvedAccounts.ruleSetPda.value)[1];
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getCreateRuleSetInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getCreateRuleSetInstructionDataSerializer().serialize(
+    resolvedArgs as CreateRuleSetInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/createV1.ts
+++ b/test/packages/js/src/generated/instructions/createV1.ts
@@ -162,7 +162,6 @@ export function createV1(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
   if (!resolvedAccounts.splTokenProgram.value) {
     resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(

--- a/test/packages/js/src/generated/instructions/createV1.ts
+++ b/test/packages/js/src/generated/instructions/createV1.ts
@@ -26,7 +26,11 @@ import {
   u64,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { AssetData, AssetDataArgs, getAssetDataSerializer } from '../types';
 
 // Accounts.
@@ -66,17 +70,10 @@ export type CreateV1InstructionDataArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-/** @deprecated Use `getCreateV1InstructionDataSerializer()` without any argument instead. */
-export function getCreateV1InstructionDataSerializer(
-  _context: object
-): Serializer<CreateV1InstructionDataArgs, CreateV1InstructionData>;
 export function getCreateV1InstructionDataSerializer(): Serializer<
   CreateV1InstructionDataArgs,
   CreateV1InstructionData
->;
-export function getCreateV1InstructionDataSerializer(
-  _context: object = {}
-): Serializer<CreateV1InstructionDataArgs, CreateV1InstructionData> {
+> {
   return mapSerializer<
     CreateV1InstructionDataArgs,
     any,
@@ -104,87 +101,93 @@ export function createV1(
   context: Pick<Context, 'programs' | 'payer'>,
   input: CreateV1InstructionAccounts & CreateV1InstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, true] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    masterEdition: {
+      index: 1,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 2, isWritable: true, value: input.mint ?? null },
+    mintAuthority: {
+      index: 3,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 4, isWritable: true, value: input.payer ?? null },
+    updateAuthority: {
+      index: 5,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    systemProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 7,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    splTokenProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'masterEdition',
-    input.masterEdition
-      ? ([input.masterEdition, true] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
+  // Arguments.
+  const resolvedArgs: CreateV1InstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+  if (!resolvedAccounts.splTokenProgram.value) {
+    resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.splTokenProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data = getCreateV1InstructionDataSerializer().serialize(resolvedArgs);
+  const data = getCreateV1InstructionDataSerializer().serialize(
+    resolvedArgs as CreateV1InstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/createV2.ts
+++ b/test/packages/js/src/generated/instructions/createV2.ts
@@ -26,7 +26,11 @@ import {
   u64,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { AssetData, AssetDataArgs, getAssetDataSerializer } from '../types';
 
 // Accounts.
@@ -64,17 +68,10 @@ export type CreateV2InstructionDataArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-/** @deprecated Use `getCreateV2InstructionDataSerializer()` without any argument instead. */
-export function getCreateV2InstructionDataSerializer(
-  _context: object
-): Serializer<CreateV2InstructionDataArgs, CreateV2InstructionData>;
 export function getCreateV2InstructionDataSerializer(): Serializer<
   CreateV2InstructionDataArgs,
   CreateV2InstructionData
->;
-export function getCreateV2InstructionDataSerializer(
-  _context: object = {}
-): Serializer<CreateV2InstructionDataArgs, CreateV2InstructionData> {
+> {
   return mapSerializer<
     CreateV2InstructionDataArgs,
     any,
@@ -101,87 +98,93 @@ export function createV2(
   context: Pick<Context, 'programs' | 'payer'>,
   input: CreateV2InstructionAccounts & CreateV2InstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, true] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    masterEdition: {
+      index: 1,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 2, isWritable: true, value: input.mint ?? null },
+    mintAuthority: {
+      index: 3,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 4, isWritable: true, value: input.payer ?? null },
+    updateAuthority: {
+      index: 5,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    systemProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 7,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    splTokenProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'masterEdition',
-    input.masterEdition
-      ? ([input.masterEdition, true] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
+  // Arguments.
+  const resolvedArgs: CreateV2InstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+  if (!resolvedAccounts.splTokenProgram.value) {
+    resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.splTokenProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data = getCreateV2InstructionDataSerializer().serialize(resolvedArgs);
+  const data = getCreateV2InstructionDataSerializer().serialize(
+    resolvedArgs as CreateV2InstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/createV2.ts
+++ b/test/packages/js/src/generated/instructions/createV2.ts
@@ -159,7 +159,6 @@ export function createV2(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
   if (!resolvedAccounts.splTokenProgram.value) {
     resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(

--- a/test/packages/js/src/generated/instructions/delegate.ts
+++ b/test/packages/js/src/generated/instructions/delegate.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   DelegateArgs,
   DelegateArgsArgs,
@@ -67,17 +71,10 @@ export type DelegateInstructionData = {
 
 export type DelegateInstructionDataArgs = { delegateArgs: DelegateArgsArgs };
 
-/** @deprecated Use `getDelegateInstructionDataSerializer()` without any argument instead. */
-export function getDelegateInstructionDataSerializer(
-  _context: object
-): Serializer<DelegateInstructionDataArgs, DelegateInstructionData>;
 export function getDelegateInstructionDataSerializer(): Serializer<
   DelegateInstructionDataArgs,
   DelegateInstructionData
->;
-export function getDelegateInstructionDataSerializer(
-  _context: object = {}
-): Serializer<DelegateInstructionDataArgs, DelegateInstructionData> {
+> {
   return mapSerializer<
     DelegateInstructionDataArgs,
     any,
@@ -102,116 +99,97 @@ export function delegate(
   context: Pick<Context, 'programs' | 'identity' | 'payer'>,
   input: DelegateInstructionAccounts & DelegateInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    delegateRecord: [input.delegateRecord, true] as const,
-    delegate: [input.delegate, false] as const,
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    delegateRecord: {
+      index: 0,
+      isWritable: true,
+      value: input.delegateRecord ?? null,
+    },
+    delegate: { index: 1, isWritable: false, value: input.delegate ?? null },
+    metadata: { index: 2, isWritable: true, value: input.metadata ?? null },
+    masterEdition: {
+      index: 3,
+      isWritable: false,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 4, isWritable: false, value: input.mint ?? null },
+    token: { index: 5, isWritable: true, value: input.token ?? null },
+    authority: { index: 6, isWritable: false, value: input.authority ?? null },
+    payer: { index: 7, isWritable: true, value: input.payer ?? null },
+    systemProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 9,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    splTokenProgram: {
+      index: 10,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
+    authorizationRulesProgram: {
+      index: 11,
+      isWritable: false,
+      value: input.authorizationRulesProgram ?? null,
+    },
+    authorizationRules: {
+      index: 12,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'masterEdition',
-    input.masterEdition
-      ? ([input.masterEdition, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'token',
-    input.token ? ([input.token, true] as const) : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([context.identity, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram
-      ? ([input.authorizationRulesProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.delegateRecord, false);
-  addAccountMeta(keys, signers, resolvedAccounts.delegate, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.token, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.authorizationRulesProgram,
-    false
+  // Arguments.
+  const resolvedArgs: DelegateInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.authority.value) {
+    resolvedAccounts.authority.value = context.identity;
+  }
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
 
   // Data.
-  const data = getDelegateInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getDelegateInstructionDataSerializer().serialize(
+    resolvedArgs as DelegateInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/delegate.ts
+++ b/test/packages/js/src/generated/instructions/delegate.ts
@@ -171,7 +171,6 @@ export function delegate(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/deprecatedCreateMasterEdition.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedCreateMasterEdition.ts
@@ -188,7 +188,6 @@ export function deprecatedCreateMasterEdition(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/deprecatedCreateMasterEdition.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedCreateMasterEdition.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   CreateMasterEditionArgs,
   CreateMasterEditionArgsArgs,
@@ -69,20 +73,7 @@ export type DeprecatedCreateMasterEditionInstructionDataArgs = {
   createMasterEditionArgs: CreateMasterEditionArgsArgs;
 };
 
-/** @deprecated Use `getDeprecatedCreateMasterEditionInstructionDataSerializer()` without any argument instead. */
-export function getDeprecatedCreateMasterEditionInstructionDataSerializer(
-  _context: object
-): Serializer<
-  DeprecatedCreateMasterEditionInstructionDataArgs,
-  DeprecatedCreateMasterEditionInstructionData
->;
 export function getDeprecatedCreateMasterEditionInstructionDataSerializer(): Serializer<
-  DeprecatedCreateMasterEditionInstructionDataArgs,
-  DeprecatedCreateMasterEditionInstructionData
->;
-export function getDeprecatedCreateMasterEditionInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   DeprecatedCreateMasterEditionInstructionDataArgs,
   DeprecatedCreateMasterEditionInstructionData
 > {
@@ -115,107 +106,107 @@ export function deprecatedCreateMasterEdition(
   input: DeprecatedCreateMasterEditionInstructionAccounts &
     DeprecatedCreateMasterEditionInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    edition: [input.edition, true] as const,
-    mint: [input.mint, true] as const,
-    printingMint: [input.printingMint, true] as const,
-    oneTimePrintingAuthorizationMint: [
-      input.oneTimePrintingAuthorizationMint,
-      true,
-    ] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
-    printingMintAuthority: [input.printingMintAuthority, false] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    metadata: [input.metadata, false] as const,
-    oneTimePrintingAuthorizationMintAuthority: [
-      input.oneTimePrintingAuthorizationMintAuthority,
-      false,
-    ] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    edition: { index: 0, isWritable: true, value: input.edition ?? null },
+    mint: { index: 1, isWritable: true, value: input.mint ?? null },
+    printingMint: {
+      index: 2,
+      isWritable: true,
+      value: input.printingMint ?? null,
+    },
+    oneTimePrintingAuthorizationMint: {
+      index: 3,
+      isWritable: true,
+      value: input.oneTimePrintingAuthorizationMint ?? null,
+    },
+    updateAuthority: {
+      index: 4,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    printingMintAuthority: {
+      index: 5,
+      isWritable: false,
+      value: input.printingMintAuthority ?? null,
+    },
+    mintAuthority: {
+      index: 6,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    metadata: { index: 7, isWritable: false, value: input.metadata ?? null },
+    payer: { index: 8, isWritable: false, value: input.payer ?? null },
+    tokenProgram: {
+      index: 9,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 10,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 11, isWritable: false, value: input.rent ?? null },
+    oneTimePrintingAuthorizationMintAuthority: {
+      index: 12,
+      isWritable: false,
+      value: input.oneTimePrintingAuthorizationMintAuthority ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, false] as const)
-      : ([context.payer, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent
-      ? ([input.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.edition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printingMint, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.oneTimePrintingAuthorizationMint,
-    false
-  );
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printingMintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.oneTimePrintingAuthorizationMintAuthority,
-    false
+  // Arguments.
+  const resolvedArgs: DeprecatedCreateMasterEditionInstructionArgs = {
+    ...input,
+  };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.
   const data =
     getDeprecatedCreateMasterEditionInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as DeprecatedCreateMasterEditionInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -192,7 +192,6 @@ export function deprecatedMintNewEditionFromMasterEditionViaPrintingToken(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionAccounts =
@@ -68,20 +72,7 @@ export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction
 export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs =
   {};
 
-/** @deprecated Use `getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataSerializer()` without any argument instead. */
-export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataSerializer(
-  _context: object
-): Serializer<
-  DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs,
-  DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData
->;
 export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataSerializer(): Serializer<
-  DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs,
-  DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData
->;
-export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs,
   DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData
 > {
@@ -109,96 +100,112 @@ export function deprecatedMintNewEditionFromMasterEditionViaPrintingToken(
   context: Pick<Context, 'programs' | 'payer'>,
   input: DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    edition: [input.edition, true] as const,
-    masterEdition: [input.masterEdition, true] as const,
-    mint: [input.mint, true] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    printingMint: [input.printingMint, true] as const,
-    masterTokenAccount: [input.masterTokenAccount, true] as const,
-    editionMarker: [input.editionMarker, true] as const,
-    burnAuthority: [input.burnAuthority, false] as const,
-    masterUpdateAuthority: [input.masterUpdateAuthority, false] as const,
-    masterMetadata: [input.masterMetadata, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    edition: { index: 1, isWritable: true, value: input.edition ?? null },
+    masterEdition: {
+      index: 2,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 3, isWritable: true, value: input.mint ?? null },
+    mintAuthority: {
+      index: 4,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    printingMint: {
+      index: 5,
+      isWritable: true,
+      value: input.printingMint ?? null,
+    },
+    masterTokenAccount: {
+      index: 6,
+      isWritable: true,
+      value: input.masterTokenAccount ?? null,
+    },
+    editionMarker: {
+      index: 7,
+      isWritable: true,
+      value: input.editionMarker ?? null,
+    },
+    burnAuthority: {
+      index: 8,
+      isWritable: false,
+      value: input.burnAuthority ?? null,
+    },
+    payer: { index: 9, isWritable: false, value: input.payer ?? null },
+    masterUpdateAuthority: {
+      index: 10,
+      isWritable: false,
+      value: input.masterUpdateAuthority ?? null,
+    },
+    masterMetadata: {
+      index: 11,
+      isWritable: false,
+      value: input.masterMetadata ?? null,
+    },
+    tokenProgram: {
+      index: 12,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 13,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 14, isWritable: false, value: input.rent ?? null },
+    reservationList: {
+      index: 15,
+      isWritable: true,
+      value: input.reservationList ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, false] as const)
-      : ([context.payer, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent
-      ? ([input.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'reservationList',
-    input.reservationList
-      ? ([input.reservationList, true] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.edition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printingMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterTokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionMarker, false);
-  addAccountMeta(keys, signers, resolvedAccounts.burnAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterUpdateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
-  addAccountMeta(keys, signers, resolvedAccounts.reservationList, false);
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data =

--- a/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokens.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokens.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   MintPrintingTokensViaTokenArgs,
   MintPrintingTokensViaTokenArgsArgs,
@@ -57,20 +61,7 @@ export type DeprecatedMintPrintingTokensInstructionDataArgs = {
   mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgsArgs;
 };
 
-/** @deprecated Use `getDeprecatedMintPrintingTokensInstructionDataSerializer()` without any argument instead. */
-export function getDeprecatedMintPrintingTokensInstructionDataSerializer(
-  _context: object
-): Serializer<
-  DeprecatedMintPrintingTokensInstructionDataArgs,
-  DeprecatedMintPrintingTokensInstructionData
->;
 export function getDeprecatedMintPrintingTokensInstructionDataSerializer(): Serializer<
-  DeprecatedMintPrintingTokensInstructionDataArgs,
-  DeprecatedMintPrintingTokensInstructionData
->;
-export function getDeprecatedMintPrintingTokensInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   DeprecatedMintPrintingTokensInstructionDataArgs,
   DeprecatedMintPrintingTokensInstructionData
 > {
@@ -106,61 +97,79 @@ export function deprecatedMintPrintingTokens(
   input: DeprecatedMintPrintingTokensInstructionAccounts &
     DeprecatedMintPrintingTokensInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    destination: [input.destination, true] as const,
-    printingMint: [input.printingMint, true] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
-    metadata: [input.metadata, false] as const,
-    masterEdition: [input.masterEdition, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    destination: {
+      index: 0,
+      isWritable: true,
+      value: input.destination ?? null,
+    },
+    printingMint: {
+      index: 1,
+      isWritable: true,
+      value: input.printingMint ?? null,
+    },
+    updateAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    metadata: { index: 3, isWritable: false, value: input.metadata ?? null },
+    masterEdition: {
+      index: 4,
+      isWritable: false,
+      value: input.masterEdition ?? null,
+    },
+    tokenProgram: {
+      index: 5,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    rent: { index: 6, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent
-      ? ([input.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.destination, false);
-  addAccountMeta(keys, signers, resolvedAccounts.printingMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
+  // Arguments.
+  const resolvedArgs: DeprecatedMintPrintingTokensInstructionArgs = {
+    ...input,
+  };
+
+  // Default values.
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data =
     getDeprecatedMintPrintingTokensInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as DeprecatedMintPrintingTokensInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokens.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokens.ts
@@ -151,7 +151,6 @@ export function deprecatedMintPrintingTokens(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
@@ -161,7 +161,6 @@ export function deprecatedMintPrintingTokensViaToken(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   MintPrintingTokensViaTokenArgs,
   MintPrintingTokensViaTokenArgsArgs,
@@ -61,20 +65,7 @@ export type DeprecatedMintPrintingTokensViaTokenInstructionDataArgs = {
   mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgsArgs;
 };
 
-/** @deprecated Use `getDeprecatedMintPrintingTokensViaTokenInstructionDataSerializer()` without any argument instead. */
-export function getDeprecatedMintPrintingTokensViaTokenInstructionDataSerializer(
-  _context: object
-): Serializer<
-  DeprecatedMintPrintingTokensViaTokenInstructionDataArgs,
-  DeprecatedMintPrintingTokensViaTokenInstructionData
->;
 export function getDeprecatedMintPrintingTokensViaTokenInstructionDataSerializer(): Serializer<
-  DeprecatedMintPrintingTokensViaTokenInstructionDataArgs,
-  DeprecatedMintPrintingTokensViaTokenInstructionData
->;
-export function getDeprecatedMintPrintingTokensViaTokenInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   DeprecatedMintPrintingTokensViaTokenInstructionDataArgs,
   DeprecatedMintPrintingTokensViaTokenInstructionData
 > {
@@ -110,73 +101,85 @@ export function deprecatedMintPrintingTokensViaToken(
   input: DeprecatedMintPrintingTokensViaTokenInstructionAccounts &
     DeprecatedMintPrintingTokensViaTokenInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    destination: [input.destination, true] as const,
-    token: [input.token, true] as const,
-    oneTimePrintingAuthorizationMint: [
-      input.oneTimePrintingAuthorizationMint,
-      true,
-    ] as const,
-    printingMint: [input.printingMint, true] as const,
-    burnAuthority: [input.burnAuthority, false] as const,
-    metadata: [input.metadata, false] as const,
-    masterEdition: [input.masterEdition, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    destination: {
+      index: 0,
+      isWritable: true,
+      value: input.destination ?? null,
+    },
+    token: { index: 1, isWritable: true, value: input.token ?? null },
+    oneTimePrintingAuthorizationMint: {
+      index: 2,
+      isWritable: true,
+      value: input.oneTimePrintingAuthorizationMint ?? null,
+    },
+    printingMint: {
+      index: 3,
+      isWritable: true,
+      value: input.printingMint ?? null,
+    },
+    burnAuthority: {
+      index: 4,
+      isWritable: false,
+      value: input.burnAuthority ?? null,
+    },
+    metadata: { index: 5, isWritable: false, value: input.metadata ?? null },
+    masterEdition: {
+      index: 6,
+      isWritable: false,
+      value: input.masterEdition ?? null,
+    },
+    tokenProgram: {
+      index: 7,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    rent: { index: 8, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent
-      ? ([input.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.destination, false);
-  addAccountMeta(keys, signers, resolvedAccounts.token, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.oneTimePrintingAuthorizationMint,
-    false
+  // Arguments.
+  const resolvedArgs: DeprecatedMintPrintingTokensViaTokenInstructionArgs = {
+    ...input,
+  };
+
+  // Default values.
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.printingMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.burnAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
 
   // Data.
   const data =
     getDeprecatedMintPrintingTokensViaTokenInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as DeprecatedMintPrintingTokensViaTokenInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/deprecatedSetReservationList.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedSetReservationList.ts
@@ -125,8 +125,6 @@ export function deprecatedSetReservationList(
     ...input,
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/deprecatedSetReservationList.ts
+++ b/test/packages/js/src/generated/instructions/deprecatedSetReservationList.ts
@@ -26,7 +26,11 @@ import {
   u64,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   Reservation,
   ReservationArgs,
@@ -59,20 +63,7 @@ export type DeprecatedSetReservationListInstructionDataArgs = {
   totalSpotOffset: number | bigint;
 };
 
-/** @deprecated Use `getDeprecatedSetReservationListInstructionDataSerializer()` without any argument instead. */
-export function getDeprecatedSetReservationListInstructionDataSerializer(
-  _context: object
-): Serializer<
-  DeprecatedSetReservationListInstructionDataArgs,
-  DeprecatedSetReservationListInstructionData
->;
 export function getDeprecatedSetReservationListInstructionDataSerializer(): Serializer<
-  DeprecatedSetReservationListInstructionDataArgs,
-  DeprecatedSetReservationListInstructionData
->;
-export function getDeprecatedSetReservationListInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   DeprecatedSetReservationListInstructionDataArgs,
   DeprecatedSetReservationListInstructionData
 > {
@@ -108,32 +99,50 @@ export function deprecatedSetReservationList(
   input: DeprecatedSetReservationListInstructionAccounts &
     DeprecatedSetReservationListInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    masterEdition: [input.masterEdition, true] as const,
-    reservationList: [input.reservationList, true] as const,
-    resource: [input.resource, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    masterEdition: {
+      index: 0,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    reservationList: {
+      index: 1,
+      isWritable: true,
+      value: input.reservationList ?? null,
+    },
+    resource: { index: 2, isWritable: false, value: input.resource ?? null },
   };
-  const resolvingArgs = {};
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.reservationList, false);
-  addAccountMeta(keys, signers, resolvedAccounts.resource, false);
+  // Arguments.
+  const resolvedArgs: DeprecatedSetReservationListInstructionArgs = {
+    ...input,
+  };
+
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data =
     getDeprecatedSetReservationListInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as DeprecatedSetReservationListInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/dummy.ts
+++ b/test/packages/js/src/generated/instructions/dummy.ts
@@ -127,9 +127,6 @@ export function dummy(
   if (!resolvedAccounts.payer.value) {
     resolvedAccounts.payer.value = context.payer;
   }
-  if (!resolvedAccounts.bar.value) {
-    resolvedAccounts.bar.value = context.payer;
-  }
   if (!resolvedAccounts.foo.value) {
     resolvedAccounts.foo.value = expectSome(resolvedAccounts.bar.value);
   }

--- a/test/packages/js/src/generated/instructions/dummy.ts
+++ b/test/packages/js/src/generated/instructions/dummy.ts
@@ -23,7 +23,13 @@ import {
   u8,
 } from '@metaplex-foundation/umi/serializers';
 import { findDelegateRecordPda } from '../accounts';
-import { PickPartial, addAccountMeta, addObjectProperty } from '../shared';
+import {
+  PickPartial,
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  expectSome,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { DelegateRole } from '../types';
 
 // Accounts.
@@ -43,17 +49,10 @@ export type DummyInstructionData = { discriminator: Array<number> };
 
 export type DummyInstructionDataArgs = {};
 
-/** @deprecated Use `getDummyInstructionDataSerializer()` without any argument instead. */
-export function getDummyInstructionDataSerializer(
-  _context: object
-): Serializer<DummyInstructionDataArgs, DummyInstructionData>;
 export function getDummyInstructionDataSerializer(): Serializer<
   DummyInstructionDataArgs,
   DummyInstructionData
->;
-export function getDummyInstructionDataSerializer(
-  _context: object = {}
-): Serializer<DummyInstructionDataArgs, DummyInstructionData> {
+> {
   return mapSerializer<DummyInstructionDataArgs, any, DummyInstructionData>(
     struct<DummyInstructionData>(
       [['discriminator', array(u8(), { size: 8 })]],
@@ -83,91 +82,87 @@ export function dummy(
   context: Pick<Context, 'programs' | 'eddsa' | 'identity' | 'payer'>,
   input: DummyInstructionAccounts & DummyInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplCandyMachineCore',
     'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    updateAuthority: [input.updateAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    edition: { index: 0, isWritable: true, value: input.edition ?? null },
+    mint: { index: 1, isWritable: true, value: input.mint ?? null },
+    updateAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    mintAuthority: {
+      index: 3,
+      isWritable: true,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 4, isWritable: true, value: input.payer ?? null },
+    foo: { index: 5, isWritable: true, value: input.foo ?? null },
+    bar: { index: 6, isWritable: false, value: input.bar ?? null },
+    delegateRecord: {
+      index: 7,
+      isWritable: true,
+      value: input.delegateRecord ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'mint',
-    input.mint ? ([input.mint, true] as const) : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'edition',
-    input.edition
-      ? ([input.edition, true] as const)
-      : ([resolvedAccounts.mint[0], true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'mintAuthority',
-    input.mintAuthority
-      ? ([input.mintAuthority, true] as const)
-      : ([input.updateAuthority, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'bar',
-    input.bar ? ([input.bar, false] as const) : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'foo',
-    input.foo
-      ? ([input.foo, true] as const)
-      : ([resolvedAccounts.bar[0], true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'delegateRecord',
-    input.delegateRecord
-      ? ([input.delegateRecord, true] as const)
-      : ([
-          findDelegateRecordPda(context, { role: DelegateRole.Collection }),
-          true,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvingArgs,
-    'identityArg',
-    input.identityArg ?? context.identity.publicKey
-  );
-  addObjectProperty(resolvingArgs, 'proof', input.proof ?? []);
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.edition, true);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.foo, true);
-  addAccountMeta(keys, signers, resolvedAccounts.bar, false);
-  addAccountMeta(keys, signers, resolvedAccounts.delegateRecord, false);
+  // Arguments.
+  const resolvedArgs: DummyInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.edition.value) {
+    resolvedAccounts.edition.value = expectSome(resolvedAccounts.mint.value);
+  }
+  if (!resolvedAccounts.mintAuthority.value) {
+    resolvedAccounts.mintAuthority.value = expectSome(
+      resolvedAccounts.updateAuthority.value
+    );
+  }
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.bar.value) {
+    resolvedAccounts.bar.value = context.payer;
+  }
+  if (!resolvedAccounts.foo.value) {
+    resolvedAccounts.foo.value = expectSome(resolvedAccounts.bar.value);
+  }
+  if (!resolvedAccounts.delegateRecord.value) {
+    resolvedAccounts.delegateRecord.value = findDelegateRecordPda(context, {
+      role: DelegateRole.Collection,
+    });
+  }
+  if (!resolvedArgs.identityArg) {
+    resolvedArgs.identityArg = context.identity.publicKey;
+  }
+  if (!resolvedArgs.proof) {
+    resolvedArgs.proof = [];
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
 
   // Remaining Accounts.
-  const remainingAccounts = resolvedArgs.proof.map(
-    (address) => [address, false] as const
-  );
-  remainingAccounts.forEach((remainingAccount) =>
-    addAccountMeta(keys, signers, remainingAccount, false)
+  const remainingAccounts = resolvedArgs.proof.map((value, index) => ({
+    index,
+    value,
+    isWritable: false,
+  }));
+  orderedAccounts.push(...remainingAccounts);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.

--- a/test/packages/js/src/generated/instructions/migrate.ts
+++ b/test/packages/js/src/generated/instructions/migrate.ts
@@ -163,7 +163,6 @@ export function migrate(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/migrate.ts
+++ b/test/packages/js/src/generated/instructions/migrate.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   MigrateArgs,
   MigrateArgsArgs,
@@ -61,17 +65,10 @@ export type MigrateInstructionData = {
 
 export type MigrateInstructionDataArgs = { migrateArgs: MigrateArgsArgs };
 
-/** @deprecated Use `getMigrateInstructionDataSerializer()` without any argument instead. */
-export function getMigrateInstructionDataSerializer(
-  _context: object
-): Serializer<MigrateInstructionDataArgs, MigrateInstructionData>;
 export function getMigrateInstructionDataSerializer(): Serializer<
   MigrateInstructionDataArgs,
   MigrateInstructionData
->;
-export function getMigrateInstructionDataSerializer(
-  _context: object = {}
-): Serializer<MigrateInstructionDataArgs, MigrateInstructionData> {
+> {
   return mapSerializer<MigrateInstructionDataArgs, any, MigrateInstructionData>(
     struct<MigrateInstructionData>(
       [
@@ -92,83 +89,99 @@ export function migrate(
   context: Pick<Context, 'programs'>,
   input: MigrateInstructionAccounts & MigrateInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    masterEdition: [input.masterEdition, false] as const,
-    tokenAccount: [input.tokenAccount, true] as const,
-    mint: [input.mint, false] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
-    collectionMetadata: [input.collectionMetadata, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    masterEdition: {
+      index: 1,
+      isWritable: false,
+      value: input.masterEdition ?? null,
+    },
+    tokenAccount: {
+      index: 2,
+      isWritable: true,
+      value: input.tokenAccount ?? null,
+    },
+    mint: { index: 3, isWritable: false, value: input.mint ?? null },
+    updateAuthority: {
+      index: 4,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    collectionMetadata: {
+      index: 5,
+      isWritable: false,
+      value: input.collectionMetadata ?? null,
+    },
+    tokenProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 7,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 8,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    authorizationRules: {
+      index: 9,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
+  // Arguments.
+  const resolvedArgs: MigrateInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data = getMigrateInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getMigrateInstructionDataSerializer().serialize(
+    resolvedArgs as MigrateInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/mint.ts
+++ b/test/packages/js/src/generated/instructions/mint.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { MintArgs, MintArgsArgs, getMintArgsSerializer } from '../types';
 
 // Accounts.
@@ -58,17 +62,10 @@ export type MintInstructionData = { discriminator: number; mintArgs: MintArgs };
 
 export type MintInstructionDataArgs = { mintArgs: MintArgsArgs };
 
-/** @deprecated Use `getMintInstructionDataSerializer()` without any argument instead. */
-export function getMintInstructionDataSerializer(
-  _context: object
-): Serializer<MintInstructionDataArgs, MintInstructionData>;
 export function getMintInstructionDataSerializer(): Serializer<
   MintInstructionDataArgs,
   MintInstructionData
->;
-export function getMintInstructionDataSerializer(
-  _context: object = {}
-): Serializer<MintInstructionDataArgs, MintInstructionData> {
+> {
   return mapSerializer<MintInstructionDataArgs, any, MintInstructionData>(
     struct<MintInstructionData>(
       [
@@ -89,128 +86,110 @@ export function mint(
   context: Pick<Context, 'programs' | 'identity' | 'payer'>,
   input: MintInstructionAccounts & MintInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    token: [input.token, true] as const,
-    metadata: [input.metadata, false] as const,
-    mint: [input.mint, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    token: { index: 0, isWritable: true, value: input.token ?? null },
+    metadata: { index: 1, isWritable: false, value: input.metadata ?? null },
+    masterEdition: {
+      index: 2,
+      isWritable: false,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 3, isWritable: true, value: input.mint ?? null },
+    payer: { index: 4, isWritable: true, value: input.payer ?? null },
+    authority: { index: 5, isWritable: false, value: input.authority ?? null },
+    systemProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 7,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    splTokenProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
+    splAtaProgram: {
+      index: 9,
+      isWritable: false,
+      value: input.splAtaProgram ?? null,
+    },
+    authorizationRulesProgram: {
+      index: 10,
+      isWritable: false,
+      value: input.authorizationRulesProgram ?? null,
+    },
+    authorizationRules: {
+      index: 11,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'masterEdition',
-    input.masterEdition
-      ? ([input.masterEdition, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([context.identity, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'splAtaProgram',
-    input.splAtaProgram
-      ? ([input.splAtaProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splAssociatedToken',
-            'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram
-      ? ([input.authorizationRulesProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.token, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splAtaProgram, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.authorizationRulesProgram,
-    false
+  // Arguments.
+  const resolvedArgs: MintInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.authority.value) {
+    resolvedAccounts.authority.value = context.identity;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+  if (!resolvedAccounts.splTokenProgram.value) {
+    resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.splTokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.splAtaProgram.value) {
+    resolvedAccounts.splAtaProgram.value = context.programs.getPublicKey(
+      'splAssociatedToken',
+      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
+    );
+    resolvedAccounts.splAtaProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
 
   // Data.
-  const data = getMintInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getMintInstructionDataSerializer().serialize(
+    resolvedArgs as MintInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/mint.ts
+++ b/test/packages/js/src/generated/instructions/mint.ts
@@ -157,7 +157,6 @@ export function mint(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
   if (!resolvedAccounts.splTokenProgram.value) {
     resolvedAccounts.splTokenProgram.value = context.programs.getPublicKey(

--- a/test/packages/js/src/generated/instructions/mintFromCandyMachine.ts
+++ b/test/packages/js/src/generated/instructions/mintFromCandyMachine.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type MintFromCandyMachineInstructionAccounts = {
@@ -52,20 +56,7 @@ export type MintFromCandyMachineInstructionData = {
 
 export type MintFromCandyMachineInstructionDataArgs = {};
 
-/** @deprecated Use `getMintFromCandyMachineInstructionDataSerializer()` without any argument instead. */
-export function getMintFromCandyMachineInstructionDataSerializer(
-  _context: object
-): Serializer<
-  MintFromCandyMachineInstructionDataArgs,
-  MintFromCandyMachineInstructionData
->;
 export function getMintFromCandyMachineInstructionDataSerializer(): Serializer<
-  MintFromCandyMachineInstructionDataArgs,
-  MintFromCandyMachineInstructionData
->;
-export function getMintFromCandyMachineInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   MintFromCandyMachineInstructionDataArgs,
   MintFromCandyMachineInstructionData
 > {
@@ -93,122 +84,133 @@ export function mintFromCandyMachine(
   context: Pick<Context, 'programs' | 'identity' | 'payer'>,
   input: MintFromCandyMachineInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplCandyMachineCore',
     'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    candyMachine: [input.candyMachine, true] as const,
-    authorityPda: [input.authorityPda, true] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
-    nftMint: [input.nftMint, true] as const,
-    nftMetadata: [input.nftMetadata, true] as const,
-    nftMasterEdition: [input.nftMasterEdition, true] as const,
-    collectionAuthorityRecord: [
-      input.collectionAuthorityRecord,
-      false,
-    ] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    collectionMetadata: [input.collectionMetadata, true] as const,
-    collectionMasterEdition: [input.collectionMasterEdition, false] as const,
-    collectionUpdateAuthority: [
-      input.collectionUpdateAuthority,
-      false,
-    ] as const,
-    recentSlothashes: [input.recentSlothashes, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    candyMachine: {
+      index: 0,
+      isWritable: true,
+      value: input.candyMachine ?? null,
+    },
+    authorityPda: {
+      index: 1,
+      isWritable: true,
+      value: input.authorityPda ?? null,
+    },
+    mintAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
+    payer: { index: 3, isWritable: true, value: input.payer ?? null },
+    nftMint: { index: 4, isWritable: true, value: input.nftMint ?? null },
+    nftMintAuthority: {
+      index: 5,
+      isWritable: false,
+      value: input.nftMintAuthority ?? null,
+    },
+    nftMetadata: {
+      index: 6,
+      isWritable: true,
+      value: input.nftMetadata ?? null,
+    },
+    nftMasterEdition: {
+      index: 7,
+      isWritable: true,
+      value: input.nftMasterEdition ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 8,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
+    collectionMint: {
+      index: 9,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collectionMetadata: {
+      index: 10,
+      isWritable: true,
+      value: input.collectionMetadata ?? null,
+    },
+    collectionMasterEdition: {
+      index: 11,
+      isWritable: false,
+      value: input.collectionMasterEdition ?? null,
+    },
+    collectionUpdateAuthority: {
+      index: 12,
+      isWritable: false,
+      value: input.collectionUpdateAuthority ?? null,
+    },
+    tokenMetadataProgram: {
+      index: 13,
+      isWritable: false,
+      value: input.tokenMetadataProgram ?? null,
+    },
+    tokenProgram: {
+      index: 14,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 15,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    recentSlothashes: {
+      index: 16,
+      isWritable: false,
+      value: input.recentSlothashes ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'nftMintAuthority',
-    input.nftMintAuthority
-      ? ([input.nftMintAuthority, false] as const)
-      : ([context.identity, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenMetadataProgram',
-    input.tokenMetadataProgram
-      ? ([input.tokenMetadataProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'mplTokenMetadata',
-            'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.candyMachine, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authorityPda, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.nftMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.nftMintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.nftMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.nftMasterEdition, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.nftMintAuthority.value) {
+    resolvedAccounts.nftMintAuthority.value = context.identity;
+  }
+  if (!resolvedAccounts.tokenMetadataProgram.value) {
+    resolvedAccounts.tokenMetadataProgram.value = context.programs.getPublicKey(
+      'mplTokenMetadata',
+      'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
+    );
+    resolvedAccounts.tokenMetadataProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionMasterEdition,
-    false
-  );
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionUpdateAuthority,
-    false
-  );
-  addAccountMeta(keys, signers, resolvedAccounts.tokenMetadataProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.recentSlothashes, false);
 
   // Data.
   const data = getMintFromCandyMachineInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
+++ b/test/packages/js/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   MintNewEditionFromMasterEditionViaTokenArgs,
   MintNewEditionFromMasterEditionViaTokenArgsArgs,
@@ -70,20 +74,7 @@ export type MintNewEditionFromMasterEditionViaTokenInstructionDataArgs = {
   mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgsArgs;
 };
 
-/** @deprecated Use `getMintNewEditionFromMasterEditionViaTokenInstructionDataSerializer()` without any argument instead. */
-export function getMintNewEditionFromMasterEditionViaTokenInstructionDataSerializer(
-  _context: object
-): Serializer<
-  MintNewEditionFromMasterEditionViaTokenInstructionDataArgs,
-  MintNewEditionFromMasterEditionViaTokenInstructionData
->;
 export function getMintNewEditionFromMasterEditionViaTokenInstructionDataSerializer(): Serializer<
-  MintNewEditionFromMasterEditionViaTokenInstructionDataArgs,
-  MintNewEditionFromMasterEditionViaTokenInstructionData
->;
-export function getMintNewEditionFromMasterEditionViaTokenInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   MintNewEditionFromMasterEditionViaTokenInstructionDataArgs,
   MintNewEditionFromMasterEditionViaTokenInstructionData
 > {
@@ -119,96 +110,106 @@ export function mintNewEditionFromMasterEditionViaToken(
   input: MintNewEditionFromMasterEditionViaTokenInstructionAccounts &
     MintNewEditionFromMasterEditionViaTokenInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    newMetadata: [input.newMetadata, true] as const,
-    newEdition: [input.newEdition, true] as const,
-    masterEdition: [input.masterEdition, true] as const,
-    newMint: [input.newMint, true] as const,
-    editionMarkPda: [input.editionMarkPda, true] as const,
-    newMintAuthority: [input.newMintAuthority, false] as const,
-    tokenAccountOwner: [input.tokenAccountOwner, false] as const,
-    tokenAccount: [input.tokenAccount, false] as const,
-    newMetadataUpdateAuthority: [
-      input.newMetadataUpdateAuthority,
-      false,
-    ] as const,
-    metadata: [input.metadata, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    newMetadata: {
+      index: 0,
+      isWritable: true,
+      value: input.newMetadata ?? null,
+    },
+    newEdition: { index: 1, isWritable: true, value: input.newEdition ?? null },
+    masterEdition: {
+      index: 2,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    newMint: { index: 3, isWritable: true, value: input.newMint ?? null },
+    editionMarkPda: {
+      index: 4,
+      isWritable: true,
+      value: input.editionMarkPda ?? null,
+    },
+    newMintAuthority: {
+      index: 5,
+      isWritable: false,
+      value: input.newMintAuthority ?? null,
+    },
+    payer: { index: 6, isWritable: true, value: input.payer ?? null },
+    tokenAccountOwner: {
+      index: 7,
+      isWritable: false,
+      value: input.tokenAccountOwner ?? null,
+    },
+    tokenAccount: {
+      index: 8,
+      isWritable: false,
+      value: input.tokenAccount ?? null,
+    },
+    newMetadataUpdateAuthority: {
+      index: 9,
+      isWritable: false,
+      value: input.newMetadataUpdateAuthority ?? null,
+    },
+    metadata: { index: 10, isWritable: false, value: input.metadata ?? null },
+    tokenProgram: {
+      index: 11,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 12,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 13, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent ? ([input.rent, false] as const) : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.newMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.newEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.newMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionMarkPda, false);
-  addAccountMeta(keys, signers, resolvedAccounts.newMintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccountOwner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.newMetadataUpdateAuthority,
-    false
+  // Arguments.
+  const resolvedArgs: MintNewEditionFromMasterEditionViaTokenInstructionArgs = {
+    ...input,
+  };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
 
   // Data.
   const data =
     getMintNewEditionFromMasterEditionViaTokenInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as MintNewEditionFromMasterEditionViaTokenInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/test/packages/js/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   MintNewEditionFromMasterEditionViaTokenArgs,
   MintNewEditionFromMasterEditionViaTokenArgsArgs,
@@ -76,20 +80,7 @@ export type MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs = {
   mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgsArgs;
 };
 
-/** @deprecated Use `getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataSerializer()` without any argument instead. */
-export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataSerializer(
-  _context: object
-): Serializer<
-  MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs,
-  MintNewEditionFromMasterEditionViaVaultProxyInstructionData
->;
 export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataSerializer(): Serializer<
-  MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs,
-  MintNewEditionFromMasterEditionViaVaultProxyInstructionData
->;
-export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs,
   MintNewEditionFromMasterEditionViaVaultProxyInstructionData
 > {
@@ -128,102 +119,116 @@ export function mintNewEditionFromMasterEditionViaVaultProxy(
   input: MintNewEditionFromMasterEditionViaVaultProxyInstructionAccounts &
     MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    newMetadata: [input.newMetadata, true] as const,
-    newEdition: [input.newEdition, true] as const,
-    masterEdition: [input.masterEdition, true] as const,
-    newMint: [input.newMint, true] as const,
-    editionMarkPda: [input.editionMarkPda, true] as const,
-    newMintAuthority: [input.newMintAuthority, false] as const,
-    vaultAuthority: [input.vaultAuthority, false] as const,
-    safetyDepositStore: [input.safetyDepositStore, false] as const,
-    safetyDepositBox: [input.safetyDepositBox, false] as const,
-    vault: [input.vault, false] as const,
-    newMetadataUpdateAuthority: [
-      input.newMetadataUpdateAuthority,
-      false,
-    ] as const,
-    metadata: [input.metadata, false] as const,
-    tokenVaultProgram: [input.tokenVaultProgram, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    newMetadata: {
+      index: 0,
+      isWritable: true,
+      value: input.newMetadata ?? null,
+    },
+    newEdition: { index: 1, isWritable: true, value: input.newEdition ?? null },
+    masterEdition: {
+      index: 2,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    newMint: { index: 3, isWritable: true, value: input.newMint ?? null },
+    editionMarkPda: {
+      index: 4,
+      isWritable: true,
+      value: input.editionMarkPda ?? null,
+    },
+    newMintAuthority: {
+      index: 5,
+      isWritable: false,
+      value: input.newMintAuthority ?? null,
+    },
+    payer: { index: 6, isWritable: true, value: input.payer ?? null },
+    vaultAuthority: {
+      index: 7,
+      isWritable: false,
+      value: input.vaultAuthority ?? null,
+    },
+    safetyDepositStore: {
+      index: 8,
+      isWritable: false,
+      value: input.safetyDepositStore ?? null,
+    },
+    safetyDepositBox: {
+      index: 9,
+      isWritable: false,
+      value: input.safetyDepositBox ?? null,
+    },
+    vault: { index: 10, isWritable: false, value: input.vault ?? null },
+    newMetadataUpdateAuthority: {
+      index: 11,
+      isWritable: false,
+      value: input.newMetadataUpdateAuthority ?? null,
+    },
+    metadata: { index: 12, isWritable: false, value: input.metadata ?? null },
+    tokenProgram: {
+      index: 13,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    tokenVaultProgram: {
+      index: 14,
+      isWritable: false,
+      value: input.tokenVaultProgram ?? null,
+    },
+    systemProgram: {
+      index: 15,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 16, isWritable: false, value: input.rent ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent ? ([input.rent, false] as const) : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.newMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.newEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.newMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.editionMarkPda, false);
-  addAccountMeta(keys, signers, resolvedAccounts.newMintAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.vaultAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.safetyDepositStore, false);
-  addAccountMeta(keys, signers, resolvedAccounts.safetyDepositBox, false);
-  addAccountMeta(keys, signers, resolvedAccounts.vault, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.newMetadataUpdateAuthority,
-    false
+  // Arguments.
+  const resolvedArgs: MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs =
+    { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenVaultProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
 
   // Data.
   const data =
     getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataSerializer().serialize(
-      resolvedArgs
+      resolvedArgs as MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs
     );
 
   // Bytes Created On Chain.

--- a/test/packages/js/src/generated/instructions/puffMetadata.ts
+++ b/test/packages/js/src/generated/instructions/puffMetadata.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type PuffMetadataInstructionAccounts = {
@@ -34,17 +38,10 @@ export type PuffMetadataInstructionData = { discriminator: number };
 
 export type PuffMetadataInstructionDataArgs = {};
 
-/** @deprecated Use `getPuffMetadataInstructionDataSerializer()` without any argument instead. */
-export function getPuffMetadataInstructionDataSerializer(
-  _context: object
-): Serializer<PuffMetadataInstructionDataArgs, PuffMetadataInstructionData>;
 export function getPuffMetadataInstructionDataSerializer(): Serializer<
   PuffMetadataInstructionDataArgs,
   PuffMetadataInstructionData
->;
-export function getPuffMetadataInstructionDataSerializer(
-  _context: object = {}
-): Serializer<PuffMetadataInstructionDataArgs, PuffMetadataInstructionData> {
+> {
   return mapSerializer<
     PuffMetadataInstructionDataArgs,
     any,
@@ -62,21 +59,30 @@ export function puffMetadata(
   context: Pick<Context, 'programs'>,
   input: PuffMetadataInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
   };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getPuffMetadataInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/puffMetadata.ts
+++ b/test/packages/js/src/generated/instructions/puffMetadata.ts
@@ -70,8 +70,6 @@ export function puffMetadata(
     metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/removeCreatorVerification.ts
+++ b/test/packages/js/src/generated/instructions/removeCreatorVerification.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type RemoveCreatorVerificationInstructionAccounts = {
@@ -38,20 +42,7 @@ export type RemoveCreatorVerificationInstructionData = {
 
 export type RemoveCreatorVerificationInstructionDataArgs = {};
 
-/** @deprecated Use `getRemoveCreatorVerificationInstructionDataSerializer()` without any argument instead. */
-export function getRemoveCreatorVerificationInstructionDataSerializer(
-  _context: object
-): Serializer<
-  RemoveCreatorVerificationInstructionDataArgs,
-  RemoveCreatorVerificationInstructionData
->;
 export function getRemoveCreatorVerificationInstructionDataSerializer(): Serializer<
-  RemoveCreatorVerificationInstructionDataArgs,
-  RemoveCreatorVerificationInstructionData
->;
-export function getRemoveCreatorVerificationInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   RemoveCreatorVerificationInstructionDataArgs,
   RemoveCreatorVerificationInstructionData
 > {
@@ -76,23 +67,31 @@ export function removeCreatorVerification(
   context: Pick<Context, 'programs'>,
   input: RemoveCreatorVerificationInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    creator: [input.creator, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    creator: { index: 1, isWritable: false, value: input.creator ?? null },
   };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.creator, false);
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data =

--- a/test/packages/js/src/generated/instructions/removeCreatorVerification.ts
+++ b/test/packages/js/src/generated/instructions/removeCreatorVerification.ts
@@ -79,8 +79,6 @@ export function removeCreatorVerification(
     creator: { index: 1, isWritable: false, value: input.creator ?? null },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/revoke.ts
+++ b/test/packages/js/src/generated/instructions/revoke.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { RevokeArgs, RevokeArgsArgs, getRevokeArgsSerializer } from '../types';
 
 // Accounts.
@@ -63,17 +67,10 @@ export type RevokeInstructionData = {
 
 export type RevokeInstructionDataArgs = { revokeArgs: RevokeArgsArgs };
 
-/** @deprecated Use `getRevokeInstructionDataSerializer()` without any argument instead. */
-export function getRevokeInstructionDataSerializer(
-  _context: object
-): Serializer<RevokeInstructionDataArgs, RevokeInstructionData>;
 export function getRevokeInstructionDataSerializer(): Serializer<
   RevokeInstructionDataArgs,
   RevokeInstructionData
->;
-export function getRevokeInstructionDataSerializer(
-  _context: object = {}
-): Serializer<RevokeInstructionDataArgs, RevokeInstructionData> {
+> {
   return mapSerializer<RevokeInstructionDataArgs, any, RevokeInstructionData>(
     struct<RevokeInstructionData>(
       [
@@ -94,116 +91,97 @@ export function revoke(
   context: Pick<Context, 'programs' | 'identity' | 'payer'>,
   input: RevokeInstructionAccounts & RevokeInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    delegateRecord: [input.delegateRecord, true] as const,
-    delegate: [input.delegate, false] as const,
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    delegateRecord: {
+      index: 0,
+      isWritable: true,
+      value: input.delegateRecord ?? null,
+    },
+    delegate: { index: 1, isWritable: false, value: input.delegate ?? null },
+    metadata: { index: 2, isWritable: true, value: input.metadata ?? null },
+    masterEdition: {
+      index: 3,
+      isWritable: false,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 4, isWritable: false, value: input.mint ?? null },
+    token: { index: 5, isWritable: true, value: input.token ?? null },
+    authority: { index: 6, isWritable: false, value: input.authority ?? null },
+    payer: { index: 7, isWritable: true, value: input.payer ?? null },
+    systemProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 9,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    splTokenProgram: {
+      index: 10,
+      isWritable: false,
+      value: input.splTokenProgram ?? null,
+    },
+    authorizationRulesProgram: {
+      index: 11,
+      isWritable: false,
+      value: input.authorizationRulesProgram ?? null,
+    },
+    authorizationRules: {
+      index: 12,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'masterEdition',
-    input.masterEdition
-      ? ([input.masterEdition, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'token',
-    input.token ? ([input.token, true] as const) : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([context.identity, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'splTokenProgram',
-    input.splTokenProgram
-      ? ([input.splTokenProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram
-      ? ([input.authorizationRulesProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.delegateRecord, false);
-  addAccountMeta(keys, signers, resolvedAccounts.delegate, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.token, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.splTokenProgram, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.authorizationRulesProgram,
-    false
+  // Arguments.
+  const resolvedArgs: RevokeInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.authority.value) {
+    resolvedAccounts.authority.value = context.identity;
+  }
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
 
   // Data.
-  const data = getRevokeInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getRevokeInstructionDataSerializer().serialize(
+    resolvedArgs as RevokeInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/revoke.ts
+++ b/test/packages/js/src/generated/instructions/revoke.ts
@@ -163,7 +163,6 @@ export function revoke(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/test/packages/js/src/generated/instructions/revokeCollectionAuthority.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type RevokeCollectionAuthorityInstructionAccounts = {
@@ -44,20 +48,7 @@ export type RevokeCollectionAuthorityInstructionData = {
 
 export type RevokeCollectionAuthorityInstructionDataArgs = {};
 
-/** @deprecated Use `getRevokeCollectionAuthorityInstructionDataSerializer()` without any argument instead. */
-export function getRevokeCollectionAuthorityInstructionDataSerializer(
-  _context: object
-): Serializer<
-  RevokeCollectionAuthorityInstructionDataArgs,
-  RevokeCollectionAuthorityInstructionData
->;
 export function getRevokeCollectionAuthorityInstructionDataSerializer(): Serializer<
-  RevokeCollectionAuthorityInstructionDataArgs,
-  RevokeCollectionAuthorityInstructionData
->;
-export function getRevokeCollectionAuthorityInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   RevokeCollectionAuthorityInstructionDataArgs,
   RevokeCollectionAuthorityInstructionData
 > {
@@ -82,34 +73,46 @@ export function revokeCollectionAuthority(
   context: Pick<Context, 'programs'>,
   input: RevokeCollectionAuthorityInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    collectionAuthorityRecord: [input.collectionAuthorityRecord, true] as const,
-    delegateAuthority: [input.delegateAuthority, true] as const,
-    revokeAuthority: [input.revokeAuthority, true] as const,
-    metadata: [input.metadata, false] as const,
-    mint: [input.mint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    collectionAuthorityRecord: {
+      index: 0,
+      isWritable: true,
+      value: input.collectionAuthorityRecord ?? null,
+    },
+    delegateAuthority: {
+      index: 1,
+      isWritable: true,
+      value: input.delegateAuthority ?? null,
+    },
+    revokeAuthority: {
+      index: 2,
+      isWritable: true,
+      value: input.revokeAuthority ?? null,
+    },
+    metadata: { index: 3, isWritable: false, value: input.metadata ?? null },
+    mint: { index: 4, isWritable: false, value: input.mint ?? null },
   };
 
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.delegateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.revokeAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
 
   // Data.
   const data =

--- a/test/packages/js/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/test/packages/js/src/generated/instructions/revokeCollectionAuthority.ts
@@ -100,8 +100,6 @@ export function revokeCollectionAuthority(
     mint: { index: 4, isWritable: false, value: input.mint ?? null },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/revokeUseAuthority.ts
+++ b/test/packages/js/src/generated/instructions/revokeUseAuthority.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type RevokeUseAuthorityInstructionAccounts = {
@@ -50,20 +54,7 @@ export type RevokeUseAuthorityInstructionData = { discriminator: number };
 
 export type RevokeUseAuthorityInstructionDataArgs = {};
 
-/** @deprecated Use `getRevokeUseAuthorityInstructionDataSerializer()` without any argument instead. */
-export function getRevokeUseAuthorityInstructionDataSerializer(
-  _context: object
-): Serializer<
-  RevokeUseAuthorityInstructionDataArgs,
-  RevokeUseAuthorityInstructionData
->;
 export function getRevokeUseAuthorityInstructionDataSerializer(): Serializer<
-  RevokeUseAuthorityInstructionDataArgs,
-  RevokeUseAuthorityInstructionData
->;
-export function getRevokeUseAuthorityInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   RevokeUseAuthorityInstructionDataArgs,
   RevokeUseAuthorityInstructionData
 > {
@@ -87,65 +78,68 @@ export function revokeUseAuthority(
   context: Pick<Context, 'programs'>,
   input: RevokeUseAuthorityInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    useAuthorityRecord: [input.useAuthorityRecord, true] as const,
-    owner: [input.owner, true] as const,
-    user: [input.user, false] as const,
-    ownerTokenAccount: [input.ownerTokenAccount, true] as const,
-    mint: [input.mint, false] as const,
-    metadata: [input.metadata, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    useAuthorityRecord: {
+      index: 0,
+      isWritable: true,
+      value: input.useAuthorityRecord ?? null,
+    },
+    owner: { index: 1, isWritable: true, value: input.owner ?? null },
+    user: { index: 2, isWritable: false, value: input.user ?? null },
+    ownerTokenAccount: {
+      index: 3,
+      isWritable: true,
+      value: input.ownerTokenAccount ?? null,
+    },
+    mint: { index: 4, isWritable: false, value: input.mint ?? null },
+    metadata: { index: 5, isWritable: false, value: input.metadata ?? null },
+    tokenProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    systemProgram: {
+      index: 7,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 8, isWritable: false, value: input.rent ?? null },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent ? ([input.rent, false] as const) : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.useAuthorityRecord, false);
-  addAccountMeta(keys, signers, resolvedAccounts.owner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.user, false);
-  addAccountMeta(keys, signers, resolvedAccounts.ownerTokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
+  // Default values.
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getRevokeUseAuthorityInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/test/packages/js/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type SetAndVerifySizedCollectionItemInstructionAccounts = {
@@ -50,20 +54,7 @@ export type SetAndVerifySizedCollectionItemInstructionData = {
 
 export type SetAndVerifySizedCollectionItemInstructionDataArgs = {};
 
-/** @deprecated Use `getSetAndVerifySizedCollectionItemInstructionDataSerializer()` without any argument instead. */
-export function getSetAndVerifySizedCollectionItemInstructionDataSerializer(
-  _context: object
-): Serializer<
-  SetAndVerifySizedCollectionItemInstructionDataArgs,
-  SetAndVerifySizedCollectionItemInstructionData
->;
 export function getSetAndVerifySizedCollectionItemInstructionDataSerializer(): Serializer<
-  SetAndVerifySizedCollectionItemInstructionDataArgs,
-  SetAndVerifySizedCollectionItemInstructionData
->;
-export function getSetAndVerifySizedCollectionItemInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   SetAndVerifySizedCollectionItemInstructionDataArgs,
   SetAndVerifySizedCollectionItemInstructionData
 > {
@@ -88,59 +79,59 @@ export function setAndVerifySizedCollectionItem(
   context: Pick<Context, 'programs' | 'payer'>,
   input: SetAndVerifySizedCollectionItemInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    updateAuthority: [input.updateAuthority, false] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    collection: [input.collection, true] as const,
-    collectionMasterEditionAccount: [
-      input.collectionMasterEditionAccount,
-      true,
-    ] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    collectionAuthority: {
+      index: 1,
+      isWritable: false,
+      value: input.collectionAuthority ?? null,
+    },
+    payer: { index: 2, isWritable: true, value: input.payer ?? null },
+    updateAuthority: {
+      index: 3,
+      isWritable: false,
+      value: input.updateAuthority ?? null,
+    },
+    collectionMint: {
+      index: 4,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collection: { index: 5, isWritable: true, value: input.collection ?? null },
+    collectionMasterEditionAccount: {
+      index: 6,
+      isWritable: true,
+      value: input.collectionMasterEditionAccount ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 7,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionAuthorityRecord',
-    input.collectionAuthorityRecord
-      ? ([input.collectionAuthorityRecord, false] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collection, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionMasterEditionAccount,
-    false
-  );
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.

--- a/test/packages/js/src/generated/instructions/setCollectionSize.ts
+++ b/test/packages/js/src/generated/instructions/setCollectionSize.ts
@@ -119,8 +119,6 @@ export function setCollectionSize(
   // Arguments.
   const resolvedArgs: SetCollectionSizeInstructionArgs = { ...input };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/setCollectionSize.ts
+++ b/test/packages/js/src/generated/instructions/setCollectionSize.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   SetCollectionSizeArgs,
   SetCollectionSizeArgsArgs,
@@ -50,20 +54,7 @@ export type SetCollectionSizeInstructionDataArgs = {
   setCollectionSizeArgs: SetCollectionSizeArgsArgs;
 };
 
-/** @deprecated Use `getSetCollectionSizeInstructionDataSerializer()` without any argument instead. */
-export function getSetCollectionSizeInstructionDataSerializer(
-  _context: object
-): Serializer<
-  SetCollectionSizeInstructionDataArgs,
-  SetCollectionSizeInstructionData
->;
 export function getSetCollectionSizeInstructionDataSerializer(): Serializer<
-  SetCollectionSizeInstructionDataArgs,
-  SetCollectionSizeInstructionData
->;
-export function getSetCollectionSizeInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   SetCollectionSizeInstructionDataArgs,
   SetCollectionSizeInstructionData
 > {
@@ -95,44 +86,57 @@ export function setCollectionSize(
   context: Pick<Context, 'programs'>,
   input: SetCollectionSizeInstructionAccounts & SetCollectionSizeInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    collectionMetadata: [input.collectionMetadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, true] as const,
-    collectionMint: [input.collectionMint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    collectionMetadata: {
+      index: 0,
+      isWritable: true,
+      value: input.collectionMetadata ?? null,
+    },
+    collectionAuthority: {
+      index: 1,
+      isWritable: true,
+      value: input.collectionAuthority ?? null,
+    },
+    collectionMint: {
+      index: 2,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 3,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionAuthorityRecord',
-    input.collectionAuthorityRecord
-      ? ([input.collectionAuthorityRecord, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMetadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Arguments.
+  const resolvedArgs: SetCollectionSizeInstructionArgs = { ...input };
+
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.
-  const data =
-    getSetCollectionSizeInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getSetCollectionSizeInstructionDataSerializer().serialize(
+    resolvedArgs as SetCollectionSizeInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/setMintAuthority.ts
+++ b/test/packages/js/src/generated/instructions/setMintAuthority.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type SetMintAuthorityInstructionAccounts = {
@@ -36,20 +40,7 @@ export type SetMintAuthorityInstructionData = { discriminator: Array<number> };
 
 export type SetMintAuthorityInstructionDataArgs = {};
 
-/** @deprecated Use `getSetMintAuthorityInstructionDataSerializer()` without any argument instead. */
-export function getSetMintAuthorityInstructionDataSerializer(
-  _context: object
-): Serializer<
-  SetMintAuthorityInstructionDataArgs,
-  SetMintAuthorityInstructionData
->;
 export function getSetMintAuthorityInstructionDataSerializer(): Serializer<
-  SetMintAuthorityInstructionDataArgs,
-  SetMintAuthorityInstructionData
->;
-export function getSetMintAuthorityInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   SetMintAuthorityInstructionDataArgs,
   SetMintAuthorityInstructionData
 > {
@@ -77,31 +68,43 @@ export function setMintAuthority(
   context: Pick<Context, 'programs' | 'identity'>,
   input: SetMintAuthorityInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplCandyMachineCore',
     'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    candyMachine: [input.candyMachine, true] as const,
-    mintAuthority: [input.mintAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    candyMachine: {
+      index: 0,
+      isWritable: true,
+      value: input.candyMachine ?? null,
+    },
+    authority: { index: 1, isWritable: false, value: input.authority ?? null },
+    mintAuthority: {
+      index: 2,
+      isWritable: false,
+      value: input.mintAuthority ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([context.identity, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.candyMachine, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mintAuthority, false);
+  // Default values.
+  if (!resolvedAccounts.authority.value) {
+    resolvedAccounts.authority.value = context.identity;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getSetMintAuthorityInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/setTokenStandard.ts
+++ b/test/packages/js/src/generated/instructions/setTokenStandard.ts
@@ -86,8 +86,6 @@ export function setTokenStandard(
     edition: { index: 3, isWritable: false, value: input.edition ?? null },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/signMetadata.ts
+++ b/test/packages/js/src/generated/instructions/signMetadata.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type SignMetadataInstructionAccounts = {
@@ -36,17 +40,10 @@ export type SignMetadataInstructionData = { discriminator: number };
 
 export type SignMetadataInstructionDataArgs = {};
 
-/** @deprecated Use `getSignMetadataInstructionDataSerializer()` without any argument instead. */
-export function getSignMetadataInstructionDataSerializer(
-  _context: object
-): Serializer<SignMetadataInstructionDataArgs, SignMetadataInstructionData>;
 export function getSignMetadataInstructionDataSerializer(): Serializer<
   SignMetadataInstructionDataArgs,
   SignMetadataInstructionData
->;
-export function getSignMetadataInstructionDataSerializer(
-  _context: object = {}
-): Serializer<SignMetadataInstructionDataArgs, SignMetadataInstructionData> {
+> {
   return mapSerializer<
     SignMetadataInstructionDataArgs,
     any,
@@ -64,23 +61,31 @@ export function signMetadata(
   context: Pick<Context, 'programs'>,
   input: SignMetadataInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    creator: [input.creator, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    creator: { index: 1, isWritable: false, value: input.creator ?? null },
   };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.creator, false);
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getSignMetadataInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/signMetadata.ts
+++ b/test/packages/js/src/generated/instructions/signMetadata.ts
@@ -73,8 +73,6 @@ export function signMetadata(
     creator: { index: 1, isWritable: false, value: input.creator ?? null },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/thawDelegatedAccount.ts
+++ b/test/packages/js/src/generated/instructions/thawDelegatedAccount.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type ThawDelegatedAccountInstructionAccounts = {
@@ -42,20 +46,7 @@ export type ThawDelegatedAccountInstructionData = { discriminator: number };
 
 export type ThawDelegatedAccountInstructionDataArgs = {};
 
-/** @deprecated Use `getThawDelegatedAccountInstructionDataSerializer()` without any argument instead. */
-export function getThawDelegatedAccountInstructionDataSerializer(
-  _context: object
-): Serializer<
-  ThawDelegatedAccountInstructionDataArgs,
-  ThawDelegatedAccountInstructionData
->;
 export function getThawDelegatedAccountInstructionDataSerializer(): Serializer<
-  ThawDelegatedAccountInstructionDataArgs,
-  ThawDelegatedAccountInstructionData
->;
-export function getThawDelegatedAccountInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   ThawDelegatedAccountInstructionDataArgs,
   ThawDelegatedAccountInstructionData
 > {
@@ -79,41 +70,49 @@ export function thawDelegatedAccount(
   context: Pick<Context, 'programs'>,
   input: ThawDelegatedAccountInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    delegate: [input.delegate, true] as const,
-    tokenAccount: [input.tokenAccount, true] as const,
-    edition: [input.edition, false] as const,
-    mint: [input.mint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    delegate: { index: 0, isWritable: true, value: input.delegate ?? null },
+    tokenAccount: {
+      index: 1,
+      isWritable: true,
+      value: input.tokenAccount ?? null,
+    },
+    edition: { index: 2, isWritable: false, value: input.edition ?? null },
+    mint: { index: 3, isWritable: false, value: input.mint ?? null },
+    tokenProgram: {
+      index: 4,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.delegate, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.edition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
+  // Default values.
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data = getThawDelegatedAccountInstructionDataSerializer().serialize({});

--- a/test/packages/js/src/generated/instructions/transfer.ts
+++ b/test/packages/js/src/generated/instructions/transfer.ts
@@ -229,7 +229,6 @@ export function transfer(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/transferOutOfEscrow.ts
+++ b/test/packages/js/src/generated/instructions/transferOutOfEscrow.ts
@@ -193,7 +193,6 @@ export function transferOutOfEscrow(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/transferOutOfEscrow.ts
+++ b/test/packages/js/src/generated/instructions/transferOutOfEscrow.ts
@@ -23,7 +23,11 @@ import {
   u64,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type TransferOutOfEscrowInstructionAccounts = {
@@ -65,20 +69,7 @@ export type TransferOutOfEscrowInstructionDataArgs = {
   amount: number | bigint;
 };
 
-/** @deprecated Use `getTransferOutOfEscrowInstructionDataSerializer()` without any argument instead. */
-export function getTransferOutOfEscrowInstructionDataSerializer(
-  _context: object
-): Serializer<
-  TransferOutOfEscrowInstructionDataArgs,
-  TransferOutOfEscrowInstructionData
->;
 export function getTransferOutOfEscrowInstructionDataSerializer(): Serializer<
-  TransferOutOfEscrowInstructionDataArgs,
-  TransferOutOfEscrowInstructionData
->;
-export function getTransferOutOfEscrowInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   TransferOutOfEscrowInstructionDataArgs,
   TransferOutOfEscrowInstructionData
 > {
@@ -111,108 +102,116 @@ export function transferOutOfEscrow(
   input: TransferOutOfEscrowInstructionAccounts &
     TransferOutOfEscrowInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    escrow: [input.escrow, false] as const,
-    metadata: [input.metadata, true] as const,
-    attributeMint: [input.attributeMint, false] as const,
-    attributeSrc: [input.attributeSrc, true] as const,
-    attributeDst: [input.attributeDst, true] as const,
-    escrowMint: [input.escrowMint, false] as const,
-    escrowAccount: [input.escrowAccount, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    escrow: { index: 0, isWritable: false, value: input.escrow ?? null },
+    metadata: { index: 1, isWritable: true, value: input.metadata ?? null },
+    payer: { index: 2, isWritable: true, value: input.payer ?? null },
+    attributeMint: {
+      index: 3,
+      isWritable: false,
+      value: input.attributeMint ?? null,
+    },
+    attributeSrc: {
+      index: 4,
+      isWritable: true,
+      value: input.attributeSrc ?? null,
+    },
+    attributeDst: {
+      index: 5,
+      isWritable: true,
+      value: input.attributeDst ?? null,
+    },
+    escrowMint: {
+      index: 6,
+      isWritable: false,
+      value: input.escrowMint ?? null,
+    },
+    escrowAccount: {
+      index: 7,
+      isWritable: false,
+      value: input.escrowAccount ?? null,
+    },
+    systemProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    ataProgram: {
+      index: 9,
+      isWritable: false,
+      value: input.ataProgram ?? null,
+    },
+    tokenProgram: {
+      index: 10,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 11,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    authority: { index: 12, isWritable: false, value: input.authority ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'ataProgram',
-    input.ataProgram
-      ? ([input.ataProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splAssociatedToken',
-            'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.escrow, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.attributeMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.attributeSrc, false);
-  addAccountMeta(keys, signers, resolvedAccounts.attributeDst, false);
-  addAccountMeta(keys, signers, resolvedAccounts.escrowMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.escrowAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.ataProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
+  // Arguments.
+  const resolvedArgs: TransferOutOfEscrowInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.ataProgram.value) {
+    resolvedAccounts.ataProgram.value = context.programs.getPublicKey(
+      'splAssociatedToken',
+      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
+    );
+    resolvedAccounts.ataProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getTransferOutOfEscrowInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getTransferOutOfEscrowInstructionDataSerializer().serialize(
+    resolvedArgs as TransferOutOfEscrowInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/unverifyCollection.ts
+++ b/test/packages/js/src/generated/instructions/unverifyCollection.ts
@@ -108,8 +108,6 @@ export function unverifyCollection(
     },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/unverifyCollection.ts
+++ b/test/packages/js/src/generated/instructions/unverifyCollection.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type UnverifyCollectionInstructionAccounts = {
@@ -44,20 +48,7 @@ export type UnverifyCollectionInstructionData = { discriminator: number };
 
 export type UnverifyCollectionInstructionDataArgs = {};
 
-/** @deprecated Use `getUnverifyCollectionInstructionDataSerializer()` without any argument instead. */
-export function getUnverifyCollectionInstructionDataSerializer(
-  _context: object
-): Serializer<
-  UnverifyCollectionInstructionDataArgs,
-  UnverifyCollectionInstructionData
->;
 export function getUnverifyCollectionInstructionDataSerializer(): Serializer<
-  UnverifyCollectionInstructionDataArgs,
-  UnverifyCollectionInstructionData
->;
-export function getUnverifyCollectionInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   UnverifyCollectionInstructionDataArgs,
   UnverifyCollectionInstructionData
 > {
@@ -81,49 +72,54 @@ export function unverifyCollection(
   context: Pick<Context, 'programs'>,
   input: UnverifyCollectionInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, true] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    collection: [input.collection, false] as const,
-    collectionMasterEditionAccount: [
-      input.collectionMasterEditionAccount,
-      false,
-    ] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    collectionAuthority: {
+      index: 1,
+      isWritable: true,
+      value: input.collectionAuthority ?? null,
+    },
+    collectionMint: {
+      index: 2,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collection: {
+      index: 3,
+      isWritable: false,
+      value: input.collection ?? null,
+    },
+    collectionMasterEditionAccount: {
+      index: 4,
+      isWritable: false,
+      value: input.collectionMasterEditionAccount ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 5,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionAuthorityRecord',
-    input.collectionAuthorityRecord
-      ? ([input.collectionAuthorityRecord, false] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collection, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionMasterEditionAccount,
-    false
-  );
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.

--- a/test/packages/js/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/test/packages/js/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type UnverifySizedCollectionItemInstructionAccounts = {
@@ -48,20 +52,7 @@ export type UnverifySizedCollectionItemInstructionData = {
 
 export type UnverifySizedCollectionItemInstructionDataArgs = {};
 
-/** @deprecated Use `getUnverifySizedCollectionItemInstructionDataSerializer()` without any argument instead. */
-export function getUnverifySizedCollectionItemInstructionDataSerializer(
-  _context: object
-): Serializer<
-  UnverifySizedCollectionItemInstructionDataArgs,
-  UnverifySizedCollectionItemInstructionData
->;
 export function getUnverifySizedCollectionItemInstructionDataSerializer(): Serializer<
-  UnverifySizedCollectionItemInstructionDataArgs,
-  UnverifySizedCollectionItemInstructionData
->;
-export function getUnverifySizedCollectionItemInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   UnverifySizedCollectionItemInstructionDataArgs,
   UnverifySizedCollectionItemInstructionData
 > {
@@ -86,57 +77,54 @@ export function unverifySizedCollectionItem(
   context: Pick<Context, 'programs' | 'payer'>,
   input: UnverifySizedCollectionItemInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    collection: [input.collection, true] as const,
-    collectionMasterEditionAccount: [
-      input.collectionMasterEditionAccount,
-      false,
-    ] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    collectionAuthority: {
+      index: 1,
+      isWritable: false,
+      value: input.collectionAuthority ?? null,
+    },
+    payer: { index: 2, isWritable: true, value: input.payer ?? null },
+    collectionMint: {
+      index: 3,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collection: { index: 4, isWritable: true, value: input.collection ?? null },
+    collectionMasterEditionAccount: {
+      index: 5,
+      isWritable: false,
+      value: input.collectionMasterEditionAccount ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 6,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionAuthorityRecord',
-    input.collectionAuthorityRecord
-      ? ([input.collectionAuthorityRecord, false] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collection, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionMasterEditionAccount,
-    false
-  );
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.

--- a/test/packages/js/src/generated/instructions/updateMetadataAccount.ts
+++ b/test/packages/js/src/generated/instructions/updateMetadataAccount.ts
@@ -135,8 +135,6 @@ export function updateMetadataAccount(
   // Arguments.
   const resolvedArgs: UpdateMetadataAccountInstructionArgs = { ...args };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/updateMetadataAccount.ts
+++ b/test/packages/js/src/generated/instructions/updateMetadataAccount.ts
@@ -29,7 +29,11 @@ import {
   u16,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { Creator, CreatorArgs, getCreatorSerializer } from '../types';
 
 // Accounts.
@@ -66,20 +70,7 @@ export type UpdateMetadataAccountInstructionDataArgs = {
   primarySaleHappened: OptionOrNullable<boolean>;
 };
 
-/** @deprecated Use `getUpdateMetadataAccountInstructionDataSerializer()` without any argument instead. */
-export function getUpdateMetadataAccountInstructionDataSerializer(
-  _context: object
-): Serializer<
-  UpdateMetadataAccountInstructionDataArgs,
-  UpdateMetadataAccountInstructionData
->;
 export function getUpdateMetadataAccountInstructionDataSerializer(): Serializer<
-  UpdateMetadataAccountInstructionDataArgs,
-  UpdateMetadataAccountInstructionData
->;
-export function getUpdateMetadataAccountInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   UpdateMetadataAccountInstructionDataArgs,
   UpdateMetadataAccountInstructionData
 > {
@@ -125,29 +116,43 @@ export function updateMetadataAccount(
   accounts: UpdateMetadataAccountInstructionAccounts,
   args: UpdateMetadataAccountInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [accounts.metadata, true] as const,
-    updateAuthority: [accounts.updateAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: accounts.metadata ?? null },
+    updateAuthority: {
+      index: 1,
+      isWritable: false,
+      value: accounts.updateAuthority ?? null,
+    },
   };
-  const resolvingArgs = {};
-  const resolvedArgs = { ...args, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
+  // Arguments.
+  const resolvedArgs: UpdateMetadataAccountInstructionArgs = { ...args };
+
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getUpdateMetadataAccountInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getUpdateMetadataAccountInstructionDataSerializer().serialize(
+    resolvedArgs as UpdateMetadataAccountInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/test/packages/js/src/generated/instructions/updateMetadataAccountV2.ts
@@ -26,7 +26,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { DataV2, DataV2Args, getDataV2Serializer } from '../types';
 
 // Accounts.
@@ -53,20 +57,7 @@ export type UpdateMetadataAccountV2InstructionDataArgs = {
   isMutable: OptionOrNullable<boolean>;
 };
 
-/** @deprecated Use `getUpdateMetadataAccountV2InstructionDataSerializer()` without any argument instead. */
-export function getUpdateMetadataAccountV2InstructionDataSerializer(
-  _context: object
-): Serializer<
-  UpdateMetadataAccountV2InstructionDataArgs,
-  UpdateMetadataAccountV2InstructionData
->;
 export function getUpdateMetadataAccountV2InstructionDataSerializer(): Serializer<
-  UpdateMetadataAccountV2InstructionDataArgs,
-  UpdateMetadataAccountV2InstructionData
->;
-export function getUpdateMetadataAccountV2InstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   UpdateMetadataAccountV2InstructionDataArgs,
   UpdateMetadataAccountV2InstructionData
 > {
@@ -102,31 +93,43 @@ export function updateMetadataAccountV2(
   accounts: UpdateMetadataAccountV2InstructionAccounts,
   args: UpdateMetadataAccountV2InstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [accounts.metadata, true] as const,
-    updateAuthority: [accounts.updateAuthority, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: accounts.metadata ?? null },
+    updateAuthority: {
+      index: 1,
+      isWritable: false,
+      value: accounts.updateAuthority ?? null,
+    },
   };
-  const resolvingArgs = {};
-  const resolvedArgs = { ...args, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.updateAuthority, false);
+  // Arguments.
+  const resolvedArgs: UpdateMetadataAccountV2InstructionArgs = { ...args };
+
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data =
-    getUpdateMetadataAccountV2InstructionDataSerializer().serialize(
-      resolvedArgs
-    );
+  const data = getUpdateMetadataAccountV2InstructionDataSerializer().serialize(
+    resolvedArgs as UpdateMetadataAccountV2InstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/test/packages/js/src/generated/instructions/updateMetadataAccountV2.ts
@@ -112,8 +112,6 @@ export function updateMetadataAccountV2(
   // Arguments.
   const resolvedArgs: UpdateMetadataAccountV2InstructionArgs = { ...args };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/test/packages/js/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -82,8 +82,6 @@ export function updatePrimarySaleHappenedViaToken(
     token: { index: 2, isWritable: false, value: input.token ?? null },
   };
 
-  // Default values.
-
   // Accounts in order.
   const orderedAccounts: ResolvedAccount[] = Object.values(
     resolvedAccounts

--- a/test/packages/js/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/test/packages/js/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type UpdatePrimarySaleHappenedViaTokenInstructionAccounts = {
@@ -40,20 +44,7 @@ export type UpdatePrimarySaleHappenedViaTokenInstructionData = {
 
 export type UpdatePrimarySaleHappenedViaTokenInstructionDataArgs = {};
 
-/** @deprecated Use `getUpdatePrimarySaleHappenedViaTokenInstructionDataSerializer()` without any argument instead. */
-export function getUpdatePrimarySaleHappenedViaTokenInstructionDataSerializer(
-  _context: object
-): Serializer<
-  UpdatePrimarySaleHappenedViaTokenInstructionDataArgs,
-  UpdatePrimarySaleHappenedViaTokenInstructionData
->;
 export function getUpdatePrimarySaleHappenedViaTokenInstructionDataSerializer(): Serializer<
-  UpdatePrimarySaleHappenedViaTokenInstructionDataArgs,
-  UpdatePrimarySaleHappenedViaTokenInstructionData
->;
-export function getUpdatePrimarySaleHappenedViaTokenInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   UpdatePrimarySaleHappenedViaTokenInstructionDataArgs,
   UpdatePrimarySaleHappenedViaTokenInstructionData
 > {
@@ -78,25 +69,32 @@ export function updatePrimarySaleHappenedViaToken(
   context: Pick<Context, 'programs'>,
   input: UpdatePrimarySaleHappenedViaTokenInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    owner: [input.owner, false] as const,
-    token: [input.token, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    owner: { index: 1, isWritable: false, value: input.owner ?? null },
+    token: { index: 2, isWritable: false, value: input.token ?? null },
   };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.owner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.token, false);
+  // Default values.
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
   const data =

--- a/test/packages/js/src/generated/instructions/updateV1.ts
+++ b/test/packages/js/src/generated/instructions/updateV1.ts
@@ -253,7 +253,6 @@ export function updateV1(
     resolvedAccounts.sysvarInstructions.value = publicKey(
       'Sysvar1nstructions1111111111111111111111111'
     );
-    resolvedAccounts.sysvarInstructions.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/updateV1.ts
+++ b/test/packages/js/src/generated/instructions/updateV1.ts
@@ -31,7 +31,11 @@ import {
   u16,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   AuthorityType,
   AuthorityTypeArgs,
@@ -131,17 +135,10 @@ export type UpdateV1InstructionDataArgs = {
   authorityType: AuthorityTypeArgs;
 };
 
-/** @deprecated Use `getUpdateV1InstructionDataSerializer()` without any argument instead. */
-export function getUpdateV1InstructionDataSerializer(
-  _context: object
-): Serializer<UpdateV1InstructionDataArgs, UpdateV1InstructionData>;
 export function getUpdateV1InstructionDataSerializer(): Serializer<
   UpdateV1InstructionDataArgs,
   UpdateV1InstructionData
->;
-export function getUpdateV1InstructionDataSerializer(
-  _context: object = {}
-): Serializer<UpdateV1InstructionDataArgs, UpdateV1InstructionData> {
+> {
   return mapSerializer<
     UpdateV1InstructionDataArgs,
     any,
@@ -194,106 +191,87 @@ export function updateV1(
   context: Pick<Context, 'programs' | 'identity'>,
   input: UpdateV1InstructionAccounts & UpdateV1InstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    mint: [input.mint, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    authority: { index: 0, isWritable: false, value: input.authority ?? null },
+    metadata: { index: 1, isWritable: true, value: input.metadata ?? null },
+    masterEdition: {
+      index: 2,
+      isWritable: true,
+      value: input.masterEdition ?? null,
+    },
+    mint: { index: 3, isWritable: false, value: input.mint ?? null },
+    systemProgram: {
+      index: 4,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    sysvarInstructions: {
+      index: 5,
+      isWritable: false,
+      value: input.sysvarInstructions ?? null,
+    },
+    token: { index: 6, isWritable: false, value: input.token ?? null },
+    delegateRecord: {
+      index: 7,
+      isWritable: false,
+      value: input.delegateRecord ?? null,
+    },
+    authorizationRulesProgram: {
+      index: 8,
+      isWritable: false,
+      value: input.authorizationRulesProgram ?? null,
+    },
+    authorizationRules: {
+      index: 9,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'authority',
-    input.authority
-      ? ([input.authority, false] as const)
-      : ([context.identity, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'masterEdition',
-    input.masterEdition
-      ? ([input.masterEdition, true] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'sysvarInstructions',
-    input.sysvarInstructions
-      ? ([input.sysvarInstructions, false] as const)
-      : ([
-          publicKey('Sysvar1nstructions1111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'token',
-    input.token
-      ? ([input.token, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'delegateRecord',
-    input.delegateRecord
-      ? ([input.delegateRecord, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram
-      ? ([input.authorizationRulesProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.authority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.masterEdition, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.sysvarInstructions, false);
-  addAccountMeta(keys, signers, resolvedAccounts.token, false);
-  addAccountMeta(keys, signers, resolvedAccounts.delegateRecord, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.authorizationRulesProgram,
-    false
+  // Arguments.
+  const resolvedArgs: UpdateV1InstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.authority.value) {
+    resolvedAccounts.authority.value = context.identity;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.sysvarInstructions.value) {
+    resolvedAccounts.sysvarInstructions.value = publicKey(
+      'Sysvar1nstructions1111111111111111111111111'
+    );
+    resolvedAccounts.sysvarInstructions.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
 
   // Data.
-  const data = getUpdateV1InstructionDataSerializer().serialize(resolvedArgs);
+  const data = getUpdateV1InstructionDataSerializer().serialize(
+    resolvedArgs as UpdateV1InstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/utilize.ts
+++ b/test/packages/js/src/generated/instructions/utilize.ts
@@ -23,7 +23,11 @@ import {
   u64,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type UtilizeInstructionAccounts = {
@@ -59,17 +63,10 @@ export type UtilizeInstructionData = {
 
 export type UtilizeInstructionDataArgs = { numberOfUses: number | bigint };
 
-/** @deprecated Use `getUtilizeInstructionDataSerializer()` without any argument instead. */
-export function getUtilizeInstructionDataSerializer(
-  _context: object
-): Serializer<UtilizeInstructionDataArgs, UtilizeInstructionData>;
 export function getUtilizeInstructionDataSerializer(): Serializer<
   UtilizeInstructionDataArgs,
   UtilizeInstructionData
->;
-export function getUtilizeInstructionDataSerializer(
-  _context: object = {}
-): Serializer<UtilizeInstructionDataArgs, UtilizeInstructionData> {
+> {
   return mapSerializer<UtilizeInstructionDataArgs, any, UtilizeInstructionData>(
     struct<UtilizeInstructionData>(
       [
@@ -90,103 +87,99 @@ export function utilize(
   context: Pick<Context, 'programs'>,
   input: UtilizeInstructionAccounts & UtilizeInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    tokenAccount: [input.tokenAccount, true] as const,
-    mint: [input.mint, true] as const,
-    useAuthority: [input.useAuthority, true] as const,
-    owner: [input.owner, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    tokenAccount: {
+      index: 1,
+      isWritable: true,
+      value: input.tokenAccount ?? null,
+    },
+    mint: { index: 2, isWritable: true, value: input.mint ?? null },
+    useAuthority: {
+      index: 3,
+      isWritable: true,
+      value: input.useAuthority ?? null,
+    },
+    owner: { index: 4, isWritable: false, value: input.owner ?? null },
+    tokenProgram: {
+      index: 5,
+      isWritable: false,
+      value: input.tokenProgram ?? null,
+    },
+    ataProgram: {
+      index: 6,
+      isWritable: false,
+      value: input.ataProgram ?? null,
+    },
+    systemProgram: {
+      index: 7,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    rent: { index: 8, isWritable: false, value: input.rent ?? null },
+    useAuthorityRecord: {
+      index: 9,
+      isWritable: true,
+      value: input.useAuthorityRecord ?? null,
+    },
+    burner: { index: 10, isWritable: false, value: input.burner ?? null },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'tokenProgram',
-    input.tokenProgram
-      ? ([input.tokenProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splToken',
-            'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'ataProgram',
-    input.ataProgram
-      ? ([input.ataProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splAssociatedToken',
-            'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'rent',
-    input.rent
-      ? ([input.rent, false] as const)
-      : ([
-          publicKey('SysvarRent111111111111111111111111111111111'),
-          false,
-        ] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'useAuthorityRecord',
-    input.useAuthorityRecord
-      ? ([input.useAuthorityRecord, true] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'burner',
-    input.burner
-      ? ([input.burner, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenAccount, false);
-  addAccountMeta(keys, signers, resolvedAccounts.mint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.useAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.owner, false);
-  addAccountMeta(keys, signers, resolvedAccounts.tokenProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.ataProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.rent, false);
-  addAccountMeta(keys, signers, resolvedAccounts.useAuthorityRecord, false);
-  addAccountMeta(keys, signers, resolvedAccounts.burner, false);
+  // Arguments.
+  const resolvedArgs: UtilizeInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.tokenProgram.value) {
+    resolvedAccounts.tokenProgram.value = context.programs.getPublicKey(
+      'splToken',
+      'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    );
+    resolvedAccounts.tokenProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.ataProgram.value) {
+    resolvedAccounts.ataProgram.value = context.programs.getPublicKey(
+      'splAssociatedToken',
+      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
+    );
+    resolvedAccounts.ataProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+  if (!resolvedAccounts.rent.value) {
+    resolvedAccounts.rent.value = publicKey(
+      'SysvarRent111111111111111111111111111111111'
+    );
+    resolvedAccounts.rent.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
+  );
 
   // Data.
-  const data = getUtilizeInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getUtilizeInstructionDataSerializer().serialize(
+    resolvedArgs as UtilizeInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/utilize.ts
+++ b/test/packages/js/src/generated/instructions/utilize.ts
@@ -161,7 +161,6 @@ export function utilize(
     resolvedAccounts.rent.value = publicKey(
       'SysvarRent111111111111111111111111111111111'
     );
-    resolvedAccounts.rent.isWritable = false;
   }
 
   // Accounts in order.

--- a/test/packages/js/src/generated/instructions/validate.ts
+++ b/test/packages/js/src/generated/instructions/validate.ts
@@ -22,7 +22,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import {
   Operation,
   OperationArgs,
@@ -75,17 +79,10 @@ export type ValidateInstructionDataArgs = {
   payload: PayloadArgs;
 };
 
-/** @deprecated Use `getValidateInstructionDataSerializer()` without any argument instead. */
-export function getValidateInstructionDataSerializer(
-  _context: object
-): Serializer<ValidateInstructionDataArgs, ValidateInstructionData>;
 export function getValidateInstructionDataSerializer(): Serializer<
   ValidateInstructionDataArgs,
   ValidateInstructionData
->;
-export function getValidateInstructionDataSerializer(
-  _context: object = {}
-): Serializer<ValidateInstructionDataArgs, ValidateInstructionData> {
+> {
   return mapSerializer<
     ValidateInstructionDataArgs,
     any,
@@ -112,68 +109,104 @@ export function validate(
   context: Pick<Context, 'programs' | 'payer'>,
   input: ValidateInstructionAccounts & ValidateInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenAuthRules',
     'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    ruleSet: [input.ruleSet, true] as const,
-    optRuleSigner1: [input.optRuleSigner1, false] as const,
-    optRuleSigner2: [input.optRuleSigner2, false] as const,
-    optRuleSigner3: [input.optRuleSigner3, false] as const,
-    optRuleSigner4: [input.optRuleSigner4, false] as const,
-    optRuleSigner5: [input.optRuleSigner5, false] as const,
-    optRuleNonsigner1: [input.optRuleNonsigner1, false] as const,
-    optRuleNonsigner2: [input.optRuleNonsigner2, false] as const,
-    optRuleNonsigner3: [input.optRuleNonsigner3, false] as const,
-    optRuleNonsigner4: [input.optRuleNonsigner4, false] as const,
-    optRuleNonsigner5: [input.optRuleNonsigner5, false] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    payer: { index: 0, isWritable: true, value: input.payer ?? null },
+    ruleSet: { index: 1, isWritable: true, value: input.ruleSet ?? null },
+    systemProgram: {
+      index: 2,
+      isWritable: false,
+      value: input.systemProgram ?? null,
+    },
+    optRuleSigner1: {
+      index: 3,
+      isWritable: false,
+      value: input.optRuleSigner1 ?? null,
+    },
+    optRuleSigner2: {
+      index: 4,
+      isWritable: false,
+      value: input.optRuleSigner2 ?? null,
+    },
+    optRuleSigner3: {
+      index: 5,
+      isWritable: false,
+      value: input.optRuleSigner3 ?? null,
+    },
+    optRuleSigner4: {
+      index: 6,
+      isWritable: false,
+      value: input.optRuleSigner4 ?? null,
+    },
+    optRuleSigner5: {
+      index: 7,
+      isWritable: false,
+      value: input.optRuleSigner5 ?? null,
+    },
+    optRuleNonsigner1: {
+      index: 8,
+      isWritable: false,
+      value: input.optRuleNonsigner1 ?? null,
+    },
+    optRuleNonsigner2: {
+      index: 9,
+      isWritable: false,
+      value: input.optRuleNonsigner2 ?? null,
+    },
+    optRuleNonsigner3: {
+      index: 10,
+      isWritable: false,
+      value: input.optRuleNonsigner3 ?? null,
+    },
+    optRuleNonsigner4: {
+      index: 11,
+      isWritable: false,
+      value: input.optRuleNonsigner4 ?? null,
+    },
+    optRuleNonsigner5: {
+      index: 12,
+      isWritable: false,
+      value: input.optRuleNonsigner5 ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'systemProgram',
-    input.systemProgram
-      ? ([input.systemProgram, false] as const)
-      : ([
-          context.programs.getPublicKey(
-            'splSystem',
-            '11111111111111111111111111111111'
-          ),
-          false,
-        ] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.ruleSet, false);
-  addAccountMeta(keys, signers, resolvedAccounts.systemProgram, false);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleSigner1, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleSigner2, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleSigner3, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleSigner4, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleSigner5, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleNonsigner1, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleNonsigner2, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleNonsigner3, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleNonsigner4, true);
-  addAccountMeta(keys, signers, resolvedAccounts.optRuleNonsigner5, true);
+  // Arguments.
+  const resolvedArgs: ValidateInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+  if (!resolvedAccounts.systemProgram.value) {
+    resolvedAccounts.systemProgram.value = context.programs.getPublicKey(
+      'splSystem',
+      '11111111111111111111111111111111'
+    );
+    resolvedAccounts.systemProgram.isWritable = false;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'omitted',
+    programId
+  );
 
   // Data.
-  const data = getValidateInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getValidateInstructionDataSerializer().serialize(
+    resolvedArgs as ValidateInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/verify.ts
+++ b/test/packages/js/src/generated/instructions/verify.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 import { VerifyArgs, VerifyArgsArgs, getVerifyArgsSerializer } from '../types';
 
 // Accounts.
@@ -46,17 +50,10 @@ export type VerifyInstructionData = {
 
 export type VerifyInstructionDataArgs = { verifyArgs: VerifyArgsArgs };
 
-/** @deprecated Use `getVerifyInstructionDataSerializer()` without any argument instead. */
-export function getVerifyInstructionDataSerializer(
-  _context: object
-): Serializer<VerifyInstructionDataArgs, VerifyInstructionData>;
 export function getVerifyInstructionDataSerializer(): Serializer<
   VerifyInstructionDataArgs,
   VerifyInstructionData
->;
-export function getVerifyInstructionDataSerializer(
-  _context: object = {}
-): Serializer<VerifyInstructionDataArgs, VerifyInstructionData> {
+> {
   return mapSerializer<VerifyInstructionDataArgs, any, VerifyInstructionData>(
     struct<VerifyInstructionData>(
       [
@@ -77,57 +74,57 @@ export function verify(
   context: Pick<Context, 'programs' | 'payer'>,
   input: VerifyInstructionAccounts & VerifyInstructionArgs
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, true] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    collectionAuthority: {
+      index: 1,
+      isWritable: true,
+      value: input.collectionAuthority ?? null,
+    },
+    payer: { index: 2, isWritable: true, value: input.payer ?? null },
+    authorizationRules: {
+      index: 3,
+      isWritable: false,
+      value: input.authorizationRules ?? null,
+    },
+    authorizationRulesProgram: {
+      index: 4,
+      isWritable: false,
+      value: input.authorizationRulesProgram ?? null,
+    },
   };
-  const resolvingArgs = {};
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRules',
-    input.authorizationRules
-      ? ([input.authorizationRules, false] as const)
-      : ([programId, false] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'authorizationRulesProgram',
-    input.authorizationRulesProgram
-      ? ([input.authorizationRulesProgram, false] as const)
-      : ([programId, false] as const)
-  );
-  const resolvedArgs = { ...input, ...resolvingArgs };
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.authorizationRules, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.authorizationRulesProgram,
-    false
+  // Arguments.
+  const resolvedArgs: VerifyInstructionArgs = { ...input };
+
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.
-  const data = getVerifyInstructionDataSerializer().serialize(resolvedArgs);
+  const data = getVerifyInstructionDataSerializer().serialize(
+    resolvedArgs as VerifyInstructionDataArgs
+  );
 
   // Bytes Created On Chain.
   const bytesCreatedOnChain = 0;

--- a/test/packages/js/src/generated/instructions/verifyCollection.ts
+++ b/test/packages/js/src/generated/instructions/verifyCollection.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type VerifyCollectionInstructionAccounts = {
@@ -44,20 +48,7 @@ export type VerifyCollectionInstructionData = { discriminator: number };
 
 export type VerifyCollectionInstructionDataArgs = {};
 
-/** @deprecated Use `getVerifyCollectionInstructionDataSerializer()` without any argument instead. */
-export function getVerifyCollectionInstructionDataSerializer(
-  _context: object
-): Serializer<
-  VerifyCollectionInstructionDataArgs,
-  VerifyCollectionInstructionData
->;
 export function getVerifyCollectionInstructionDataSerializer(): Serializer<
-  VerifyCollectionInstructionDataArgs,
-  VerifyCollectionInstructionData
->;
-export function getVerifyCollectionInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   VerifyCollectionInstructionDataArgs,
   VerifyCollectionInstructionData
 > {
@@ -81,44 +72,53 @@ export function verifyCollection(
   context: Pick<Context, 'programs' | 'payer'>,
   input: VerifyCollectionInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, true] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    collection: [input.collection, false] as const,
-    collectionMasterEditionAccount: [
-      input.collectionMasterEditionAccount,
-      false,
-    ] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    collectionAuthority: {
+      index: 1,
+      isWritable: true,
+      value: input.collectionAuthority ?? null,
+    },
+    payer: { index: 2, isWritable: true, value: input.payer ?? null },
+    collectionMint: {
+      index: 3,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collection: {
+      index: 4,
+      isWritable: false,
+      value: input.collection ?? null,
+    },
+    collectionMasterEditionAccount: {
+      index: 5,
+      isWritable: false,
+      value: input.collectionMasterEditionAccount ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collection, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionMasterEditionAccount,
-    false
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.

--- a/test/packages/js/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/test/packages/js/src/generated/instructions/verifySizedCollectionItem.ts
@@ -21,7 +21,11 @@ import {
   struct,
   u8,
 } from '@metaplex-foundation/umi/serializers';
-import { addAccountMeta, addObjectProperty } from '../shared';
+import {
+  ResolvedAccount,
+  ResolvedAccountsWithIndices,
+  getAccountMetasAndSigners,
+} from '../shared';
 
 // Accounts.
 export type VerifySizedCollectionItemInstructionAccounts = {
@@ -48,20 +52,7 @@ export type VerifySizedCollectionItemInstructionData = {
 
 export type VerifySizedCollectionItemInstructionDataArgs = {};
 
-/** @deprecated Use `getVerifySizedCollectionItemInstructionDataSerializer()` without any argument instead. */
-export function getVerifySizedCollectionItemInstructionDataSerializer(
-  _context: object
-): Serializer<
-  VerifySizedCollectionItemInstructionDataArgs,
-  VerifySizedCollectionItemInstructionData
->;
 export function getVerifySizedCollectionItemInstructionDataSerializer(): Serializer<
-  VerifySizedCollectionItemInstructionDataArgs,
-  VerifySizedCollectionItemInstructionData
->;
-export function getVerifySizedCollectionItemInstructionDataSerializer(
-  _context: object = {}
-): Serializer<
   VerifySizedCollectionItemInstructionDataArgs,
   VerifySizedCollectionItemInstructionData
 > {
@@ -86,57 +77,54 @@ export function verifySizedCollectionItem(
   context: Pick<Context, 'programs' | 'payer'>,
   input: VerifySizedCollectionItemInstructionAccounts
 ): TransactionBuilder {
-  const signers: Signer[] = [];
-  const keys: AccountMeta[] = [];
-
   // Program ID.
   const programId = context.programs.getPublicKey(
     'mplTokenMetadata',
     'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
   );
 
-  // Resolved inputs.
-  const resolvedAccounts = {
-    metadata: [input.metadata, true] as const,
-    collectionAuthority: [input.collectionAuthority, false] as const,
-    collectionMint: [input.collectionMint, false] as const,
-    collection: [input.collection, true] as const,
-    collectionMasterEditionAccount: [
-      input.collectionMasterEditionAccount,
-      false,
-    ] as const,
+  // Accounts.
+  const resolvedAccounts: ResolvedAccountsWithIndices = {
+    metadata: { index: 0, isWritable: true, value: input.metadata ?? null },
+    collectionAuthority: {
+      index: 1,
+      isWritable: false,
+      value: input.collectionAuthority ?? null,
+    },
+    payer: { index: 2, isWritable: true, value: input.payer ?? null },
+    collectionMint: {
+      index: 3,
+      isWritable: false,
+      value: input.collectionMint ?? null,
+    },
+    collection: { index: 4, isWritable: true, value: input.collection ?? null },
+    collectionMasterEditionAccount: {
+      index: 5,
+      isWritable: false,
+      value: input.collectionMasterEditionAccount ?? null,
+    },
+    collectionAuthorityRecord: {
+      index: 6,
+      isWritable: false,
+      value: input.collectionAuthorityRecord ?? null,
+    },
   };
-  addObjectProperty(
-    resolvedAccounts,
-    'payer',
-    input.payer
-      ? ([input.payer, true] as const)
-      : ([context.payer, true] as const)
-  );
-  addObjectProperty(
-    resolvedAccounts,
-    'collectionAuthorityRecord',
-    input.collectionAuthorityRecord
-      ? ([input.collectionAuthorityRecord, false] as const)
-      : ([programId, false] as const)
-  );
 
-  addAccountMeta(keys, signers, resolvedAccounts.metadata, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionAuthority, false);
-  addAccountMeta(keys, signers, resolvedAccounts.payer, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collectionMint, false);
-  addAccountMeta(keys, signers, resolvedAccounts.collection, false);
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionMasterEditionAccount,
-    false
-  );
-  addAccountMeta(
-    keys,
-    signers,
-    resolvedAccounts.collectionAuthorityRecord,
-    false
+  // Default values.
+  if (!resolvedAccounts.payer.value) {
+    resolvedAccounts.payer.value = context.payer;
+  }
+
+  // Accounts in order.
+  const orderedAccounts: ResolvedAccount[] = Object.values(
+    resolvedAccounts
+  ).sort((a, b) => a.index - b.index);
+
+  // Keys and Signers.
+  const [keys, signers] = getAccountMetasAndSigners(
+    orderedAccounts,
+    'programId',
+    programId
   );
 
   // Data.

--- a/test/packages/js/src/generated/types/assetData.ts
+++ b/test/packages/js/src/generated/types/assetData.ts
@@ -78,14 +78,7 @@ export type AssetDataArgs = {
   delegateState: OptionOrNullable<DelegateStateArgs>;
 };
 
-/** @deprecated Use `getAssetDataSerializer()` without any argument instead. */
-export function getAssetDataSerializer(
-  _context: object
-): Serializer<AssetDataArgs, AssetData>;
-export function getAssetDataSerializer(): Serializer<AssetDataArgs, AssetData>;
-export function getAssetDataSerializer(
-  _context: object = {}
-): Serializer<AssetDataArgs, AssetData> {
+export function getAssetDataSerializer(): Serializer<AssetDataArgs, AssetData> {
   return struct<AssetData>(
     [
       ['updateAuthority', publicKeySerializer()],

--- a/test/packages/js/src/generated/types/authorityType.ts
+++ b/test/packages/js/src/generated/types/authorityType.ts
@@ -17,17 +17,10 @@ export enum AuthorityType {
 
 export type AuthorityTypeArgs = AuthorityType;
 
-/** @deprecated Use `getAuthorityTypeSerializer()` without any argument instead. */
-export function getAuthorityTypeSerializer(
-  _context: object
-): Serializer<AuthorityTypeArgs, AuthorityType>;
 export function getAuthorityTypeSerializer(): Serializer<
   AuthorityTypeArgs,
   AuthorityType
->;
-export function getAuthorityTypeSerializer(
-  _context: object = {}
-): Serializer<AuthorityTypeArgs, AuthorityType> {
+> {
   return scalarEnum<AuthorityType>(AuthorityType, {
     description: 'AuthorityType',
   }) as Serializer<AuthorityTypeArgs, AuthorityType>;

--- a/test/packages/js/src/generated/types/authorizationData.ts
+++ b/test/packages/js/src/generated/types/authorizationData.ts
@@ -13,17 +13,10 @@ export type AuthorizationData = { payload: Payload };
 
 export type AuthorizationDataArgs = { payload: PayloadArgs };
 
-/** @deprecated Use `getAuthorizationDataSerializer()` without any argument instead. */
-export function getAuthorizationDataSerializer(
-  _context: object
-): Serializer<AuthorizationDataArgs, AuthorizationData>;
 export function getAuthorizationDataSerializer(): Serializer<
   AuthorizationDataArgs,
   AuthorizationData
->;
-export function getAuthorizationDataSerializer(
-  _context: object = {}
-): Serializer<AuthorizationDataArgs, AuthorizationData> {
+> {
   return struct<AuthorizationData>([['payload', getPayloadSerializer()]], {
     description: 'AuthorizationData',
   }) as Serializer<AuthorizationDataArgs, AuthorizationData>;

--- a/test/packages/js/src/generated/types/burnArgs.ts
+++ b/test/packages/js/src/generated/types/burnArgs.ts
@@ -18,14 +18,7 @@ export enum BurnArgs {
 
 export type BurnArgsArgs = BurnArgs;
 
-/** @deprecated Use `getBurnArgsSerializer()` without any argument instead. */
-export function getBurnArgsSerializer(
-  _context: object
-): Serializer<BurnArgsArgs, BurnArgs>;
-export function getBurnArgsSerializer(): Serializer<BurnArgsArgs, BurnArgs>;
-export function getBurnArgsSerializer(
-  _context: object = {}
-): Serializer<BurnArgsArgs, BurnArgs> {
+export function getBurnArgsSerializer(): Serializer<BurnArgsArgs, BurnArgs> {
   return scalarEnum<BurnArgs>(BurnArgs, {
     size: u64(),
     description: 'BurnArgs',

--- a/test/packages/js/src/generated/types/candyMachineData.ts
+++ b/test/packages/js/src/generated/types/candyMachineData.ts
@@ -73,17 +73,10 @@ export type CandyMachineDataArgs = {
   hiddenSettings: OptionOrNullable<HiddenSettingsArgs>;
 };
 
-/** @deprecated Use `getCandyMachineDataSerializer()` without any argument instead. */
-export function getCandyMachineDataSerializer(
-  _context: object
-): Serializer<CandyMachineDataArgs, CandyMachineData>;
 export function getCandyMachineDataSerializer(): Serializer<
   CandyMachineDataArgs,
   CandyMachineData
->;
-export function getCandyMachineDataSerializer(
-  _context: object = {}
-): Serializer<CandyMachineDataArgs, CandyMachineData> {
+> {
   return struct<CandyMachineData>(
     [
       ['itemsAvailable', u64()],

--- a/test/packages/js/src/generated/types/cmCreator.ts
+++ b/test/packages/js/src/generated/types/cmCreator.ts
@@ -25,14 +25,7 @@ export type CmCreator = {
 
 export type CmCreatorArgs = CmCreator;
 
-/** @deprecated Use `getCmCreatorSerializer()` without any argument instead. */
-export function getCmCreatorSerializer(
-  _context: object
-): Serializer<CmCreatorArgs, CmCreator>;
-export function getCmCreatorSerializer(): Serializer<CmCreatorArgs, CmCreator>;
-export function getCmCreatorSerializer(
-  _context: object = {}
-): Serializer<CmCreatorArgs, CmCreator> {
+export function getCmCreatorSerializer(): Serializer<CmCreatorArgs, CmCreator> {
   return struct<CmCreator>(
     [
       ['address', publicKeySerializer()],

--- a/test/packages/js/src/generated/types/collection.ts
+++ b/test/packages/js/src/generated/types/collection.ts
@@ -19,17 +19,10 @@ export type Collection = { verified: boolean; key: PublicKey };
 
 export type CollectionArgs = { verified?: boolean; key: PublicKey };
 
-/** @deprecated Use `getCollectionSerializer()` without any argument instead. */
-export function getCollectionSerializer(
-  _context: object
-): Serializer<CollectionArgs, Collection>;
 export function getCollectionSerializer(): Serializer<
   CollectionArgs,
   Collection
->;
-export function getCollectionSerializer(
-  _context: object = {}
-): Serializer<CollectionArgs, Collection> {
+> {
   return mapSerializer<CollectionArgs, any, Collection>(
     struct<Collection>(
       [

--- a/test/packages/js/src/generated/types/collectionDetails.ts
+++ b/test/packages/js/src/generated/types/collectionDetails.ts
@@ -19,17 +19,10 @@ export type CollectionDetails = { __kind: 'V1'; size: bigint };
 
 export type CollectionDetailsArgs = { __kind: 'V1'; size: number | bigint };
 
-/** @deprecated Use `getCollectionDetailsSerializer()` without any argument instead. */
-export function getCollectionDetailsSerializer(
-  _context: object
-): Serializer<CollectionDetailsArgs, CollectionDetails>;
 export function getCollectionDetailsSerializer(): Serializer<
   CollectionDetailsArgs,
   CollectionDetails
->;
-export function getCollectionDetailsSerializer(
-  _context: object = {}
-): Serializer<CollectionDetailsArgs, CollectionDetails> {
+> {
   return dataEnum<CollectionDetails>(
     [
       [

--- a/test/packages/js/src/generated/types/configLine.ts
+++ b/test/packages/js/src/generated/types/configLine.ts
@@ -22,17 +22,10 @@ export type ConfigLine = {
 
 export type ConfigLineArgs = ConfigLine;
 
-/** @deprecated Use `getConfigLineSerializer()` without any argument instead. */
-export function getConfigLineSerializer(
-  _context: object
-): Serializer<ConfigLineArgs, ConfigLine>;
 export function getConfigLineSerializer(): Serializer<
   ConfigLineArgs,
   ConfigLine
->;
-export function getConfigLineSerializer(
-  _context: object = {}
-): Serializer<ConfigLineArgs, ConfigLine> {
+> {
   return struct<ConfigLine>(
     [
       ['name', string()],

--- a/test/packages/js/src/generated/types/configLineSettings.ts
+++ b/test/packages/js/src/generated/types/configLineSettings.ts
@@ -30,17 +30,10 @@ export type ConfigLineSettings = {
 
 export type ConfigLineSettingsArgs = ConfigLineSettings;
 
-/** @deprecated Use `getConfigLineSettingsSerializer()` without any argument instead. */
-export function getConfigLineSettingsSerializer(
-  _context: object
-): Serializer<ConfigLineSettingsArgs, ConfigLineSettings>;
 export function getConfigLineSettingsSerializer(): Serializer<
   ConfigLineSettingsArgs,
   ConfigLineSettings
->;
-export function getConfigLineSettingsSerializer(
-  _context: object = {}
-): Serializer<ConfigLineSettingsArgs, ConfigLineSettings> {
+> {
   return struct<ConfigLineSettings>(
     [
       ['prefixName', string()],

--- a/test/packages/js/src/generated/types/createMasterEditionArgs.ts
+++ b/test/packages/js/src/generated/types/createMasterEditionArgs.ts
@@ -20,17 +20,10 @@ export type CreateMasterEditionArgsArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-/** @deprecated Use `getCreateMasterEditionArgsSerializer()` without any argument instead. */
-export function getCreateMasterEditionArgsSerializer(
-  _context: object
-): Serializer<CreateMasterEditionArgsArgs, CreateMasterEditionArgs>;
 export function getCreateMasterEditionArgsSerializer(): Serializer<
   CreateMasterEditionArgsArgs,
   CreateMasterEditionArgs
->;
-export function getCreateMasterEditionArgsSerializer(
-  _context: object = {}
-): Serializer<CreateMasterEditionArgsArgs, CreateMasterEditionArgs> {
+> {
   return struct<CreateMasterEditionArgs>([['maxSupply', option(u64())]], {
     description: 'CreateMasterEditionArgs',
   }) as Serializer<CreateMasterEditionArgsArgs, CreateMasterEditionArgs>;

--- a/test/packages/js/src/generated/types/creator.ts
+++ b/test/packages/js/src/generated/types/creator.ts
@@ -24,14 +24,7 @@ export type CreatorArgs = {
   share?: number;
 };
 
-/** @deprecated Use `getCreatorSerializer()` without any argument instead. */
-export function getCreatorSerializer(
-  _context: object
-): Serializer<CreatorArgs, Creator>;
-export function getCreatorSerializer(): Serializer<CreatorArgs, Creator>;
-export function getCreatorSerializer(
-  _context: object = {}
-): Serializer<CreatorArgs, Creator> {
+export function getCreatorSerializer(): Serializer<CreatorArgs, Creator> {
   return mapSerializer<CreatorArgs, any, Creator>(
     struct<Creator>(
       [

--- a/test/packages/js/src/generated/types/dataV2.ts
+++ b/test/packages/js/src/generated/types/dataV2.ts
@@ -47,14 +47,7 @@ export type DataV2Args = {
   uses: OptionOrNullable<UsesArgs>;
 };
 
-/** @deprecated Use `getDataV2Serializer()` without any argument instead. */
-export function getDataV2Serializer(
-  _context: object
-): Serializer<DataV2Args, DataV2>;
-export function getDataV2Serializer(): Serializer<DataV2Args, DataV2>;
-export function getDataV2Serializer(
-  _context: object = {}
-): Serializer<DataV2Args, DataV2> {
+export function getDataV2Serializer(): Serializer<DataV2Args, DataV2> {
   return struct<DataV2>(
     [
       ['name', string()],

--- a/test/packages/js/src/generated/types/delegateArgs.ts
+++ b/test/packages/js/src/generated/types/delegateArgs.ts
@@ -27,17 +27,10 @@ export type DelegateArgsArgs =
   | { __kind: 'SaleV1'; amount: SolAmount }
   | { __kind: 'TransferV1'; amount: number | bigint };
 
-/** @deprecated Use `getDelegateArgsSerializer()` without any argument instead. */
-export function getDelegateArgsSerializer(
-  _context: object
-): Serializer<DelegateArgsArgs, DelegateArgs>;
 export function getDelegateArgsSerializer(): Serializer<
   DelegateArgsArgs,
   DelegateArgs
->;
-export function getDelegateArgsSerializer(
-  _context: object = {}
-): Serializer<DelegateArgsArgs, DelegateArgs> {
+> {
   return dataEnum<DelegateArgs>(
     [
       ['CollectionV1', unit()],

--- a/test/packages/js/src/generated/types/delegateRole.ts
+++ b/test/packages/js/src/generated/types/delegateRole.ts
@@ -20,17 +20,10 @@ export enum DelegateRole {
 
 export type DelegateRoleArgs = DelegateRole;
 
-/** @deprecated Use `getDelegateRoleSerializer()` without any argument instead. */
-export function getDelegateRoleSerializer(
-  _context: object
-): Serializer<DelegateRoleArgs, DelegateRole>;
 export function getDelegateRoleSerializer(): Serializer<
   DelegateRoleArgs,
   DelegateRole
->;
-export function getDelegateRoleSerializer(
-  _context: object = {}
-): Serializer<DelegateRoleArgs, DelegateRole> {
+> {
   return scalarEnum<DelegateRole>(DelegateRole, {
     description: 'DelegateRole',
   }) as Serializer<DelegateRoleArgs, DelegateRole>;

--- a/test/packages/js/src/generated/types/delegateState.ts
+++ b/test/packages/js/src/generated/types/delegateState.ts
@@ -27,17 +27,10 @@ export type DelegateStateArgs = {
   hasData: boolean;
 };
 
-/** @deprecated Use `getDelegateStateSerializer()` without any argument instead. */
-export function getDelegateStateSerializer(
-  _context: object
-): Serializer<DelegateStateArgs, DelegateState>;
 export function getDelegateStateSerializer(): Serializer<
   DelegateStateArgs,
   DelegateState
->;
-export function getDelegateStateSerializer(
-  _context: object = {}
-): Serializer<DelegateStateArgs, DelegateState> {
+> {
   return struct<DelegateState>(
     [
       ['role', getDelegateRoleSerializer()],

--- a/test/packages/js/src/generated/types/dummyLines.ts
+++ b/test/packages/js/src/generated/types/dummyLines.ts
@@ -24,17 +24,10 @@ export type DummyLinesArgs = {
   lines: Array<ConfigLineArgs>;
 };
 
-/** @deprecated Use `getDummyLinesSerializer()` without any argument instead. */
-export function getDummyLinesSerializer(
-  _context: object
-): Serializer<DummyLinesArgs, DummyLines>;
 export function getDummyLinesSerializer(): Serializer<
   DummyLinesArgs,
   DummyLines
->;
-export function getDummyLinesSerializer(
-  _context: object = {}
-): Serializer<DummyLinesArgs, DummyLines> {
+> {
   return struct<DummyLines>(
     [['lines', array(getConfigLineSerializer(), { size: 'remainder' })]],
     { description: 'DummyLines' }

--- a/test/packages/js/src/generated/types/escrowAuthority.ts
+++ b/test/packages/js/src/generated/types/escrowAuthority.ts
@@ -24,17 +24,10 @@ export type EscrowAuthority =
 
 export type EscrowAuthorityArgs = EscrowAuthority;
 
-/** @deprecated Use `getEscrowAuthoritySerializer()` without any argument instead. */
-export function getEscrowAuthoritySerializer(
-  _context: object
-): Serializer<EscrowAuthorityArgs, EscrowAuthority>;
 export function getEscrowAuthoritySerializer(): Serializer<
   EscrowAuthorityArgs,
   EscrowAuthority
->;
-export function getEscrowAuthoritySerializer(
-  _context: object = {}
-): Serializer<EscrowAuthorityArgs, EscrowAuthority> {
+> {
   return dataEnum<EscrowAuthority>(
     [
       ['TokenOwner', unit()],

--- a/test/packages/js/src/generated/types/extendedPayload.ts
+++ b/test/packages/js/src/generated/types/extendedPayload.ts
@@ -33,17 +33,10 @@ export type ExtendedPayloadArgs = {
   args: [number, string];
 };
 
-/** @deprecated Use `getExtendedPayloadSerializer()` without any argument instead. */
-export function getExtendedPayloadSerializer(
-  _context: object
-): Serializer<ExtendedPayloadArgs, ExtendedPayload>;
 export function getExtendedPayloadSerializer(): Serializer<
   ExtendedPayloadArgs,
   ExtendedPayload
->;
-export function getExtendedPayloadSerializer(
-  _context: object = {}
-): Serializer<ExtendedPayloadArgs, ExtendedPayload> {
+> {
   return struct<ExtendedPayload>(
     [
       ['map', map(getPayloadKeySerializer(), getPayloadTypeSerializer())],

--- a/test/packages/js/src/generated/types/hiddenSettings.ts
+++ b/test/packages/js/src/generated/types/hiddenSettings.ts
@@ -25,17 +25,10 @@ export type HiddenSettings = {
 
 export type HiddenSettingsArgs = HiddenSettings;
 
-/** @deprecated Use `getHiddenSettingsSerializer()` without any argument instead. */
-export function getHiddenSettingsSerializer(
-  _context: object
-): Serializer<HiddenSettingsArgs, HiddenSettings>;
 export function getHiddenSettingsSerializer(): Serializer<
   HiddenSettingsArgs,
   HiddenSettings
->;
-export function getHiddenSettingsSerializer(
-  _context: object = {}
-): Serializer<HiddenSettingsArgs, HiddenSettings> {
+> {
   return struct<HiddenSettings>(
     [
       ['name', string()],

--- a/test/packages/js/src/generated/types/migrateArgs.ts
+++ b/test/packages/js/src/generated/types/migrateArgs.ts
@@ -14,17 +14,10 @@ export enum MigrateArgs {
 
 export type MigrateArgsArgs = MigrateArgs;
 
-/** @deprecated Use `getMigrateArgsSerializer()` without any argument instead. */
-export function getMigrateArgsSerializer(
-  _context: object
-): Serializer<MigrateArgsArgs, MigrateArgs>;
 export function getMigrateArgsSerializer(): Serializer<
   MigrateArgsArgs,
   MigrateArgs
->;
-export function getMigrateArgsSerializer(
-  _context: object = {}
-): Serializer<MigrateArgsArgs, MigrateArgs> {
+> {
   return scalarEnum<MigrateArgs>(MigrateArgs, {
     description: 'MigrateArgs',
   }) as Serializer<MigrateArgsArgs, MigrateArgs>;

--- a/test/packages/js/src/generated/types/mintArgs.ts
+++ b/test/packages/js/src/generated/types/mintArgs.ts
@@ -34,14 +34,7 @@ export type MintArgsArgs = {
   authorizationData: OptionOrNullable<AuthorizationDataArgs>;
 };
 
-/** @deprecated Use `getMintArgsSerializer()` without any argument instead. */
-export function getMintArgsSerializer(
-  _context: object
-): Serializer<MintArgsArgs, MintArgs>;
-export function getMintArgsSerializer(): Serializer<MintArgsArgs, MintArgs>;
-export function getMintArgsSerializer(
-  _context: object = {}
-): Serializer<MintArgsArgs, MintArgs> {
+export function getMintArgsSerializer(): Serializer<MintArgsArgs, MintArgs> {
   return dataEnum<MintArgs>(
     [
       [

--- a/test/packages/js/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
+++ b/test/packages/js/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
@@ -14,20 +14,7 @@ export type MintNewEditionFromMasterEditionViaTokenArgsArgs = {
   edition: number | bigint;
 };
 
-/** @deprecated Use `getMintNewEditionFromMasterEditionViaTokenArgsSerializer()` without any argument instead. */
-export function getMintNewEditionFromMasterEditionViaTokenArgsSerializer(
-  _context: object
-): Serializer<
-  MintNewEditionFromMasterEditionViaTokenArgsArgs,
-  MintNewEditionFromMasterEditionViaTokenArgs
->;
 export function getMintNewEditionFromMasterEditionViaTokenArgsSerializer(): Serializer<
-  MintNewEditionFromMasterEditionViaTokenArgsArgs,
-  MintNewEditionFromMasterEditionViaTokenArgs
->;
-export function getMintNewEditionFromMasterEditionViaTokenArgsSerializer(
-  _context: object = {}
-): Serializer<
   MintNewEditionFromMasterEditionViaTokenArgsArgs,
   MintNewEditionFromMasterEditionViaTokenArgs
 > {

--- a/test/packages/js/src/generated/types/mintPrintingTokensViaTokenArgs.ts
+++ b/test/packages/js/src/generated/types/mintPrintingTokensViaTokenArgs.ts
@@ -12,20 +12,7 @@ export type MintPrintingTokensViaTokenArgs = { supply: bigint };
 
 export type MintPrintingTokensViaTokenArgsArgs = { supply: number | bigint };
 
-/** @deprecated Use `getMintPrintingTokensViaTokenArgsSerializer()` without any argument instead. */
-export function getMintPrintingTokensViaTokenArgsSerializer(
-  _context: object
-): Serializer<
-  MintPrintingTokensViaTokenArgsArgs,
-  MintPrintingTokensViaTokenArgs
->;
 export function getMintPrintingTokensViaTokenArgsSerializer(): Serializer<
-  MintPrintingTokensViaTokenArgsArgs,
-  MintPrintingTokensViaTokenArgs
->;
-export function getMintPrintingTokensViaTokenArgsSerializer(
-  _context: object = {}
-): Serializer<
   MintPrintingTokensViaTokenArgsArgs,
   MintPrintingTokensViaTokenArgs
 > {

--- a/test/packages/js/src/generated/types/operation.ts
+++ b/test/packages/js/src/generated/types/operation.ts
@@ -17,14 +17,7 @@ export enum Operation {
 
 export type OperationArgs = Operation;
 
-/** @deprecated Use `getOperationSerializer()` without any argument instead. */
-export function getOperationSerializer(
-  _context: object
-): Serializer<OperationArgs, Operation>;
-export function getOperationSerializer(): Serializer<OperationArgs, Operation>;
-export function getOperationSerializer(
-  _context: object = {}
-): Serializer<OperationArgs, Operation> {
+export function getOperationSerializer(): Serializer<OperationArgs, Operation> {
   return scalarEnum<Operation>(Operation, {
     description: 'Operation',
   }) as Serializer<OperationArgs, Operation>;

--- a/test/packages/js/src/generated/types/payload.ts
+++ b/test/packages/js/src/generated/types/payload.ts
@@ -20,14 +20,7 @@ export type Payload = { map: Map<PayloadKey, PayloadType> };
 
 export type PayloadArgs = { map: Map<PayloadKeyArgs, PayloadTypeArgs> };
 
-/** @deprecated Use `getPayloadSerializer()` without any argument instead. */
-export function getPayloadSerializer(
-  _context: object
-): Serializer<PayloadArgs, Payload>;
-export function getPayloadSerializer(): Serializer<PayloadArgs, Payload>;
-export function getPayloadSerializer(
-  _context: object = {}
-): Serializer<PayloadArgs, Payload> {
+export function getPayloadSerializer(): Serializer<PayloadArgs, Payload> {
   return struct<Payload>(
     [['map', map(getPayloadKeySerializer(), getPayloadTypeSerializer())]],
     { description: 'Payload' }

--- a/test/packages/js/src/generated/types/payloadKey.ts
+++ b/test/packages/js/src/generated/types/payloadKey.ts
@@ -17,17 +17,10 @@ export enum PayloadKey {
 
 export type PayloadKeyArgs = PayloadKey;
 
-/** @deprecated Use `getPayloadKeySerializer()` without any argument instead. */
-export function getPayloadKeySerializer(
-  _context: object
-): Serializer<PayloadKeyArgs, PayloadKey>;
 export function getPayloadKeySerializer(): Serializer<
   PayloadKeyArgs,
   PayloadKey
->;
-export function getPayloadKeySerializer(
-  _context: object = {}
-): Serializer<PayloadKeyArgs, PayloadKey> {
+> {
   return scalarEnum<PayloadKey>(PayloadKey, {
     description: 'PayloadKey',
   }) as Serializer<PayloadKeyArgs, PayloadKey>;

--- a/test/packages/js/src/generated/types/payloadType.ts
+++ b/test/packages/js/src/generated/types/payloadType.ts
@@ -34,17 +34,10 @@ export type PayloadTypeArgs =
   | { __kind: 'MerkleProof'; leaf: Uint8Array; proof: Array<Uint8Array> }
   | { __kind: 'Number'; fields: [number | bigint] };
 
-/** @deprecated Use `getPayloadTypeSerializer()` without any argument instead. */
-export function getPayloadTypeSerializer(
-  _context: object
-): Serializer<PayloadTypeArgs, PayloadType>;
 export function getPayloadTypeSerializer(): Serializer<
   PayloadTypeArgs,
   PayloadType
->;
-export function getPayloadTypeSerializer(
-  _context: object = {}
-): Serializer<PayloadTypeArgs, PayloadType> {
+> {
   return dataEnum<PayloadType>(
     [
       [

--- a/test/packages/js/src/generated/types/programmableConfig.ts
+++ b/test/packages/js/src/generated/types/programmableConfig.ts
@@ -17,17 +17,10 @@ export type ProgrammableConfig = { ruleSet: PublicKey };
 
 export type ProgrammableConfigArgs = ProgrammableConfig;
 
-/** @deprecated Use `getProgrammableConfigSerializer()` without any argument instead. */
-export function getProgrammableConfigSerializer(
-  _context: object
-): Serializer<ProgrammableConfigArgs, ProgrammableConfig>;
 export function getProgrammableConfigSerializer(): Serializer<
   ProgrammableConfigArgs,
   ProgrammableConfig
->;
-export function getProgrammableConfigSerializer(
-  _context: object = {}
-): Serializer<ProgrammableConfigArgs, ProgrammableConfig> {
+> {
   return struct<ProgrammableConfig>([['ruleSet', publicKeySerializer()]], {
     description: 'ProgrammableConfig',
   }) as Serializer<ProgrammableConfigArgs, ProgrammableConfig>;

--- a/test/packages/js/src/generated/types/reservation.ts
+++ b/test/packages/js/src/generated/types/reservation.ts
@@ -26,17 +26,10 @@ export type ReservationArgs = {
   totalSpots: number | bigint;
 };
 
-/** @deprecated Use `getReservationSerializer()` without any argument instead. */
-export function getReservationSerializer(
-  _context: object
-): Serializer<ReservationArgs, Reservation>;
 export function getReservationSerializer(): Serializer<
   ReservationArgs,
   Reservation
->;
-export function getReservationSerializer(
-  _context: object = {}
-): Serializer<ReservationArgs, Reservation> {
+> {
   return struct<Reservation>(
     [
       ['address', publicKeySerializer()],

--- a/test/packages/js/src/generated/types/reservationListV1AccountData.ts
+++ b/test/packages/js/src/generated/types/reservationListV1AccountData.ts
@@ -38,17 +38,10 @@ export type ReservationListV1AccountDataArgs = {
   reservations: Array<ReservationV1Args>;
 };
 
-/** @deprecated Use `getReservationListV1AccountDataSerializer()` without any argument instead. */
-export function getReservationListV1AccountDataSerializer(
-  _context: object
-): Serializer<ReservationListV1AccountDataArgs, ReservationListV1AccountData>;
 export function getReservationListV1AccountDataSerializer(): Serializer<
   ReservationListV1AccountDataArgs,
   ReservationListV1AccountData
->;
-export function getReservationListV1AccountDataSerializer(
-  _context: object = {}
-): Serializer<ReservationListV1AccountDataArgs, ReservationListV1AccountData> {
+> {
   return mapSerializer<
     ReservationListV1AccountDataArgs,
     any,

--- a/test/packages/js/src/generated/types/reservationV1.ts
+++ b/test/packages/js/src/generated/types/reservationV1.ts
@@ -22,17 +22,10 @@ export type ReservationV1 = {
 
 export type ReservationV1Args = ReservationV1;
 
-/** @deprecated Use `getReservationV1Serializer()` without any argument instead. */
-export function getReservationV1Serializer(
-  _context: object
-): Serializer<ReservationV1Args, ReservationV1>;
 export function getReservationV1Serializer(): Serializer<
   ReservationV1Args,
   ReservationV1
->;
-export function getReservationV1Serializer(
-  _context: object = {}
-): Serializer<ReservationV1Args, ReservationV1> {
+> {
   return struct<ReservationV1>(
     [
       ['address', publicKeySerializer()],

--- a/test/packages/js/src/generated/types/revokeArgs.ts
+++ b/test/packages/js/src/generated/types/revokeArgs.ts
@@ -16,17 +16,10 @@ export enum RevokeArgs {
 
 export type RevokeArgsArgs = RevokeArgs;
 
-/** @deprecated Use `getRevokeArgsSerializer()` without any argument instead. */
-export function getRevokeArgsSerializer(
-  _context: object
-): Serializer<RevokeArgsArgs, RevokeArgs>;
 export function getRevokeArgsSerializer(): Serializer<
   RevokeArgsArgs,
   RevokeArgs
->;
-export function getRevokeArgsSerializer(
-  _context: object = {}
-): Serializer<RevokeArgsArgs, RevokeArgs> {
+> {
   return scalarEnum<RevokeArgs>(RevokeArgs, {
     description: 'RevokeArgs',
   }) as Serializer<RevokeArgsArgs, RevokeArgs>;

--- a/test/packages/js/src/generated/types/setCollectionSizeArgs.ts
+++ b/test/packages/js/src/generated/types/setCollectionSizeArgs.ts
@@ -12,17 +12,10 @@ export type SetCollectionSizeArgs = { size: bigint };
 
 export type SetCollectionSizeArgsArgs = { size: number | bigint };
 
-/** @deprecated Use `getSetCollectionSizeArgsSerializer()` without any argument instead. */
-export function getSetCollectionSizeArgsSerializer(
-  _context: object
-): Serializer<SetCollectionSizeArgsArgs, SetCollectionSizeArgs>;
 export function getSetCollectionSizeArgsSerializer(): Serializer<
   SetCollectionSizeArgsArgs,
   SetCollectionSizeArgs
->;
-export function getSetCollectionSizeArgsSerializer(
-  _context: object = {}
-): Serializer<SetCollectionSizeArgsArgs, SetCollectionSizeArgs> {
+> {
   return struct<SetCollectionSizeArgs>([['size', u64()]], {
     description: 'SetCollectionSizeArgs',
   }) as Serializer<SetCollectionSizeArgsArgs, SetCollectionSizeArgs>;

--- a/test/packages/js/src/generated/types/taCreateArgs.ts
+++ b/test/packages/js/src/generated/types/taCreateArgs.ts
@@ -21,17 +21,10 @@ export type TaCreateArgs = {
 
 export type TaCreateArgsArgs = TaCreateArgs;
 
-/** @deprecated Use `getTaCreateArgsSerializer()` without any argument instead. */
-export function getTaCreateArgsSerializer(
-  _context: object
-): Serializer<TaCreateArgsArgs, TaCreateArgs>;
 export function getTaCreateArgsSerializer(): Serializer<
   TaCreateArgsArgs,
   TaCreateArgs
->;
-export function getTaCreateArgsSerializer(
-  _context: object = {}
-): Serializer<TaCreateArgsArgs, TaCreateArgs> {
+> {
   return struct<TaCreateArgs>(
     [
       ['ruleSetName', string()],

--- a/test/packages/js/src/generated/types/taKey.ts
+++ b/test/packages/js/src/generated/types/taKey.ts
@@ -15,14 +15,7 @@ export enum TaKey {
 
 export type TaKeyArgs = TaKey;
 
-/** @deprecated Use `getTaKeySerializer()` without any argument instead. */
-export function getTaKeySerializer(
-  _context: object
-): Serializer<TaKeyArgs, TaKey>;
-export function getTaKeySerializer(): Serializer<TaKeyArgs, TaKey>;
-export function getTaKeySerializer(
-  _context: object = {}
-): Serializer<TaKeyArgs, TaKey> {
+export function getTaKeySerializer(): Serializer<TaKeyArgs, TaKey> {
   return scalarEnum<TaKey>(TaKey, { description: 'TaKey' }) as Serializer<
     TaKeyArgs,
     TaKey

--- a/test/packages/js/src/generated/types/tmCreateArgs.ts
+++ b/test/packages/js/src/generated/types/tmCreateArgs.ts
@@ -41,17 +41,10 @@ export type TmCreateArgsArgs =
       maxSupply: OptionOrNullable<number | bigint>;
     };
 
-/** @deprecated Use `getTmCreateArgsSerializer()` without any argument instead. */
-export function getTmCreateArgsSerializer(
-  _context: object
-): Serializer<TmCreateArgsArgs, TmCreateArgs>;
 export function getTmCreateArgsSerializer(): Serializer<
   TmCreateArgsArgs,
   TmCreateArgs
->;
-export function getTmCreateArgsSerializer(
-  _context: object = {}
-): Serializer<TmCreateArgsArgs, TmCreateArgs> {
+> {
   return dataEnum<TmCreateArgs>(
     [
       [

--- a/test/packages/js/src/generated/types/tmKey.ts
+++ b/test/packages/js/src/generated/types/tmKey.ts
@@ -25,14 +25,7 @@ export enum TmKey {
 
 export type TmKeyArgs = TmKey;
 
-/** @deprecated Use `getTmKeySerializer()` without any argument instead. */
-export function getTmKeySerializer(
-  _context: object
-): Serializer<TmKeyArgs, TmKey>;
-export function getTmKeySerializer(): Serializer<TmKeyArgs, TmKey>;
-export function getTmKeySerializer(
-  _context: object = {}
-): Serializer<TmKeyArgs, TmKey> {
+export function getTmKeySerializer(): Serializer<TmKeyArgs, TmKey> {
   return scalarEnum<TmKey>(TmKey, { description: 'TmKey' }) as Serializer<
     TmKeyArgs,
     TmKey

--- a/test/packages/js/src/generated/types/tokenStandard.ts
+++ b/test/packages/js/src/generated/types/tokenStandard.ts
@@ -18,17 +18,10 @@ export enum TokenStandard {
 
 export type TokenStandardArgs = TokenStandard;
 
-/** @deprecated Use `getTokenStandardSerializer()` without any argument instead. */
-export function getTokenStandardSerializer(
-  _context: object
-): Serializer<TokenStandardArgs, TokenStandard>;
 export function getTokenStandardSerializer(): Serializer<
   TokenStandardArgs,
   TokenStandard
->;
-export function getTokenStandardSerializer(
-  _context: object = {}
-): Serializer<TokenStandardArgs, TokenStandard> {
+> {
   return scalarEnum<TokenStandard>(TokenStandard, {
     description: 'TokenStandard',
   }) as Serializer<TokenStandardArgs, TokenStandard>;

--- a/test/packages/js/src/generated/types/transferArgs.ts
+++ b/test/packages/js/src/generated/types/transferArgs.ts
@@ -34,17 +34,10 @@ export type TransferArgsArgs = {
   amount: number | bigint;
 };
 
-/** @deprecated Use `getTransferArgsSerializer()` without any argument instead. */
-export function getTransferArgsSerializer(
-  _context: object
-): Serializer<TransferArgsArgs, TransferArgs>;
 export function getTransferArgsSerializer(): Serializer<
   TransferArgsArgs,
   TransferArgs
->;
-export function getTransferArgsSerializer(
-  _context: object = {}
-): Serializer<TransferArgsArgs, TransferArgs> {
+> {
   return dataEnum<TransferArgs>(
     [
       [

--- a/test/packages/js/src/generated/types/updateArgs.ts
+++ b/test/packages/js/src/generated/types/updateArgs.ts
@@ -100,17 +100,10 @@ export type UpdateArgsArgs = {
   authorityType: AuthorityTypeArgs;
 };
 
-/** @deprecated Use `getUpdateArgsSerializer()` without any argument instead. */
-export function getUpdateArgsSerializer(
-  _context: object
-): Serializer<UpdateArgsArgs, UpdateArgs>;
 export function getUpdateArgsSerializer(): Serializer<
   UpdateArgsArgs,
   UpdateArgs
->;
-export function getUpdateArgsSerializer(
-  _context: object = {}
-): Serializer<UpdateArgsArgs, UpdateArgs> {
+> {
   return dataEnum<UpdateArgs>(
     [
       [

--- a/test/packages/js/src/generated/types/useAssetArgs.ts
+++ b/test/packages/js/src/generated/types/useAssetArgs.ts
@@ -19,17 +19,10 @@ export type UseAssetArgs = { __kind: 'V1'; useCount: bigint };
 
 export type UseAssetArgsArgs = { __kind: 'V1'; useCount: number | bigint };
 
-/** @deprecated Use `getUseAssetArgsSerializer()` without any argument instead. */
-export function getUseAssetArgsSerializer(
-  _context: object
-): Serializer<UseAssetArgsArgs, UseAssetArgs>;
 export function getUseAssetArgsSerializer(): Serializer<
   UseAssetArgsArgs,
   UseAssetArgs
->;
-export function getUseAssetArgsSerializer(
-  _context: object = {}
-): Serializer<UseAssetArgsArgs, UseAssetArgs> {
+> {
   return dataEnum<UseAssetArgs>(
     [
       [

--- a/test/packages/js/src/generated/types/useMethod.ts
+++ b/test/packages/js/src/generated/types/useMethod.ts
@@ -16,14 +16,7 @@ export enum UseMethod {
 
 export type UseMethodArgs = UseMethod;
 
-/** @deprecated Use `getUseMethodSerializer()` without any argument instead. */
-export function getUseMethodSerializer(
-  _context: object
-): Serializer<UseMethodArgs, UseMethod>;
-export function getUseMethodSerializer(): Serializer<UseMethodArgs, UseMethod>;
-export function getUseMethodSerializer(
-  _context: object = {}
-): Serializer<UseMethodArgs, UseMethod> {
+export function getUseMethodSerializer(): Serializer<UseMethodArgs, UseMethod> {
   return scalarEnum<UseMethod>(UseMethod, {
     description: 'UseMethod',
   }) as Serializer<UseMethodArgs, UseMethod>;

--- a/test/packages/js/src/generated/types/uses.ts
+++ b/test/packages/js/src/generated/types/uses.ts
@@ -17,12 +17,7 @@ export type UsesArgs = {
   total: number | bigint;
 };
 
-/** @deprecated Use `getUsesSerializer()` without any argument instead. */
-export function getUsesSerializer(_context: object): Serializer<UsesArgs, Uses>;
-export function getUsesSerializer(): Serializer<UsesArgs, Uses>;
-export function getUsesSerializer(
-  _context: object = {}
-): Serializer<UsesArgs, Uses> {
+export function getUsesSerializer(): Serializer<UsesArgs, Uses> {
   return struct<Uses>(
     [
       ['useMethod', getUseMethodSerializer()],

--- a/test/packages/js/src/generated/types/verifyArgs.ts
+++ b/test/packages/js/src/generated/types/verifyArgs.ts
@@ -14,17 +14,10 @@ export enum VerifyArgs {
 
 export type VerifyArgsArgs = VerifyArgs;
 
-/** @deprecated Use `getVerifyArgsSerializer()` without any argument instead. */
-export function getVerifyArgsSerializer(
-  _context: object
-): Serializer<VerifyArgsArgs, VerifyArgs>;
 export function getVerifyArgsSerializer(): Serializer<
   VerifyArgsArgs,
   VerifyArgs
->;
-export function getVerifyArgsSerializer(
-  _context: object = {}
-): Serializer<VerifyArgsArgs, VerifyArgs> {
+> {
   return scalarEnum<VerifyArgs>(VerifyArgs, {
     description: 'VerifyArgs',
   }) as Serializer<VerifyArgsArgs, VerifyArgs>;

--- a/test/packages/js/src/hooked/resolvers.ts
+++ b/test/packages/js/src/hooked/resolvers.ts
@@ -1,7 +1,7 @@
 import { Context } from '@metaplex-foundation/umi';
 import {
   ResolvedAccount,
-  ResolvedAccountsWithIndices,
+  ResolvedAccounts,
   TokenStandard,
   expectPublicKey,
   findMasterEditionV2Pda,
@@ -9,7 +9,7 @@ import {
 
 export const resolveMasterEditionFromTokenStandard = (
   context: Pick<Context, 'eddsa' | 'programs'>,
-  accounts: ResolvedAccountsWithIndices,
+  accounts: ResolvedAccounts,
   args: { tokenStandard?: TokenStandard },
   programId: any,
   isWritable: any

--- a/test/packages/js/src/hooked/resolvers.ts
+++ b/test/packages/js/src/hooked/resolvers.ts
@@ -1,20 +1,16 @@
-import {
-  Context,
-  Pda,
-  PublicKey,
-  Signer,
-  publicKey,
-} from '@metaplex-foundation/umi';
+import { Context } from '@metaplex-foundation/umi';
 import {
   ResolvedAccount,
+  ResolvedAccountsWithIndices,
   TokenStandard,
+  expectPublicKey,
   findMasterEditionV2Pda,
 } from '../generated';
 
 export const resolveMasterEditionFromTokenStandard = (
   context: Pick<Context, 'eddsa' | 'programs'>,
-  accounts: { mint: ResolvedAccount<PublicKey | Pda> },
-  args: { tokenStandard: TokenStandard },
+  accounts: ResolvedAccountsWithIndices,
+  args: { tokenStandard?: TokenStandard },
   programId: any,
   isWritable: any
 ): Partial<ResolvedAccount> => {
@@ -22,7 +18,7 @@ export const resolveMasterEditionFromTokenStandard = (
     args.tokenStandard === TokenStandard.ProgrammableNonFungible
     ? {
         value: findMasterEditionV2Pda(context, {
-          mint: publicKey(accounts.mint.value, false),
+          mint: expectPublicKey(accounts.mint.value),
         }),
       }
     : { value: null };

--- a/test/packages/js/src/hooked/resolvers.ts
+++ b/test/packages/js/src/hooked/resolvers.ts
@@ -6,25 +6,22 @@ import {
   publicKey,
 } from '@metaplex-foundation/umi';
 import {
+  ResolvedAccount,
   TokenStandard,
-  WithWritable,
   findMasterEditionV2Pda,
 } from '../generated';
 
 export const resolveMasterEditionFromTokenStandard = (
   context: Pick<Context, 'eddsa' | 'programs'>,
-  accounts: { mint: WithWritable<PublicKey | Pda | Signer> },
-  args: { tokenStandard: TokenStandard },
-  programId: PublicKey,
-  isWritable: boolean
-): WithWritable<PublicKey | Pda> => {
+  accounts: { mint: ResolvedAccount<PublicKey | Pda | Signer> },
+  args: { tokenStandard: TokenStandard }
+): Partial<ResolvedAccount> => {
   return args.tokenStandard === TokenStandard.NonFungible ||
     args.tokenStandard === TokenStandard.ProgrammableNonFungible
-    ? [
-        findMasterEditionV2Pda(context, {
-          mint: publicKey(accounts.mint[0], false),
+    ? {
+        value: findMasterEditionV2Pda(context, {
+          mint: publicKey(accounts.mint.value, false),
         }),
-        isWritable,
-      ]
-    : [programId, false];
+      }
+    : { value: null };
 };

--- a/test/packages/js/src/hooked/resolvers.ts
+++ b/test/packages/js/src/hooked/resolvers.ts
@@ -13,8 +13,10 @@ import {
 
 export const resolveMasterEditionFromTokenStandard = (
   context: Pick<Context, 'eddsa' | 'programs'>,
-  accounts: { mint: ResolvedAccount<PublicKey | Pda | Signer> },
-  args: { tokenStandard: TokenStandard }
+  accounts: { mint: ResolvedAccount<PublicKey | Pda> },
+  args: { tokenStandard: TokenStandard },
+  programId: any,
+  isWritable: any
 ): Partial<ResolvedAccount> => {
   return args.tokenStandard === TokenStandard.NonFungible ||
     args.tokenStandard === TokenStandard.ProgrammableNonFungible

--- a/test/testFile.cjs
+++ b/test/testFile.cjs
@@ -105,7 +105,6 @@ kinobi.update(
         bar: {
           defaultsTo: k.programIdDefault(),
           isOptional: true,
-          isOptionalStrategy: 'programId',
         },
         delegateRecord: {
           defaultsTo: k.pdaDefault('delegateRecord', {


### PR DESCRIPTION
- Refactor instruction input resolution so it's more intuitive and easier to maintain
- More `isOptionalStrategy` from `instructionAccountNode` to `instructionNode` as `optionalAccountStrategy`
- Remove `programId` account default when `optionalAccountStrategy` is `programId` already
- Remove deprecated signatures in JS renderer