### PR TITLE
Add serde to accounts and defined types

### DIFF
--- a/.changeset/red-dragons-refuse.md
+++ b/.changeset/red-dragons-refuse.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add serde to accounts and defined types

--- a/src/renderers/rust/GetRustTypeManifestVisitor.ts
+++ b/src/renderers/rust/GetRustTypeManifestVisitor.ts
@@ -329,7 +329,8 @@ export class GetRustTypeManifestVisitor implements Visitor<RustTypeManifest> {
 
     let derive = '';
     if (fieldManifest.type === 'Pubkey') {
-      derive = '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::DisplayFromStr>"))]\n';
+      derive =
+        '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::DisplayFromStr>"))]\n';
     }
 
     return {

--- a/src/renderers/rust/GetRustTypeManifestVisitor.ts
+++ b/src/renderers/rust/GetRustTypeManifestVisitor.ts
@@ -36,7 +36,10 @@ export class GetRustTypeManifestVisitor implements Visitor<RustTypeManifest> {
     this.parentName = null;
     return {
       ...manifest,
-      type: `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n${manifest.type}`,
+      type:
+        '#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n' +
+        '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
+        `${manifest.type}`,
     };
   }
 
@@ -93,9 +96,15 @@ export class GetRustTypeManifestVisitor implements Visitor<RustTypeManifest> {
     }
     return {
       ...manifest,
-      type: `#[derive(${traits.join(', ')})]\n${manifest.type}`,
+      type:
+        `#[derive(${traits.join(', ')})]\n` +
+        '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
+        `${manifest.type}`,
       nestedStructs: manifest.nestedStructs.map(
-        (struct) => `#[derive(${traits.join(', ')})]\n${struct}`
+        (struct) =>
+          `#[derive(${traits.join(', ')})]\n` +
+          '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
+          `${struct}`
       ),
     };
   }
@@ -318,11 +327,16 @@ export class GetRustTypeManifestVisitor implements Visitor<RustTypeManifest> {
     const fieldName = snakeCase(structFieldType.name);
     const docblock = this.createDocblock(structFieldType.docs);
 
+    let derive = '';
+    if (fieldManifest.type === 'Pubkey') {
+      derive = '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::DisplayFromStr>"))]\n';
+    }
+
     return {
       ...fieldManifest,
       type: this.inlineStruct
-        ? `${docblock}${fieldName}: ${fieldManifest.type},`
-        : `${docblock}pub ${fieldName}: ${fieldManifest.type},`,
+        ? `${docblock}${derive}${fieldName}: ${fieldManifest.type},`
+        : `${docblock}${derive}pub ${fieldName}: ${fieldManifest.type},`,
     };
   }
 

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -125,7 +125,8 @@ impl {{ instruction.name | pascalCase }}InstructionData {
 }
 
 {% if hasArgs %}
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct {{ instruction.name | pascalCase }}InstructionArgs {
   {% for arg in instructionArgs %}
     {% if not arg.default %}
@@ -137,6 +138,7 @@ pub struct {{ instruction.name | pascalCase }}InstructionArgs {
 
 {% for nestedStruct in typeManifest.nestedStructs %}
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 {{ nestedStruct }}
 {% endfor %}
 

--- a/test/packages/rust/Cargo.lock
+++ b/test/packages/rust/Cargo.lock
@@ -26,6 +26,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +410,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +447,12 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -513,6 +547,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,10 +628,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
@@ -603,6 +693,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -611,10 +707,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -638,6 +746,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +788,28 @@ dependencies = [
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -689,10 +848,9 @@ dependencies = [
 [[package]]
 name = "kaigan"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ed6e2dabe34b706323b7243e4411a16f77161bffbe19748cd7ae2c6918c7b2"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
 ]
 
 [[package]]
@@ -712,6 +870,8 @@ dependencies = [
  "kaigan",
  "num-derive",
  "num-traits",
+ "serde",
+ "serde_with",
  "solana-program",
  "thiserror",
 ]
@@ -1134,6 +1294,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+dependencies = [
+ "base64 0.21.3",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1537,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.29",
+]
+
+[[package]]
+name = "time"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+dependencies = [
+ "deranged",
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1488,6 +1711,15 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/test/packages/rust/Cargo.toml
+++ b/test/packages/rust/Cargo.toml
@@ -4,13 +4,18 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[dependencies]
-borsh = ">= 0.9"
-kaigan = ">= 0.1"
-num-derive = "^0.3"
-num-traits = "^0.2"
-solana-program = "^1.10"
-thiserror = "^1.0"
-
 [lib]
 crate-type = ["lib"]
+
+[features]
+serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
+
+[dependencies]
+borsh = ">= 0.9"
+kaigan = { version = ">= 0.1" }
+num-derive = "^0.3"
+num-traits = "^0.2"
+serde = { version = "^1.0", features = ["derive"], optional = true }
+serde_with = { version = "^3.0", optional = true }
+solana-program = "^1.14"
+thiserror = "^1.0"

--- a/test/packages/rust/Cargo.toml
+++ b/test/packages/rust/Cargo.toml
@@ -12,7 +12,7 @@ serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]
 borsh = ">= 0.9"
-kaigan = { version = ">= 0.1" }
+kaigan = ">= 0.1"
 num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -13,15 +13,28 @@ use solana_program::pubkey::Pubkey;
 /// Candy machine state and config data.
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CandyMachine {
     pub discriminator: [u8; 8],
     /// Features versioning flags.
     pub features: u64,
     /// Authority address.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub authority: Pubkey,
     /// Authority address allowed to mint from the candy machine.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub mint_authority: Pubkey,
     /// The collection mint for the candy machine.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub collection_mint: Pubkey,
     /// Number of assets redeemed.
     pub items_redeemed: u64,

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -11,6 +11,7 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CollectionAuthorityRecord {
     pub key: TmKey,
     pub bump: u8,

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -11,6 +11,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DelegateRecord {
     pub key: TmKey,
     pub role: DelegateRole,

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -11,8 +11,13 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Edition {
     pub key: TmKey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub parent: Pubkey,
     pub edition: u64,
 }

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EditionMarker {
     pub key: TmKey,
     pub ledger: [u8; 31],

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FrequencyAccount {
     /// Test with only one line.
     pub key: u64,

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -12,11 +12,20 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MasterEditionV1 {
     pub key: TmKey,
     pub supply: u64,
     pub max_supply: Option<u64>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub printing_mint: Pubkey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub one_time_printing_authorization_mint: Pubkey,
 }
 

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -11,6 +11,7 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MasterEditionV2 {
     pub key: TmKey,
     pub supply: u64,

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -18,9 +18,18 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Metadata {
     pub key: TmKey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub update_authority: Pubkey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub mint: Pubkey,
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -12,8 +12,13 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReservationListV1 {
     pub key: TmKey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub master_edition: Pubkey,
     pub supply_snapshot: Option<u64>,
     pub reservations: Vec<ReservationV1>,

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -12,8 +12,13 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReservationListV2 {
     pub key: TmKey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub master_edition: Pubkey,
     pub supply_snapshot: Option<u64>,
     pub reservations: Vec<Reservation>,

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -12,8 +12,13 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TokenOwnedEscrow {
     pub key: TmKey,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub base_token: Pubkey,
     pub authority: EscrowAuthority,
     pub bump: u8,

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseAuthorityRecord {
     pub key: TmKey,
     pub allowed_uses: u64,

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -56,7 +56,8 @@ impl AddConfigLinesInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddConfigLinesInstructionArgs {
     pub index: u32,
     pub config_lines: Vec<ConfigLine>,

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -112,7 +112,8 @@ impl ApproveUseAuthorityInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ApproveUseAuthorityInstructionArgs {
     pub number_of_uses: u64,
 }

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -82,7 +82,8 @@ impl BubblegumSetCollectionSizeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BubblegumSetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -116,7 +116,8 @@ impl BurnInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BurnInstructionArgs {
     pub burn_args: BurnArgs,
 }

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -61,7 +61,8 @@ impl CreateFrequencyRuleInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateFrequencyRuleInstructionArgs {
     pub rule_set_name: String,
     pub freq_rule_name: String,

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -96,7 +96,8 @@ impl CreateMasterEditionInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -103,7 +103,8 @@ impl CreateMasterEditionV3InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMasterEditionV3InstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -84,7 +84,8 @@ impl CreateMetadataAccountInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountInstructionArgs {
     pub data: CreateMetadataAccountInstructionDataData,
     pub is_mutable: bool,
@@ -92,6 +93,7 @@ pub struct CreateMetadataAccountInstructionArgs {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountInstructionDataData {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -91,7 +91,8 @@ impl CreateMetadataAccountV2InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountV2InstructionArgs {
     pub data: DataV2,
     pub is_mutable: bool,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -92,7 +92,8 @@ impl CreateMetadataAccountV3InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountV3InstructionArgs {
     pub data: DataV2,
     pub is_mutable: bool,

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -60,7 +60,8 @@ impl CreateRuleSetInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRuleSetInstructionArgs {
     pub create_args: TaCreateArgs,
     pub rule_set_bump: u8,

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -107,7 +107,8 @@ impl CreateV1InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateV1InstructionArgs {
     pub asset_data: AssetData,
     pub decimals: Option<u8>,

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -107,7 +107,8 @@ impl CreateV2InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateV2InstructionArgs {
     pub asset_data: AssetData,
     pub max_supply: Option<u64>,

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -151,7 +151,8 @@ impl DelegateInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DelegateInstructionArgs {
     pub delegate_args: DelegateArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -120,7 +120,8 @@ impl DeprecatedCreateMasterEditionInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedCreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -86,7 +86,8 @@ impl DeprecatedMintPrintingTokensInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedMintPrintingTokensInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -97,7 +97,8 @@ impl DeprecatedMintPrintingTokensViaTokenInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -63,7 +63,8 @@ impl DeprecatedSetReservationListInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedSetReservationListInstructionArgs {
     pub reservations: Vec<Reservation>,
     pub total_reservation_spots: Option<u64>,

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -109,7 +109,8 @@ impl InitializeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeInstructionArgs {
     pub data: CandyMachineData,
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -109,7 +109,8 @@ impl MigrateInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MigrateInstructionArgs {
     pub migrate_args: MigrateArgs,
 }

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -133,7 +133,8 @@ impl MintInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintInstructionArgs {
     pub mint_args: MintArgs,
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -134,7 +134,8 @@ impl MintNewEditionFromMasterEditionViaTokenInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:
         MintNewEditionFromMasterEditionViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -151,7 +151,8 @@ impl MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:
         MintNewEditionFromMasterEditionViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -151,7 +151,8 @@ impl RevokeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RevokeInstructionArgs {
     pub revoke_args: RevokeArgs,
 }

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -56,7 +56,8 @@ impl SetAuthorityInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAuthorityInstructionArgs {
     pub new_authority: Pubkey,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -76,7 +76,8 @@ impl SetCollectionSizeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -159,7 +159,8 @@ impl TransferInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferInstructionArgs {
     pub transfer_args: TransferArgs,
 }

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -127,7 +127,8 @@ impl TransferOutOfEscrowInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferOutOfEscrowInstructionArgs {
     pub amount: u64,
 }

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -58,7 +58,8 @@ impl UpdateCandyMachineInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateCandyMachineInstructionArgs {
     pub data: CandyMachineData,
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -58,7 +58,8 @@ impl UpdateMetadataAccountInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateMetadataAccountInstructionArgs {
     pub data: Option<UpdateMetadataAccountInstructionDataData>,
     pub update_authority_arg: Option<Pubkey>,
@@ -66,6 +67,7 @@ pub struct UpdateMetadataAccountInstructionArgs {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateMetadataAccountInstructionDataData {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -58,7 +58,8 @@ impl UpdateMetadataAccountV2InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateMetadataAccountV2InstructionArgs {
     pub data: Option<DataV2>,
     pub update_authority_arg: Option<Pubkey>,

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -149,7 +149,8 @@ impl UpdateV1InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateV1InstructionArgs {
     pub authorization_data: Option<AuthorizationData>,
     pub new_update_authority: Option<Pubkey>,
@@ -166,6 +167,7 @@ pub struct UpdateV1InstructionArgs {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateV1InstructionDataData {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -128,7 +128,8 @@ impl UseAssetInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseAssetInstructionArgs {
     pub use_asset_args: UseAssetArgs,
 }

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -118,7 +118,8 @@ impl UtilizeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UtilizeInstructionArgs {
     pub number_of_uses: u64,
 }

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -141,7 +141,8 @@ impl ValidateInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidateInstructionArgs {
     pub rule_set_name: String,
     pub operation: Operation,

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -86,7 +86,8 @@ impl VerifyInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerifyInstructionArgs {
     pub verify_args: VerifyArgs,
 }

--- a/test/packages/rust/src/generated/types/asset_data.rs
+++ b/test/packages/rust/src/generated/types/asset_data.rs
@@ -17,7 +17,12 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AssetData {
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub update_authority: Pubkey,
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/authority_type.rs
+++ b/test/packages/rust/src/generated/types/authority_type.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AuthorityType {
     Metadata,
     Delegate,

--- a/test/packages/rust/src/generated/types/authorization_data.rs
+++ b/test/packages/rust/src/generated/types/authorization_data.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthorizationData {
     pub payload: Payload,
 }

--- a/test/packages/rust/src/generated/types/burn_args.rs
+++ b/test/packages/rust/src/generated/types/burn_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BurnArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/candy_machine_data.rs
+++ b/test/packages/rust/src/generated/types/candy_machine_data.rs
@@ -13,6 +13,7 @@ use borsh::BorshSerialize;
 
 /// Candy machine configuration data.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CandyMachineData {
     /// Number of assets available
     pub items_available: u64,

--- a/test/packages/rust/src/generated/types/cm_creator.rs
+++ b/test/packages/rust/src/generated/types/cm_creator.rs
@@ -10,8 +10,13 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CmCreator {
     /// Pubkey address
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub address: Pubkey,
     /// Whether the creator is verified or not
     pub verified: bool,

--- a/test/packages/rust/src/generated/types/collection.rs
+++ b/test/packages/rust/src/generated/types/collection.rs
@@ -10,7 +10,12 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Collection {
     pub verified: bool,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub key: Pubkey,
 }

--- a/test/packages/rust/src/generated/types/collection_details.rs
+++ b/test/packages/rust/src/generated/types/collection_details.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CollectionDetails {
     V1 { size: u64 },
 }

--- a/test/packages/rust/src/generated/types/config_line.rs
+++ b/test/packages/rust/src/generated/types/config_line.rs
@@ -10,6 +10,7 @@ use borsh::BorshSerialize;
 
 /// Config line struct for storing asset (NFT) data pre-mint.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigLine {
     /// Name of the asset.
     pub name: String,

--- a/test/packages/rust/src/generated/types/config_line_settings.rs
+++ b/test/packages/rust/src/generated/types/config_line_settings.rs
@@ -10,6 +10,7 @@ use borsh::BorshSerialize;
 
 /// Config line settings to allocate space for individual name + URI.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigLineSettings {
     /// Common name prefix
     pub prefix_name: String,

--- a/test/packages/rust/src/generated/types/create_master_edition_args.rs
+++ b/test/packages/rust/src/generated/types/create_master_edition_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMasterEditionArgs {
     pub max_supply: Option<u64>,
 }

--- a/test/packages/rust/src/generated/types/creator.rs
+++ b/test/packages/rust/src/generated/types/creator.rs
@@ -10,7 +10,12 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Creator {
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub address: Pubkey,
     pub verified: bool,
     pub share: u8,

--- a/test/packages/rust/src/generated/types/data_v2.rs
+++ b/test/packages/rust/src/generated/types/data_v2.rs
@@ -12,6 +12,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DataV2 {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/delegate_args.rs
+++ b/test/packages/rust/src/generated/types/delegate_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DelegateArgs {
     CollectionV1,
     SaleV1 { amount: u64 },

--- a/test/packages/rust/src/generated/types/delegate_role.rs
+++ b/test/packages/rust/src/generated/types/delegate_role.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DelegateRole {
     Authority,
     Collection,

--- a/test/packages/rust/src/generated/types/delegate_state.rs
+++ b/test/packages/rust/src/generated/types/delegate_state.rs
@@ -11,8 +11,13 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DelegateState {
     pub role: DelegateRole,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub delegate: Pubkey,
     pub has_data: bool,
 }

--- a/test/packages/rust/src/generated/types/dummy_lines.rs
+++ b/test/packages/rust/src/generated/types/dummy_lines.rs
@@ -12,6 +12,7 @@ use kaigan::types::RemainderVec;
 
 /// Dummy lines.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DummyLines {
     /// The dummy lines.
     pub lines: RemainderVec<ConfigLine>,

--- a/test/packages/rust/src/generated/types/escrow_authority.rs
+++ b/test/packages/rust/src/generated/types/escrow_authority.rs
@@ -10,6 +10,7 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum EscrowAuthority {
     TokenOwner,
     Creator(Pubkey),

--- a/test/packages/rust/src/generated/types/extended_payload.rs
+++ b/test/packages/rust/src/generated/types/extended_payload.rs
@@ -12,6 +12,7 @@ use borsh::BorshSerialize;
 use std::collections::HashMap;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtendedPayload {
     pub map: HashMap<PayloadKey, PayloadType>,
     pub args: (u8, String),

--- a/test/packages/rust/src/generated/types/hidden_settings.rs
+++ b/test/packages/rust/src/generated/types/hidden_settings.rs
@@ -10,6 +10,7 @@ use borsh::BorshSerialize;
 
 /// Hidden settings for large mints used with off-chain data.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HiddenSettings {
     /// Asset prefix name
     pub name: String,

--- a/test/packages/rust/src/generated/types/migrate_args.rs
+++ b/test/packages/rust/src/generated/types/migrate_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MigrateArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/mint_args.rs
+++ b/test/packages/rust/src/generated/types/mint_args.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MintArgs {
     V1 {
         amount: u64,

--- a/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintNewEditionFromMasterEditionViaTokenArgs {
     pub edition: u64,
 }

--- a/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintPrintingTokensViaTokenArgs {
     pub supply: u64,
 }

--- a/test/packages/rust/src/generated/types/operation.rs
+++ b/test/packages/rust/src/generated/types/operation.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Operation {
     Transfer,
     Delegate,

--- a/test/packages/rust/src/generated/types/payload.rs
+++ b/test/packages/rust/src/generated/types/payload.rs
@@ -12,6 +12,7 @@ use borsh::BorshSerialize;
 use std::collections::HashMap;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Payload {
     pub map: HashMap<PayloadKey, PayloadType>,
 }

--- a/test/packages/rust/src/generated/types/payload_key.rs
+++ b/test/packages/rust/src/generated/types/payload_key.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PayloadKey {
     Target,
     Holder,

--- a/test/packages/rust/src/generated/types/payload_type.rs
+++ b/test/packages/rust/src/generated/types/payload_type.rs
@@ -11,6 +11,7 @@ use solana_program::pubkey::Pubkey;
 
 /// This is a union of all the possible payload types.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PayloadType {
     Pubkey(Pubkey),
     Seeds {

--- a/test/packages/rust/src/generated/types/programmable_config.rs
+++ b/test/packages/rust/src/generated/types/programmable_config.rs
@@ -10,6 +10,11 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProgrammableConfig {
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub rule_set: Pubkey,
 }

--- a/test/packages/rust/src/generated/types/reservation.rs
+++ b/test/packages/rust/src/generated/types/reservation.rs
@@ -10,7 +10,12 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Reservation {
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub address: Pubkey,
     pub spots_remaining: u64,
     pub total_spots: u64,

--- a/test/packages/rust/src/generated/types/reservation_list_v1_account_data.rs
+++ b/test/packages/rust/src/generated/types/reservation_list_v1_account_data.rs
@@ -12,8 +12,10 @@ use borsh::BorshSerialize;
 use borsh::BorshDeserialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReservationListV1AccountData {
 pub key: TmKey,
+#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::DisplayFromStr>"))]
 pub master_edition: Pubkey,
 pub supply_snapshot: Option<u64>,
 pub reservations: Vec<ReservationV1>,

--- a/test/packages/rust/src/generated/types/reservation_v1.rs
+++ b/test/packages/rust/src/generated/types/reservation_v1.rs
@@ -10,7 +10,12 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReservationV1 {
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
     pub address: Pubkey,
     pub spots_remaining: u8,
     pub total_spots: u8,

--- a/test/packages/rust/src/generated/types/revoke_args.rs
+++ b/test/packages/rust/src/generated/types/revoke_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum RevokeArgs {
     CollectionV1,
     TransferV1,

--- a/test/packages/rust/src/generated/types/set_collection_size_args.rs
+++ b/test/packages/rust/src/generated/types/set_collection_size_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCollectionSizeArgs {
     pub size: u64,
 }

--- a/test/packages/rust/src/generated/types/ta_create_args.rs
+++ b/test/packages/rust/src/generated/types/ta_create_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TaCreateArgs {
     pub rule_set_name: String,
     pub serialized_rule_set: Vec<u8>,

--- a/test/packages/rust/src/generated/types/ta_key.rs
+++ b/test/packages/rust/src/generated/types/ta_key.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TaKey {
     Uninitialized,
     Frequency,

--- a/test/packages/rust/src/generated/types/tm_create_args.rs
+++ b/test/packages/rust/src/generated/types/tm_create_args.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TmCreateArgs {
     V1 {
         asset_data: AssetData,

--- a/test/packages/rust/src/generated/types/tm_key.rs
+++ b/test/packages/rust/src/generated/types/tm_key.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TmKey {
     Uninitialized,
     EditionV1,

--- a/test/packages/rust/src/generated/types/token_standard.rs
+++ b/test/packages/rust/src/generated/types/token_standard.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TokenStandard {
     NonFungible,
     FungibleAsset,

--- a/test/packages/rust/src/generated/types/transfer_args.rs
+++ b/test/packages/rust/src/generated/types/transfer_args.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum TransferArgs {
     V1 {
         authorization_data: Option<AuthorizationData>,

--- a/test/packages/rust/src/generated/types/update_args.rs
+++ b/test/packages/rust/src/generated/types/update_args.rs
@@ -19,6 +19,7 @@ use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UpdateArgs {
     V1 {
         authorization_data: Option<AuthorizationData>,
@@ -37,6 +38,7 @@ pub enum UpdateArgs {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateArgsV1Data {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/use_asset_args.rs
+++ b/test/packages/rust/src/generated/types/use_asset_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UseAssetArgs {
     V1 { use_count: u64 },
 }

--- a/test/packages/rust/src/generated/types/use_method.rs
+++ b/test/packages/rust/src/generated/types/use_method.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum UseMethod {
     Burn,
     Multiple,

--- a/test/packages/rust/src/generated/types/uses.rs
+++ b/test/packages/rust/src/generated/types/uses.rs
@@ -10,6 +10,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Uses {
     pub use_method: UseMethod,
     pub remaining: u64,

--- a/test/packages/rust/src/generated/types/verify_args.rs
+++ b/test/packages/rust/src/generated/types/verify_args.rs
@@ -9,6 +9,7 @@ use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum VerifyArgs {
     V1,
 }


### PR DESCRIPTION
This PR adds `serde` and `serde_with` derives for account and defined types. These are "gated" by a `serde` feature flag.