### PR TITLE
Switch to use error traits

### DIFF
--- a/.changeset/eight-moons-bathe.md
+++ b/.changeset/eight-moons-bathe.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Switch to use error traits

--- a/src/renderers/rust/templates/errorsPage.njk
+++ b/src/renderers/rust/templates/errorsPage.njk
@@ -2,15 +2,22 @@
 
 {% block main %}
 
-use spl_program_error::*;
+use num_derive::FromPrimitive;
+use thiserror::Error;
 
-#[spl_program_error]
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum {{ program.name | pascalCase }}Error {
 {% for error in errors | sort(false, false, 'code') %}
     /// 0x{{ error.code.toString(16) | upper }} - {{ error.message }}
     #[error("{{ error.message }}")]
     {{ error.name | pascalCase }},
 {% endfor %}
+}
+
+impl solana_program::program_error::PrintProgramError for {{ program.name | pascalCase }}Error {
+    fn print<E>(&self) {
+        solana_program::msg!(&self.to_string());
+    }
 }
 
 {% endblock %}

--- a/test/packages/rust/Cargo.lock
+++ b/test/packages/rust/Cargo.lock
@@ -180,9 +180,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "bincode"
@@ -710,8 +710,10 @@ version = "0.1.0"
 dependencies = [
  "borsh 0.10.3",
  "kaigan",
+ "num-derive",
+ "num-traits",
  "solana-program",
- "spl-program-error",
+ "thiserror",
 ]
 
 [[package]]
@@ -1093,9 +1095,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -1111,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1183,9 +1185,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.9"
+version = "1.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89ed0a4ba426c461866700f082a00d490e4bde6d27d2d88e129acb3fde79054"
+checksum = "a5bea7d4af435e9dea1399e89cb1318d733abae64a5d5982cff6391d9c486a5d"
 dependencies = [
  "ahash 0.8.3",
  "blake3",
@@ -1216,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.9"
+version = "1.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69dd83d2d675cad4ed0f0086a7d0c669dc407213b4bc916555ed329ea93f531"
+checksum = "86c30e992a5ac91b85c07a64bfb5c70e7bf734cb6494289ca59963d03e788e7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1228,16 +1230,16 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.9"
+version = "1.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38a798723409541aae8ddc9b69c4c78b798e6c219e3e526b5bd4280974a5f29"
+checksum = "ad831bc4fa40b061daf6f189c8764e8b1e0e340ea16e189166ef8f6b530c3679"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "array-bytes",
- "base64 0.21.2",
+ "base64 0.21.3",
  "bincode",
  "bitflags",
  "blake3",
@@ -1283,38 +1285,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.9"
+version = "1.16.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e5a8c7e9e91c7d35f24ffd47a04221f76edb9aba968d79ee10e1cb26f16d2f"
+checksum = "691874c5e3ca1cc172421b8266b1bf96bfdb6d7e2685543e7604aa4de2fd07f3"
 dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af92f74cd3b0fdfda59fef4b571a92123e4df0f67cc43f73163975d31118ef82"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-program-error-derive",
- "thiserror",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173f3cc506847882189b3a5b67299f617fed2f9730f122dd197b82e1e213dee5"
-dependencies = [
- "proc-macro2",
- "quote",
  "syn 2.0.29",
 ]
 

--- a/test/packages/rust/Cargo.toml
+++ b/test/packages/rust/Cargo.toml
@@ -7,8 +7,10 @@ publish = false
 [dependencies]
 borsh = ">= 0.9"
 kaigan = ">= 0.1"
-solana-program = "^1.14"
-spl-program-error = ">= 0.1.0"
+num-derive = "^0.3"
+num-traits = "^0.2"
+solana-program = "^1.10"
+thiserror = "^1.0"
 
 [lib]
 crate-type = ["lib"]

--- a/test/packages/rust/src/generated/errors/mpl_candy_machine_core.rs
+++ b/test/packages/rust/src/generated/errors/mpl_candy_machine_core.rs
@@ -5,9 +5,10 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use spl_program_error::*;
+use num_derive::FromPrimitive;
+use thiserror::Error;
 
-#[spl_program_error]
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplCandyMachineCoreError {
     /// 0x1770 - Account does not have correct owner
     #[error("Account does not have correct owner")]
@@ -72,4 +73,10 @@ pub enum MplCandyMachineCoreError {
     /// 0x1784 - Not all config lines were added to the candy machine
     #[error("Not all config lines were added to the candy machine")]
     NotFullyLoaded,
+}
+
+impl solana_program::program_error::PrintProgramError for MplCandyMachineCoreError {
+    fn print<E>(&self) {
+        solana_program::msg!(&self.to_string());
+    }
 }

--- a/test/packages/rust/src/generated/errors/mpl_token_auth_rules.rs
+++ b/test/packages/rust/src/generated/errors/mpl_token_auth_rules.rs
@@ -5,9 +5,10 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use spl_program_error::*;
+use num_derive::FromPrimitive;
+use thiserror::Error;
 
-#[spl_program_error]
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplTokenAuthRulesError {
     /// 0x0 - Numerical Overflow
     #[error("Numerical Overflow")]
@@ -54,4 +55,10 @@ pub enum MplTokenAuthRulesError {
     /// 0xE - Borsh Serialization Error
     #[error("Borsh Serialization Error")]
     BorshSerializationError,
+}
+
+impl solana_program::program_error::PrintProgramError for MplTokenAuthRulesError {
+    fn print<E>(&self) {
+        solana_program::msg!(&self.to_string());
+    }
 }

--- a/test/packages/rust/src/generated/errors/mpl_token_metadata.rs
+++ b/test/packages/rust/src/generated/errors/mpl_token_metadata.rs
@@ -5,9 +5,10 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use spl_program_error::*;
+use num_derive::FromPrimitive;
+use thiserror::Error;
 
-#[spl_program_error]
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplTokenMetadataError {
     /// 0x0 - Failed to unpack instruction data
     #[error("Failed to unpack instruction data")]
@@ -466,4 +467,10 @@ pub enum MplTokenMetadataError {
     /// 0x96 - Invalid delegate role for transfer
     #[error("Invalid delegate role for transfer")]
     InvalidDelegateRoleForTransfer,
+}
+
+impl solana_program::program_error::PrintProgramError for MplTokenMetadataError {
+    fn print<E>(&self) {
+        solana_program::msg!(&self.to_string());
+    }
 }


### PR DESCRIPTION
This PR replaces the dependency on `spl-program-error` by deriving directly the traits included. The reason for this is that version `0.1.0`, which supports Solana `1.14`, does not export the dependent libraries.