### PR TITLE
Add bytes helper to account types on Rust client

### DIFF
--- a/.changeset/blue-zebras-wink.md
+++ b/.changeset/blue-zebras-wink.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add bytes helper to account types on the Rust client

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -77,6 +77,7 @@ impl {{ account.name | pascalCase }} {
     }
   {% endif %}
 
+  #[inline(always)]
   pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
     let mut data = data;
     Self::deserialize(&mut data)

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -12,41 +12,12 @@
 {{ nestedStruct }}
 {% endfor %}
 
-{% if account.size != null or seeds.length > 0 %}
 impl {{ account.name | pascalCase }} {
   {% if account.size != null %}
     pub const LEN: usize = {{ account.size }};
   {% endif %}
 
   {% if seeds.length > 0 %}
-    pub fn find_pda(
-    {% if hasVariableSeeds %}
-        {% for seed in seeds %}
-          {% if seed.kind == 'variable' and seed.type.kind == 'publicKeyTypeNode' %}
-            {{ seed.name | snakeCase }}: &{{ seed.typeManifest.type }},
-          {% elif seed.kind === 'variable' %}
-            {{ seed.name | snakeCase }}: {{ seed.typeManifest.type }},
-          {% endif %}
-        {% endfor %}
-    {% endif %}
-    ) -> (solana_program::pubkey::Pubkey, u8) {
-      solana_program::pubkey::Pubkey::find_program_address(
-        &[
-          {% for seed in seeds %}
-            {% if seed.kind === 'programId' %}
-              crate::{{ program.name | snakeCase | upper }}_ID.as_ref(),
-            {% elif seed.kind === 'constant' %}
-              {{ seed.value.render }}.as_bytes(),
-            {% elif seed.kind == 'variable' and seed.type.kind == 'publicKeyTypeNode' %}
-              {{ seed.name | snakeCase }}.as_ref(),
-            {% else %}
-              {{ seed.name | snakeCase }}.to_string().as_ref(),
-            {% endif %}
-          {% endfor %}
-        ],
-        &crate::{{ program.name | snakeCase | upper }}_ID,
-      )
-    }
     pub fn create_pda(
       {% if hasVariableSeeds %}
           {% for seed in seeds %}
@@ -75,9 +46,42 @@ impl {{ account.name | pascalCase }} {
         &crate::{{ program.name | snakeCase | upper }}_ID,
       )
     }
+
+    pub fn find_pda(
+    {% if hasVariableSeeds %}
+        {% for seed in seeds %}
+          {% if seed.kind == 'variable' and seed.type.kind == 'publicKeyTypeNode' %}
+            {{ seed.name | snakeCase }}: &{{ seed.typeManifest.type }},
+          {% elif seed.kind === 'variable' %}
+            {{ seed.name | snakeCase }}: {{ seed.typeManifest.type }},
+          {% endif %}
+        {% endfor %}
+    {% endif %}
+    ) -> (solana_program::pubkey::Pubkey, u8) {
+      solana_program::pubkey::Pubkey::find_program_address(
+        &[
+          {% for seed in seeds %}
+            {% if seed.kind === 'programId' %}
+              crate::{{ program.name | snakeCase | upper }}_ID.as_ref(),
+            {% elif seed.kind === 'constant' %}
+              {{ seed.value.render }}.as_bytes(),
+            {% elif seed.kind == 'variable' and seed.type.kind == 'publicKeyTypeNode' %}
+              {{ seed.name | snakeCase }}.as_ref(),
+            {% else %}
+              {{ seed.name | snakeCase }}.to_string().as_ref(),
+            {% endif %}
+          {% endfor %}
+        ],
+        &crate::{{ program.name | snakeCase | upper }}_ID,
+      )
+    }
   {% endif %}
+
+  pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+    let mut data = data;
+    Self::deserialize(&mut data)
+  }
 }
-{% endif %}
 
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for {{ account.name | pascalCase }} {
   type Error = std::io::Error;

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -42,6 +42,13 @@ pub struct CandyMachine {
     pub data: CandyMachineData,
 }
 
+impl CandyMachine {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
+}
+
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for CandyMachine {
     type Error = std::io::Error;
 

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -43,6 +43,7 @@ pub struct CandyMachine {
 }
 
 impl CandyMachine {
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -18,6 +18,13 @@ pub struct CollectionAuthorityRecord {
     pub update_authority: Option<Pubkey>,
 }
 
+impl CollectionAuthorityRecord {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
+}
+
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for CollectionAuthorityRecord {
     type Error = std::io::Error;
 

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -19,6 +19,7 @@ pub struct CollectionAuthorityRecord {
 }
 
 impl CollectionAuthorityRecord {
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -47,6 +47,7 @@ impl DelegateRecord {
         )
     }
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -21,16 +21,6 @@ pub struct DelegateRecord {
 impl DelegateRecord {
     pub const LEN: usize = 282;
 
-    pub fn find_pda(role: DelegateRole) -> (solana_program::pubkey::Pubkey, u8) {
-        solana_program::pubkey::Pubkey::find_program_address(
-            &[
-                "delegate_record".as_bytes(),
-                crate::MPL_TOKEN_METADATA_ID.as_ref(),
-                role.to_string().as_ref(),
-            ],
-            &crate::MPL_TOKEN_METADATA_ID,
-        )
-    }
     pub fn create_pda(
         role: DelegateRole,
         bump: u8,
@@ -44,6 +34,22 @@ impl DelegateRecord {
             ],
             &crate::MPL_TOKEN_METADATA_ID,
         )
+    }
+
+    pub fn find_pda(role: DelegateRole) -> (solana_program::pubkey::Pubkey, u8) {
+        solana_program::pubkey::Pubkey::find_program_address(
+            &[
+                "delegate_record".as_bytes(),
+                crate::MPL_TOKEN_METADATA_ID.as_ref(),
+                role.to_string().as_ref(),
+            ],
+            &crate::MPL_TOKEN_METADATA_ID,
+        )
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
     }
 }
 

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -24,6 +24,11 @@ pub struct Edition {
 
 impl Edition {
     pub const LEN: usize = 41;
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
 }
 
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for Edition {

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -25,6 +25,7 @@ pub struct Edition {
 impl Edition {
     pub const LEN: usize = 41;
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -19,6 +19,7 @@ pub struct EditionMarker {
 impl EditionMarker {
     pub const LEN: usize = 32;
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -18,6 +18,11 @@ pub struct EditionMarker {
 
 impl EditionMarker {
     pub const LEN: usize = 32;
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
 }
 
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for EditionMarker {

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -22,15 +22,6 @@ pub struct FrequencyAccount {
 impl FrequencyAccount {
     pub const LEN: usize = 24;
 
-    pub fn find_pda() -> (solana_program::pubkey::Pubkey, u8) {
-        solana_program::pubkey::Pubkey::find_program_address(
-            &[
-                "frequency_pda".as_bytes(),
-                crate::MPL_TOKEN_AUTH_RULES_ID.as_ref(),
-            ],
-            &crate::MPL_TOKEN_AUTH_RULES_ID,
-        )
-    }
     pub fn create_pda(
         bump: u8,
     ) -> Result<solana_program::pubkey::Pubkey, solana_program::pubkey::PubkeyError> {
@@ -42,6 +33,21 @@ impl FrequencyAccount {
             ],
             &crate::MPL_TOKEN_AUTH_RULES_ID,
         )
+    }
+
+    pub fn find_pda() -> (solana_program::pubkey::Pubkey, u8) {
+        solana_program::pubkey::Pubkey::find_program_address(
+            &[
+                "frequency_pda".as_bytes(),
+                crate::MPL_TOKEN_AUTH_RULES_ID.as_ref(),
+            ],
+            &crate::MPL_TOKEN_AUTH_RULES_ID,
+        )
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
     }
 }
 

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -45,6 +45,7 @@ impl FrequencyAccount {
         )
     }
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -56,6 +56,7 @@ impl MasterEditionV1 {
         )
     }
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -30,16 +30,6 @@ pub struct MasterEditionV1 {
 }
 
 impl MasterEditionV1 {
-    pub fn find_pda(delegate_role: DelegateRole) -> (solana_program::pubkey::Pubkey, u8) {
-        solana_program::pubkey::Pubkey::find_program_address(
-            &[
-                "metadata".as_bytes(),
-                crate::MPL_TOKEN_METADATA_ID.as_ref(),
-                delegate_role.to_string().as_ref(),
-            ],
-            &crate::MPL_TOKEN_METADATA_ID,
-        )
-    }
     pub fn create_pda(
         delegate_role: DelegateRole,
         bump: u8,
@@ -53,6 +43,22 @@ impl MasterEditionV1 {
             ],
             &crate::MPL_TOKEN_METADATA_ID,
         )
+    }
+
+    pub fn find_pda(delegate_role: DelegateRole) -> (solana_program::pubkey::Pubkey, u8) {
+        solana_program::pubkey::Pubkey::find_program_address(
+            &[
+                "metadata".as_bytes(),
+                crate::MPL_TOKEN_METADATA_ID.as_ref(),
+                delegate_role.to_string().as_ref(),
+            ],
+            &crate::MPL_TOKEN_METADATA_ID,
+        )
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
     }
 }
 

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -21,17 +21,6 @@ pub struct MasterEditionV2 {
 impl MasterEditionV2 {
     pub const LEN: usize = 282;
 
-    pub fn find_pda(mint: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
-        solana_program::pubkey::Pubkey::find_program_address(
-            &[
-                "metadata".as_bytes(),
-                crate::MPL_TOKEN_METADATA_ID.as_ref(),
-                mint.as_ref(),
-                "edition".as_bytes(),
-            ],
-            &crate::MPL_TOKEN_METADATA_ID,
-        )
-    }
     pub fn create_pda(
         mint: Pubkey,
         bump: u8,
@@ -46,6 +35,23 @@ impl MasterEditionV2 {
             ],
             &crate::MPL_TOKEN_METADATA_ID,
         )
+    }
+
+    pub fn find_pda(mint: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
+        solana_program::pubkey::Pubkey::find_program_address(
+            &[
+                "metadata".as_bytes(),
+                crate::MPL_TOKEN_METADATA_ID.as_ref(),
+                mint.as_ref(),
+                "edition".as_bytes(),
+            ],
+            &crate::MPL_TOKEN_METADATA_ID,
+        )
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
     }
 }
 

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -49,6 +49,7 @@ impl MasterEditionV2 {
         )
     }
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -50,16 +50,6 @@ pub struct Metadata {
 impl Metadata {
     pub const LEN: usize = 679;
 
-    pub fn find_pda(mint: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
-        solana_program::pubkey::Pubkey::find_program_address(
-            &[
-                "metadata".as_bytes(),
-                crate::MPL_TOKEN_METADATA_ID.as_ref(),
-                mint.as_ref(),
-            ],
-            &crate::MPL_TOKEN_METADATA_ID,
-        )
-    }
     pub fn create_pda(
         mint: Pubkey,
         bump: u8,
@@ -73,6 +63,22 @@ impl Metadata {
             ],
             &crate::MPL_TOKEN_METADATA_ID,
         )
+    }
+
+    pub fn find_pda(mint: &Pubkey) -> (solana_program::pubkey::Pubkey, u8) {
+        solana_program::pubkey::Pubkey::find_program_address(
+            &[
+                "metadata".as_bytes(),
+                crate::MPL_TOKEN_METADATA_ID.as_ref(),
+                mint.as_ref(),
+            ],
+            &crate::MPL_TOKEN_METADATA_ID,
+        )
+    }
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
     }
 }
 

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -76,6 +76,7 @@ impl Metadata {
         )
     }
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -24,6 +24,13 @@ pub struct ReservationListV1 {
     pub reservations: Vec<ReservationV1>,
 }
 
+impl ReservationListV1 {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
+}
+
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for ReservationListV1 {
     type Error = std::io::Error;
 

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -25,6 +25,7 @@ pub struct ReservationListV1 {
 }
 
 impl ReservationListV1 {
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -26,6 +26,13 @@ pub struct ReservationListV2 {
     pub current_reservation_spots: u64,
 }
 
+impl ReservationListV2 {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
+}
+
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for ReservationListV2 {
     type Error = std::io::Error;
 

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -27,6 +27,7 @@ pub struct ReservationListV2 {
 }
 
 impl ReservationListV2 {
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -24,6 +24,13 @@ pub struct TokenOwnedEscrow {
     pub bump: u8,
 }
 
+impl TokenOwnedEscrow {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
+}
+
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for TokenOwnedEscrow {
     type Error = std::io::Error;
 

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -25,6 +25,7 @@ pub struct TokenOwnedEscrow {
 }
 
 impl TokenOwnedEscrow {
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -19,6 +19,11 @@ pub struct UseAuthorityRecord {
 
 impl UseAuthorityRecord {
     pub const LEN: usize = 10;
+
+    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+        let mut data = data;
+        Self::deserialize(&mut data)
+    }
 }
 
 impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for UseAuthorityRecord {

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -20,6 +20,7 @@ pub struct UseAuthorityRecord {
 impl UseAuthorityRecord {
     pub const LEN: usize = 10;
 
+    #[inline(always)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)


### PR DESCRIPTION
This PR adds a `from_bytes` helper to account types on the Rust client to make is easier to load an account.

Currently, we need to pass a mutable slice to `BorshDeserialize::deserialize(...)`:
```rust
let metadata_account = get_account(&mut context, &metadata).await;
let metadata: Metadata = Metadata::deserialize(&mut &metadata_account.data[..]).unwrap();
```
With the change proposed in this PR, the code is simplified:
```rust
let metadata_account = get_account(&mut context, &metadata).await;
let metadata: Metadata = Metadata::from_bytes(&metadata_account.data).unwrap();
```