### PR TITLE
Add doc to default accounts

### DIFF
--- a/.changeset/friendly-candles-relate.md
+++ b/.changeset/friendly-candles-relate.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add doc to default accounts

--- a/src/renderers/rust/templates/instructionsPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsPageBuilder.njk
@@ -20,7 +20,9 @@ impl {{ instruction.name | pascalCase }}Builder {
     Self::default()
   }
   {% for account in instruction.accounts %}
-    {{'/// `[optional account]`\n' if account.isOptional }}
+    {{'/// `[optional account]`\n' if account.isOptional -}}
+    {{"/// `[optional account, default to '" + account.defaultsTo.program.publicKey + "']`\n" if account.defaultsTo.kind === 'program' -}}
+    {{"/// `[optional account, default to '" + account.defaultsTo.publicKey + "']`\n" if account.defaultsTo.kind === 'publicKey' -}}
     {{- macros.docblock(account.docs) -}}
     #[inline(always)]
     pub fn {{ account.name | snakeCase }}(&mut self, {{ account.name | snakeCase }}: solana_program::pubkey::Pubkey{{ ', as_signer: bool' if account.isSigner === 'either' }}) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -153,6 +153,7 @@ impl ApproveCollectionAuthorityBuilder {
         self.mint = Some(mint);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -193,12 +193,14 @@ impl ApproveUseAuthorityBuilder {
         self.burner = Some(burner);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -174,6 +174,7 @@ impl BurnBuilder {
         self.master_edition_account = Some(master_edition_account);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token Program
     #[inline(always)]
     pub fn spl_token_program(

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -190,6 +190,7 @@ impl BurnEditionNftBuilder {
         self.edition_marker_account = Some(edition_marker_account);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token Program
     #[inline(always)]
     pub fn spl_token_program(

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -133,6 +133,7 @@ impl BurnNftBuilder {
         self.master_edition_account = Some(master_edition_account);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token Program
     #[inline(always)]
     pub fn spl_token_program(

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -138,12 +138,14 @@ impl CloseEscrowAccountBuilder {
         self.payer = Some(payer);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -151,12 +151,14 @@ impl CreateEscrowAccountBuilder {
         self.payer = Some(payer);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -98,6 +98,7 @@ impl CreateFrequencyRuleBuilder {
         self.frequency_pda = Some(frequency_pda);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -160,18 +160,21 @@ impl CreateMasterEditionBuilder {
         self.metadata = Some(metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent info
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -167,12 +167,14 @@ impl CreateMasterEditionV3Builder {
         self.metadata = Some(metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -154,12 +154,14 @@ impl CreateMetadataAccountBuilder {
         self.update_authority = Some(update_authority);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent info
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -149,6 +149,7 @@ impl CreateMetadataAccountV2Builder {
         self.update_authority = Some(update_authority);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -152,6 +152,7 @@ impl CreateMetadataAccountV3Builder {
         self.update_authority = Some(update_authority);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -144,12 +144,14 @@ impl CreateReservationListBuilder {
         self.metadata = Some(metadata);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent info
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -93,6 +93,7 @@ impl CreateRuleSetBuilder {
         self.rule_set_pda = Some(rule_set_pda);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -176,12 +176,14 @@ impl CreateV1Builder {
         self.update_authority = Some(update_authority);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(
@@ -191,6 +193,7 @@ impl CreateV1Builder {
         self.sysvar_instructions = Some(sysvar_instructions);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token program
     #[inline(always)]
     pub fn spl_token_program(

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -174,12 +174,14 @@ impl CreateV2Builder {
         self.update_authority = Some(update_authority);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(
@@ -189,6 +191,7 @@ impl CreateV2Builder {
         self.sysvar_instructions = Some(sysvar_instructions);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token program
     #[inline(always)]
     pub fn spl_token_program(

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -233,12 +233,14 @@ impl DelegateBuilder {
         self.payer = Some(payer);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System Program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -212,18 +212,21 @@ impl DeprecatedCreateMasterEditionBuilder {
         self.payer = Some(payer);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent info
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -245,18 +245,21 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenBuilder {
         self.master_metadata = Some(master_metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent info
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -142,12 +142,14 @@ impl DeprecatedMintPrintingTokensBuilder {
         self.master_edition = Some(master_edition);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -167,12 +167,14 @@ impl DeprecatedMintPrintingTokensViaTokenBuilder {
         self.master_edition = Some(master_edition);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -106,6 +106,7 @@ impl FreezeDelegatedAccountBuilder {
         self.mint = Some(mint);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token Program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -196,6 +196,7 @@ impl InitializeBuilder {
         self.collection_authority_record = Some(collection_authority_record);
         self
     }
+    /// `[optional account, default to 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s']`
     #[inline(always)]
     pub fn token_metadata_program(
         &mut self,
@@ -204,6 +205,7 @@ impl InitializeBuilder {
         self.token_metadata_program = Some(token_metadata_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -177,18 +177,21 @@ impl MigrateBuilder {
         self.collection_metadata = Some(collection_metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token Program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instruction sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -198,12 +198,14 @@ impl MintBuilder {
         self.authority = Some(authority);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(
@@ -213,6 +215,7 @@ impl MintBuilder {
         self.sysvar_instructions = Some(sysvar_instructions);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token program
     #[inline(always)]
     pub fn spl_token_program(
@@ -222,6 +225,7 @@ impl MintBuilder {
         self.spl_token_program = Some(spl_token_program);
         self
     }
+    /// `[optional account, default to 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL']`
     /// SPL Associated Token Account program
     #[inline(always)]
     pub fn spl_ata_program(

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -253,6 +253,7 @@ impl MintFromCandyMachineBuilder {
         self.collection_update_authority = Some(collection_update_authority);
         self
     }
+    /// `[optional account, default to 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s']`
     #[inline(always)]
     pub fn token_metadata_program(
         &mut self,
@@ -261,11 +262,13 @@ impl MintFromCandyMachineBuilder {
         self.token_metadata_program = Some(token_metadata_program);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -244,12 +244,14 @@ impl MintNewEditionFromMasterEditionViaTokenBuilder {
         self.metadata = Some(metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -282,6 +282,7 @@ impl MintNewEditionFromMasterEditionViaVaultProxyBuilder {
         self.metadata = Some(metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
@@ -297,6 +298,7 @@ impl MintNewEditionFromMasterEditionViaVaultProxyBuilder {
         self.token_vault_program = Some(token_vault_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -233,12 +233,14 @@ impl RevokeBuilder {
         self.payer = Some(payer);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System Program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -156,12 +156,14 @@ impl RevokeUseAuthorityBuilder {
         self.metadata = Some(metadata);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -228,6 +228,7 @@ impl SetCollectionBuilder {
         self.new_collection_authority_record = Some(new_collection_authority_record);
         self
     }
+    /// `[optional account, default to 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s']`
     #[inline(always)]
     pub fn token_metadata_program(
         &mut self,
@@ -236,6 +237,7 @@ impl SetCollectionBuilder {
         self.token_metadata_program = Some(token_metadata_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -106,6 +106,7 @@ impl ThawDelegatedAccountBuilder {
         self.mint = Some(mint);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token Program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -252,6 +252,7 @@ impl TransferBuilder {
         self.master_edition = Some(master_edition);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token Program
     #[inline(always)]
     pub fn spl_token_program(
@@ -261,6 +262,7 @@ impl TransferBuilder {
         self.spl_token_program = Some(spl_token_program);
         self
     }
+    /// `[optional account, default to 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL']`
     /// SPL Associated Token Account program
     #[inline(always)]
     pub fn spl_ata_program(
@@ -270,12 +272,14 @@ impl TransferBuilder {
         self.spl_ata_program = Some(spl_ata_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System Program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -204,24 +204,28 @@ impl TransferOutOfEscrowBuilder {
         self.escrow_account = Some(escrow_account);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL']`
     /// Associated Token program
     #[inline(always)]
     pub fn ata_program(&mut self, ata_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.ata_program = Some(ata_program);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// Instructions sysvar account
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -232,12 +232,14 @@ impl UpdateV1Builder {
         self.mint = Some(mint);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'Sysvar1nstructions1111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn sysvar_instructions(

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -185,6 +185,7 @@ impl UseAssetBuilder {
         self.owner = Some(owner);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// SPL Token program
     #[inline(always)]
     pub fn spl_token_program(
@@ -194,12 +195,14 @@ impl UseAssetBuilder {
         self.spl_token_program = Some(spl_token_program);
         self
     }
+    /// `[optional account, default to 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL']`
     /// Associated Token program
     #[inline(always)]
     pub fn ata_program(&mut self, ata_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.ata_program = Some(ata_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -175,24 +175,28 @@ impl UtilizeBuilder {
         self.owner = Some(owner);
         self
     }
+    /// `[optional account, default to 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA']`
     /// Token program
     #[inline(always)]
     pub fn token_program(&mut self, token_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.token_program = Some(token_program);
         self
     }
+    /// `[optional account, default to 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL']`
     /// Associated Token program
     #[inline(always)]
     pub fn ata_program(&mut self, ata_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.ata_program = Some(ata_program);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {
         self.system_program = Some(system_program);
         self
     }
+    /// `[optional account, default to 'SysvarRent111111111111111111111111111111111']`
     /// Rent info
     #[inline(always)]
     pub fn rent(&mut self, rent: solana_program::pubkey::Pubkey) -> &mut Self {

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -186,6 +186,7 @@ impl ValidateBuilder {
         self.rule_set = Some(rule_set);
         self
     }
+    /// `[optional account, default to '11111111111111111111111111111111']`
     /// System program
     #[inline(always)]
     pub fn system_program(&mut self, system_program: solana_program::pubkey::Pubkey) -> &mut Self {


### PR DESCRIPTION
This PR adds doc tags on instruction builders to accounts with default values.