### PR TITLE
Separate lifetimes on cpi builder

### DIFF
--- a/.changeset/heavy-tomatoes-marry.md
+++ b/.changeset/heavy-tomatoes-marry.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Separate lifetimes on Rust CPI builders

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -84,10 +84,10 @@ impl {{ account.name | pascalCase }} {
   }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for {{ account.name | pascalCase }} {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for {{ account.name | pascalCase }} {
   type Error = std::io::Error;
 
-  fn try_from(account_info: &'a solana_program::account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
+  fn try_from(account_info: &solana_program::account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
       let mut data: &[u8] = &(*account_info.data).borrow();
       Self::deserialize(&mut data)
   }

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -1,14 +1,14 @@
 /// `{{ instruction.name | snakeCase }}` CPI accounts.
-pub struct {{ instruction.name | pascalCase }}CpiAccounts<'a> {
+pub struct {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b> {
   {% for account in instruction.accounts %}
     {% if account.docs.length > 0 %}
       {{ macros.docblock(account.docs) }}
     {% endif %}
 
     {% if account.isSigner === 'either' %}
-      {% set type = '(&\'a solana_program::account_info::AccountInfo<\'a>, bool)' %}
+      {% set type = '(&\'b solana_program::account_info::AccountInfo<\'a>, bool)' %}
     {% else %}
-      {% set type = '&\'a solana_program::account_info::AccountInfo<\'a>' %}
+      {% set type = '&\'b solana_program::account_info::AccountInfo<\'a>' %}
     {% endif %}
 
     {% if account.isOptional %}
@@ -20,18 +20,18 @@ pub struct {{ instruction.name | pascalCase }}CpiAccounts<'a> {
 }
 
 /// `{{ instruction.name | snakeCase }}` CPI instruction.
-pub struct {{ instruction.name | pascalCase }}Cpi<'a> {
+pub struct {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
   /// The program to invoke.
-  pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+  pub __program: &'b solana_program::account_info::AccountInfo<'a>,
   {% for account in instruction.accounts %}
     {% if account.docs.length > 0 %}
       {{ macros.docblock(account.docs) }}
     {% endif %}
 
     {% if account.isSigner === 'either' %}
-      {% set type = '(&\'a solana_program::account_info::AccountInfo<\'a>, bool)' %}
+      {% set type = '(&\'b solana_program::account_info::AccountInfo<\'a>, bool)' %}
     {% else %}
-      {% set type = '&\'a solana_program::account_info::AccountInfo<\'a>' %}
+      {% set type = '&\'b solana_program::account_info::AccountInfo<\'a>' %}
     {% endif %}
 
     {% if account.isOptional %}
@@ -46,10 +46,10 @@ pub struct {{ instruction.name | pascalCase }}Cpi<'a> {
   {% endif %}
 }
 
-impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
+impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
   pub fn new(
-    program: &'a solana_program::account_info::AccountInfo<'a>,
-    accounts: {{ instruction.name | pascalCase }}CpiAccounts<'a>,
+    program: &'b solana_program::account_info::AccountInfo<'a>,
+    accounts: {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b>,
     {% if hasArgs %}
       args: {{ instruction.name | pascalCase }}InstructionArgs,
     {% endif %}
@@ -69,7 +69,7 @@ impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
     self.invoke_signed_with_remaining_accounts(&[], &[])
   }
   #[inline(always)]
-  pub fn invoke_with_remaining_accounts(&self, remaining_accounts: &[super::InstructionAccountInfo<'a>]) -> solana_program::entrypoint::ProgramResult {
+  pub fn invoke_with_remaining_accounts(&self, remaining_accounts: &[super::InstructionAccountInfo<'a, '_>]) -> solana_program::entrypoint::ProgramResult {
     self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
   }
   #[inline(always)]
@@ -81,7 +81,7 @@ impl<'a> {{ instruction.name | pascalCase }}Cpi<'a> {
   pub fn invoke_signed_with_remaining_accounts(
     &self,
     signers_seeds: &[&[&[u8]]],
-    remaining_accounts: &[super::InstructionAccountInfo<'a>]
+    remaining_accounts: &[super::InstructionAccountInfo<'a, '_>]
   ) -> solana_program::entrypoint::ProgramResult {
     let mut accounts = Vec::with_capacity({{ instruction.accounts.length }} + remaining_accounts.len());
     {% for account in instruction.accounts %}

--- a/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
@@ -1,10 +1,10 @@
 /// `{{ instruction.name | snakeCase }}` CPI instruction builder.
-pub struct {{ instruction.name | pascalCase }}CpiBuilder<'a> {
-  instruction: Box<{{ instruction.name | pascalCase }}CpiBuilderInstruction<'a>>,
+pub struct {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
+  instruction: Box<{{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> {{ instruction.name | pascalCase }}CpiBuilder<'a> {
-  pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
+  pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
     let instruction = Box::new({{ instruction.name | pascalCase }}CpiBuilderInstruction {
       __program: program,
       {% for account in instruction.accounts %}
@@ -23,7 +23,7 @@ impl<'a> {{ instruction.name | pascalCase }}CpiBuilder<'a> {
     {{'/// `[optional account]`\n' if account.isOptional }}
     {{- macros.docblock(account.docs) -}}
     #[inline(always)]
-    pub fn {{ account.name | snakeCase }}(&mut self, {{ account.name | snakeCase }}: {{ "Option<&'a solana_program::account_info::AccountInfo<'a>>" if account.isOptional else "&'a solana_program::account_info::AccountInfo<'a>" }}{{ ', as_signer: bool' if account.isSigner === 'either' }}) -> &mut Self {
+    pub fn {{ account.name | snakeCase }}(&mut self, {{ account.name | snakeCase }}: {{ "Option<&'b solana_program::account_info::AccountInfo<'a>>" if account.isOptional else "&'b solana_program::account_info::AccountInfo<'a>" }}{{ ', as_signer: bool' if account.isSigner === 'either' }}) -> &mut Self {
       {% if account.isOptional %}
         {% if account.isSigner === 'either' %}
           if let Some({{ account.name | snakeCase }}) = {{ account.name | snakeCase }} {
@@ -57,12 +57,12 @@ impl<'a> {{ instruction.name | pascalCase }}CpiBuilder<'a> {
     {% endif %}
   {% endfor %}
   #[inline(always)]
-  pub fn add_remaining_account(&mut self, account: super::InstructionAccountInfo<'a>) -> &mut Self {
+  pub fn add_remaining_account(&mut self, account: super::InstructionAccountInfo<'a,'b>) -> &mut Self {
     self.instruction.__remaining_accounts.push(account);
     self
   }
   #[inline(always)]
-  pub fn add_remaining_accounts(&mut self, accounts: &[super::InstructionAccountInfo<'a>]) -> &mut Self {
+  pub fn add_remaining_accounts(&mut self, accounts: &[super::InstructionAccountInfo<'a, 'b>]) -> &mut Self {
     self.instruction.__remaining_accounts.extend_from_slice(accounts);
     self
   }
@@ -103,13 +103,13 @@ impl<'a> {{ instruction.name | pascalCase }}CpiBuilder<'a> {
   }
 }
 
-struct {{ instruction.name | pascalCase }}CpiBuilderInstruction<'a> {
-  __program: &'a solana_program::account_info::AccountInfo<'a>,
+struct {{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b> {
+  __program: &'b solana_program::account_info::AccountInfo<'a>,
   {% for account in instruction.accounts %}
     {% if account.isSigner === 'either' %}
-      {{ account.name | snakeCase }}: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
+      {{ account.name | snakeCase }}: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
     {% else %}
-      {{ account.name | snakeCase }}: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+      {{ account.name | snakeCase }}: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     {% endif %}
   {% endfor %}
   {% for arg in instructionArgs %}
@@ -117,5 +117,5 @@ struct {{ instruction.name | pascalCase }}CpiBuilderInstruction<'a> {
       {{ arg.name | snakeCase }}: {{ arg.type if arg.innerOptionType else 'Option<' + arg.type + '>' }},
     {% endif %}
   {% endfor %}
-  __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+  __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/src/renderers/rust/templates/instructionsMod.njk
+++ b/src/renderers/rust/templates/instructionsMod.njk
@@ -36,14 +36,14 @@ impl InstructionAccount {
 }
 
 #[derive(Clone, Copy)]
-pub enum InstructionAccountInfo<'a> {
-  Readonly(&'a solana_program::account_info::AccountInfo<'a>),
-  ReadonlySigner(&'a solana_program::account_info::AccountInfo<'a>),
-  Writable(&'a solana_program::account_info::AccountInfo<'a>),
-  WritableSigner(&'a solana_program::account_info::AccountInfo<'a>),
+pub enum InstructionAccountInfo<'a, 'b> {
+  Readonly(&'b solana_program::account_info::AccountInfo<'a>),
+  ReadonlySigner(&'b solana_program::account_info::AccountInfo<'a>),
+  Writable(&'b solana_program::account_info::AccountInfo<'a>),
+  WritableSigner(&'b solana_program::account_info::AccountInfo<'a>),
 }
 
-impl<'a> InstructionAccountInfo<'a> {
+impl<'a, 'b> InstructionAccountInfo<'a, 'b> {
   pub fn to_account_meta(&self) -> solana_program::instruction::AccountMeta {
     let (pubkey, writable, signer) = match self {
       InstructionAccountInfo::Readonly(account_info) => (account_info.key, false, false),
@@ -58,7 +58,7 @@ impl<'a> InstructionAccountInfo<'a> {
       solana_program::instruction::AccountMeta::new_readonly(*pubkey, signer)
     }
   }
-  pub fn account_info(&self) -> &'a solana_program::account_info::AccountInfo<'a> {
+  pub fn account_info(&self) -> &'b solana_program::account_info::AccountInfo<'a> {
     match self {
       InstructionAccountInfo::Readonly(account_info)
         | InstructionAccountInfo::ReadonlySigner(account_info)

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -50,11 +50,11 @@ impl CandyMachine {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for CandyMachine {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for CandyMachine {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -26,11 +26,11 @@ impl CollectionAuthorityRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for CollectionAuthorityRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for CollectionAuthorityRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -54,11 +54,11 @@ impl DelegateRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for DelegateRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for DelegateRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -32,11 +32,11 @@ impl Edition {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for Edition {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Edition {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -26,11 +26,11 @@ impl EditionMarker {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for EditionMarker {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for EditionMarker {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -52,11 +52,11 @@ impl FrequencyAccount {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for FrequencyAccount {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for FrequencyAccount {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -63,11 +63,11 @@ impl MasterEditionV1 {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for MasterEditionV1 {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for MasterEditionV1 {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -56,11 +56,11 @@ impl MasterEditionV2 {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for MasterEditionV2 {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for MasterEditionV2 {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -83,11 +83,11 @@ impl Metadata {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for Metadata {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for Metadata {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -32,11 +32,11 @@ impl ReservationListV1 {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for ReservationListV1 {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for ReservationListV1 {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -34,11 +34,11 @@ impl ReservationListV2 {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for ReservationListV2 {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for ReservationListV2 {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -32,11 +32,11 @@ impl TokenOwnedEscrow {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for TokenOwnedEscrow {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for TokenOwnedEscrow {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -27,11 +27,11 @@ impl UseAuthorityRecord {
     }
 }
 
-impl<'a> TryFrom<&'a solana_program::account_info::AccountInfo<'a>> for UseAuthorityRecord {
+impl<'a> TryFrom<&solana_program::account_info::AccountInfo<'a>> for UseAuthorityRecord {
     type Error = std::io::Error;
 
     fn try_from(
-        account_info: &'a solana_program::account_info::AccountInfo<'a>,
+        account_info: &solana_program::account_info::AccountInfo<'a>,
     ) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
         Self::deserialize(&mut data)

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -133,28 +133,28 @@ impl AddConfigLinesBuilder {
 }
 
 /// `add_config_lines` CPI accounts.
-pub struct AddConfigLinesCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct AddConfigLinesCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `add_config_lines` CPI instruction.
-pub struct AddConfigLinesCpi<'a> {
+pub struct AddConfigLinesCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: AddConfigLinesInstructionArgs,
 }
 
-impl<'a> AddConfigLinesCpi<'a> {
+impl<'a, 'b> AddConfigLinesCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: AddConfigLinesCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: AddConfigLinesCpiAccounts<'a, 'b>,
         args: AddConfigLinesInstructionArgs,
     ) -> Self {
         Self {
@@ -171,7 +171,7 @@ impl<'a> AddConfigLinesCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -187,7 +187,7 @@ impl<'a> AddConfigLinesCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -227,12 +227,12 @@ impl<'a> AddConfigLinesCpi<'a> {
 }
 
 /// `add_config_lines` CPI instruction builder.
-pub struct AddConfigLinesCpiBuilder<'a> {
-    instruction: Box<AddConfigLinesCpiBuilderInstruction<'a>>,
+pub struct AddConfigLinesCpiBuilder<'a, 'b> {
+    instruction: Box<AddConfigLinesCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> AddConfigLinesCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> AddConfigLinesCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(AddConfigLinesCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -246,7 +246,7 @@ impl<'a> AddConfigLinesCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -254,7 +254,7 @@ impl<'a> AddConfigLinesCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -272,7 +272,7 @@ impl<'a> AddConfigLinesCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -280,7 +280,7 @@ impl<'a> AddConfigLinesCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -323,11 +323,11 @@ impl<'a> AddConfigLinesCpiBuilder<'a> {
     }
 }
 
-struct AddConfigLinesCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct AddConfigLinesCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     index: Option<u32>,
     config_lines: Option<Vec<ConfigLine>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -211,51 +211,51 @@ impl ApproveCollectionAuthorityBuilder {
 }
 
 /// `approve_collection_authority` CPI accounts.
-pub struct ApproveCollectionAuthorityCpiAccounts<'a> {
+pub struct ApproveCollectionAuthorityCpiAccounts<'a, 'b> {
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Collection Authority
-    pub new_collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Collection Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `approve_collection_authority` CPI instruction.
-pub struct ApproveCollectionAuthorityCpi<'a> {
+pub struct ApproveCollectionAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Collection Authority
-    pub new_collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Collection Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> ApproveCollectionAuthorityCpi<'a> {
+impl<'a, 'b> ApproveCollectionAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ApproveCollectionAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ApproveCollectionAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -276,7 +276,7 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -292,7 +292,7 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -370,12 +370,12 @@ impl<'a> ApproveCollectionAuthorityCpi<'a> {
 }
 
 /// `approve_collection_authority` CPI instruction builder.
-pub struct ApproveCollectionAuthorityCpiBuilder<'a> {
-    instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a>>,
+pub struct ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ApproveCollectionAuthorityCpiBuilderInstruction {
             __program: program,
             collection_authority_record: None,
@@ -394,7 +394,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -403,7 +403,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_authority(
         &mut self,
-        new_collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_authority = Some(new_collection_authority);
         self
@@ -412,14 +412,14 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -427,14 +427,14 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of Collection Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -442,7 +442,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -452,7 +452,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -460,7 +460,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -468,7 +468,7 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -523,15 +523,15 @@ impl<'a> ApproveCollectionAuthorityCpiBuilder<'a> {
     }
 }
 
-struct ApproveCollectionAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -275,65 +275,65 @@ impl ApproveUseAuthorityBuilder {
 }
 
 /// `approve_use_authority` CPI accounts.
-pub struct ApproveUseAuthorityCpiAccounts<'a> {
+pub struct ApproveUseAuthorityCpiAccounts<'a, 'b> {
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Program As Signer (Burner)
-    pub burner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `approve_use_authority` CPI instruction.
-pub struct ApproveUseAuthorityCpi<'a> {
+pub struct ApproveUseAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Program As Signer (Burner)
-    pub burner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: ApproveUseAuthorityInstructionArgs,
 }
 
-impl<'a> ApproveUseAuthorityCpi<'a> {
+impl<'a, 'b> ApproveUseAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ApproveUseAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ApproveUseAuthorityCpiAccounts<'a, 'b>,
         args: ApproveUseAuthorityInstructionArgs,
     ) -> Self {
         Self {
@@ -359,7 +359,7 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -375,7 +375,7 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -470,12 +470,12 @@ impl<'a> ApproveUseAuthorityCpi<'a> {
 }
 
 /// `approve_use_authority` CPI instruction builder.
-pub struct ApproveUseAuthorityCpiBuilder<'a> {
-    instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a>>,
+pub struct ApproveUseAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ApproveUseAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ApproveUseAuthorityCpiBuilderInstruction {
             __program: program,
             use_authority_record: None,
@@ -498,26 +498,26 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority_record = Some(use_authority_record);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     /// A Use Authority
     #[inline(always)]
-    pub fn user(&mut self, user: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn user(&mut self, user: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.user = Some(user);
         self
     }
@@ -525,7 +525,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn owner_token_account(
         &mut self,
-        owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.owner_token_account = Some(owner_token_account);
         self
@@ -534,14 +534,14 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -549,7 +549,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn burner(
         &mut self,
-        burner: &'a solana_program::account_info::AccountInfo<'a>,
+        burner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.burner = Some(burner);
         self
@@ -558,7 +558,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -567,7 +567,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -577,7 +577,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -590,7 +590,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -598,7 +598,7 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -667,19 +667,19 @@ impl<'a> ApproveUseAuthorityCpiBuilder<'a> {
     }
 }
 
-struct ApproveUseAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    user: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct ApproveUseAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    user: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     number_of_uses: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -203,41 +203,41 @@ impl BubblegumSetCollectionSizeBuilder {
 }
 
 /// `bubblegum_set_collection_size` CPI accounts.
-pub struct BubblegumSetCollectionSizeCpiAccounts<'a> {
+pub struct BubblegumSetCollectionSizeCpiAccounts<'a, 'b> {
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Signing PDA of Bubblegum program
-    pub bubblegum_signer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub bubblegum_signer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `bubblegum_set_collection_size` CPI instruction.
-pub struct BubblegumSetCollectionSizeCpi<'a> {
+pub struct BubblegumSetCollectionSizeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Signing PDA of Bubblegum program
-    pub bubblegum_signer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub bubblegum_signer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: BubblegumSetCollectionSizeInstructionArgs,
 }
 
-impl<'a> BubblegumSetCollectionSizeCpi<'a> {
+impl<'a, 'b> BubblegumSetCollectionSizeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BubblegumSetCollectionSizeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BubblegumSetCollectionSizeCpiAccounts<'a, 'b>,
         args: BubblegumSetCollectionSizeInstructionArgs,
     ) -> Self {
         Self {
@@ -257,7 +257,7 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -273,7 +273,7 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -339,12 +339,12 @@ impl<'a> BubblegumSetCollectionSizeCpi<'a> {
 }
 
 /// `bubblegum_set_collection_size` CPI instruction builder.
-pub struct BubblegumSetCollectionSizeCpiBuilder<'a> {
-    instruction: Box<BubblegumSetCollectionSizeCpiBuilderInstruction<'a>>,
+pub struct BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
+    instruction: Box<BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BubblegumSetCollectionSizeCpiBuilderInstruction {
             __program: program,
             collection_metadata: None,
@@ -361,7 +361,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -370,7 +370,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
@@ -379,7 +379,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -388,7 +388,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn bubblegum_signer(
         &mut self,
-        bubblegum_signer: &'a solana_program::account_info::AccountInfo<'a>,
+        bubblegum_signer: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.bubblegum_signer = Some(bubblegum_signer);
         self
@@ -398,7 +398,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -414,7 +414,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -422,7 +422,7 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -479,13 +479,13 @@ impl<'a> BubblegumSetCollectionSizeCpiBuilder<'a> {
     }
 }
 
-struct BubblegumSetCollectionSizeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    bubblegum_signer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    bubblegum_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     set_collection_size_args: Option<SetCollectionSizeArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -266,57 +266,57 @@ impl BurnBuilder {
 }
 
 /// `burn` CPI accounts.
-pub struct BurnCpiAccounts<'a> {
+pub struct BurnCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition of the asset
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `burn` CPI instruction.
-pub struct BurnCpi<'a> {
+pub struct BurnCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Asset owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition of the asset
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: BurnInstructionArgs,
 }
 
-impl<'a> BurnCpi<'a> {
+impl<'a, 'b> BurnCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BurnCpiAccounts<'a, 'b>,
         args: BurnInstructionArgs,
     ) -> Self {
         Self {
@@ -340,7 +340,7 @@ impl<'a> BurnCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -356,7 +356,7 @@ impl<'a> BurnCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -458,12 +458,12 @@ impl<'a> BurnCpi<'a> {
 }
 
 /// `burn` CPI instruction builder.
-pub struct BurnCpiBuilder<'a> {
-    instruction: Box<BurnCpiBuilderInstruction<'a>>,
+pub struct BurnCpiBuilder<'a, 'b> {
+    instruction: Box<BurnCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BurnCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BurnCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BurnCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -484,20 +484,20 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Asset owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -505,7 +505,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -514,7 +514,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_account(
         &mut self,
-        master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_account = Some(master_edition_account);
         self
@@ -523,7 +523,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -533,7 +533,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -543,7 +543,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -553,7 +553,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -566,7 +566,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -574,7 +574,7 @@ impl<'a> BurnCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -636,17 +636,17 @@ impl<'a> BurnCpiBuilder<'a> {
     }
 }
 
-struct BurnCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct BurnCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     burn_args: Option<BurnArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -256,59 +256,59 @@ impl BurnEditionNftBuilder {
 }
 
 /// `burn_edition_nft` CPI accounts.
-pub struct BurnEditionNftCpiAccounts<'a> {
+pub struct BurnEditionNftCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the print edition NFT
-    pub print_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the original/master NFT
-    pub master_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the print edition NFT is in
-    pub print_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the Master Edition NFT is in
-    pub master_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the original NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Print Edition account of the NFT
-    pub print_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition Marker PDA of the NFT
-    pub edition_marker_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `burn_edition_nft` CPI instruction.
-pub struct BurnEditionNftCpi<'a> {
+pub struct BurnEditionNftCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the print edition NFT
-    pub print_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the original/master NFT
-    pub master_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the print edition NFT is in
-    pub print_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account the Master Edition NFT is in
-    pub master_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the original NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Print Edition account of the NFT
-    pub print_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub print_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition Marker PDA of the NFT
-    pub edition_marker_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> BurnEditionNftCpi<'a> {
+impl<'a, 'b> BurnEditionNftCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnEditionNftCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BurnEditionNftCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -331,7 +331,7 @@ impl<'a> BurnEditionNftCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -347,7 +347,7 @@ impl<'a> BurnEditionNftCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -425,12 +425,12 @@ impl<'a> BurnEditionNftCpi<'a> {
 }
 
 /// `burn_edition_nft` CPI instruction builder.
-pub struct BurnEditionNftCpiBuilder<'a> {
-    instruction: Box<BurnEditionNftCpiBuilderInstruction<'a>>,
+pub struct BurnEditionNftCpiBuilder<'a, 'b> {
+    instruction: Box<BurnEditionNftCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BurnEditionNftCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BurnEditionNftCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BurnEditionNftCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -451,14 +451,14 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// NFT owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
@@ -466,7 +466,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn print_edition_mint(
         &mut self,
-        print_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        print_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.print_edition_mint = Some(print_edition_mint);
         self
@@ -475,7 +475,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_mint(
         &mut self,
-        master_edition_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_mint = Some(master_edition_mint);
         self
@@ -484,7 +484,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn print_edition_token_account(
         &mut self,
-        print_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        print_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.print_edition_token_account = Some(print_edition_token_account);
         self
@@ -493,7 +493,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_token_account(
         &mut self,
-        master_edition_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_token_account = Some(master_edition_token_account);
         self
@@ -502,7 +502,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_account(
         &mut self,
-        master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_account = Some(master_edition_account);
         self
@@ -511,7 +511,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn print_edition_account(
         &mut self,
-        print_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        print_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.print_edition_account = Some(print_edition_account);
         self
@@ -520,7 +520,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_marker_account(
         &mut self,
-        edition_marker_account: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_marker_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_marker_account = Some(edition_marker_account);
         self
@@ -529,7 +529,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -537,7 +537,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -545,7 +545,7 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -616,17 +616,17 @@ impl<'a> BurnEditionNftCpiBuilder<'a> {
     }
 }
 
-struct BurnEditionNftCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    print_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    print_edition_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    print_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_marker_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct BurnEditionNftCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    print_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    print_edition_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    print_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_marker_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -194,47 +194,47 @@ impl BurnNftBuilder {
 }
 
 /// `burn_nft` CPI accounts.
-pub struct BurnNftCpiAccounts<'a> {
+pub struct BurnNftCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the NFT
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `burn_nft` CPI instruction.
-pub struct BurnNftCpi<'a> {
+pub struct BurnNftCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// NFT owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the NFT
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to close
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 of the NFT
-    pub master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata of the Collection
-    pub collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> BurnNftCpi<'a> {
+impl<'a, 'b> BurnNftCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnNftCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: BurnNftCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -254,7 +254,7 @@ impl<'a> BurnNftCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -270,7 +270,7 @@ impl<'a> BurnNftCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -342,12 +342,12 @@ impl<'a> BurnNftCpi<'a> {
 }
 
 /// `burn_nft` CPI instruction builder.
-pub struct BurnNftCpiBuilder<'a> {
-    instruction: Box<BurnNftCpiBuilderInstruction<'a>>,
+pub struct BurnNftCpiBuilder<'a, 'b> {
+    instruction: Box<BurnNftCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> BurnNftCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> BurnNftCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(BurnNftCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -365,20 +365,20 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// NFT owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Mint of the NFT
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -386,7 +386,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -395,7 +395,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition_account(
         &mut self,
-        master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition_account = Some(master_edition_account);
         self
@@ -404,7 +404,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -414,7 +414,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_metadata = collection_metadata;
         self
@@ -422,7 +422,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -430,7 +430,7 @@ impl<'a> BurnNftCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -480,14 +480,14 @@ impl<'a> BurnNftCpiBuilder<'a> {
     }
 }
 
-struct BurnNftCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct BurnNftCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -197,51 +197,51 @@ impl CloseEscrowAccountBuilder {
 }
 
 /// `close_escrow_account` CPI accounts.
-pub struct CloseEscrowAccountCpiAccounts<'a> {
+pub struct CloseEscrowAccountCpiAccounts<'a, 'b> {
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `close_escrow_account` CPI instruction.
-pub struct CloseEscrowAccountCpi<'a> {
+pub struct CloseEscrowAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> CloseEscrowAccountCpi<'a> {
+impl<'a, 'b> CloseEscrowAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CloseEscrowAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CloseEscrowAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -262,7 +262,7 @@ impl<'a> CloseEscrowAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -278,7 +278,7 @@ impl<'a> CloseEscrowAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -348,12 +348,12 @@ impl<'a> CloseEscrowAccountCpi<'a> {
 }
 
 /// `close_escrow_account` CPI instruction builder.
-pub struct CloseEscrowAccountCpiBuilder<'a> {
-    instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a>>,
+pub struct CloseEscrowAccountCpiBuilder<'a, 'b> {
+    instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CloseEscrowAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CloseEscrowAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CloseEscrowAccountCpiBuilderInstruction {
             __program: program,
             escrow: None,
@@ -372,7 +372,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow(
         &mut self,
-        escrow: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow = Some(escrow);
         self
@@ -381,14 +381,14 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -396,7 +396,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -405,14 +405,14 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Wallet paying for the transaction and new account
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -420,7 +420,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -429,7 +429,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -437,7 +437,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -445,7 +445,7 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -497,15 +497,15 @@ impl<'a> CloseEscrowAccountCpiBuilder<'a> {
     }
 }
 
-struct CloseEscrowAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    escrow: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct CloseEscrowAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -120,31 +120,31 @@ impl ConvertMasterEditionV1ToV2Builder {
 }
 
 /// `convert_master_edition_v1_to_v2` CPI accounts.
-pub struct ConvertMasterEditionV1ToV2CpiAccounts<'a> {
+pub struct ConvertMasterEditionV1ToV2CpiAccounts<'a, 'b> {
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization mint
-    pub one_time_auth: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_auth: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `convert_master_edition_v1_to_v2` CPI instruction.
-pub struct ConvertMasterEditionV1ToV2Cpi<'a> {
+pub struct ConvertMasterEditionV1ToV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization mint
-    pub one_time_auth: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_auth: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
+impl<'a, 'b> ConvertMasterEditionV1ToV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ConvertMasterEditionV1ToV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ConvertMasterEditionV1ToV2CpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -160,7 +160,7 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -176,7 +176,7 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -221,12 +221,12 @@ impl<'a> ConvertMasterEditionV1ToV2Cpi<'a> {
 }
 
 /// `convert_master_edition_v1_to_v2` CPI instruction builder.
-pub struct ConvertMasterEditionV1ToV2CpiBuilder<'a> {
-    instruction: Box<ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a>>,
+pub struct ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
+    instruction: Box<ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ConvertMasterEditionV1ToV2CpiBuilderInstruction {
             __program: program,
             master_edition: None,
@@ -240,7 +240,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -249,7 +249,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn one_time_auth(
         &mut self,
-        one_time_auth: &'a solana_program::account_info::AccountInfo<'a>,
+        one_time_auth: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.one_time_auth = Some(one_time_auth);
         self
@@ -258,7 +258,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -266,7 +266,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -274,7 +274,7 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -316,10 +316,10 @@ impl<'a> ConvertMasterEditionV1ToV2CpiBuilder<'a> {
     }
 }
 
-struct ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    one_time_auth: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    one_time_auth: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -218,55 +218,55 @@ impl CreateEscrowAccountBuilder {
 }
 
 /// `create_escrow_account` CPI accounts.
-pub struct CreateEscrowAccountCpiAccounts<'a> {
+pub struct CreateEscrowAccountCpiAccounts<'a, 'b> {
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of the token
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_escrow_account` CPI instruction.
-pub struct CreateEscrowAccountCpi<'a> {
+pub struct CreateEscrowAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account of the token
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> CreateEscrowAccountCpi<'a> {
+impl<'a, 'b> CreateEscrowAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateEscrowAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateEscrowAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -288,7 +288,7 @@ impl<'a> CreateEscrowAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -304,7 +304,7 @@ impl<'a> CreateEscrowAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -388,12 +388,12 @@ impl<'a> CreateEscrowAccountCpi<'a> {
 }
 
 /// `create_escrow_account` CPI instruction builder.
-pub struct CreateEscrowAccountCpiBuilder<'a> {
-    instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a>>,
+pub struct CreateEscrowAccountCpiBuilder<'a, 'b> {
+    instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateEscrowAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateEscrowAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateEscrowAccountCpiBuilderInstruction {
             __program: program,
             escrow: None,
@@ -413,7 +413,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow(
         &mut self,
-        escrow: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow = Some(escrow);
         self
@@ -422,14 +422,14 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -437,7 +437,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -446,14 +446,14 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Wallet paying for the transaction and new account
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -461,7 +461,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -470,7 +470,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -480,7 +480,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authority = authority;
         self
@@ -488,7 +488,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -496,7 +496,7 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -550,16 +550,16 @@ impl<'a> CreateEscrowAccountCpiBuilder<'a> {
     }
 }
 
-struct CreateEscrowAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    escrow: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct CreateEscrowAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -173,33 +173,33 @@ impl CreateFrequencyRuleBuilder {
 }
 
 /// `create_frequency_rule` CPI accounts.
-pub struct CreateFrequencyRuleCpiAccounts<'a> {
+pub struct CreateFrequencyRuleCpiAccounts<'a, 'b> {
     /// Payer and creator of the Frequency Rule
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The PDA account where the Frequency Rule is stored
-    pub frequency_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub frequency_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_frequency_rule` CPI instruction.
-pub struct CreateFrequencyRuleCpi<'a> {
+pub struct CreateFrequencyRuleCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer and creator of the Frequency Rule
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The PDA account where the Frequency Rule is stored
-    pub frequency_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub frequency_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateFrequencyRuleInstructionArgs,
 }
 
-impl<'a> CreateFrequencyRuleCpi<'a> {
+impl<'a, 'b> CreateFrequencyRuleCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateFrequencyRuleCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateFrequencyRuleCpiAccounts<'a, 'b>,
         args: CreateFrequencyRuleInstructionArgs,
     ) -> Self {
         Self {
@@ -217,7 +217,7 @@ impl<'a> CreateFrequencyRuleCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -233,7 +233,7 @@ impl<'a> CreateFrequencyRuleCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -280,12 +280,12 @@ impl<'a> CreateFrequencyRuleCpi<'a> {
 }
 
 /// `create_frequency_rule` CPI instruction builder.
-pub struct CreateFrequencyRuleCpiBuilder<'a> {
-    instruction: Box<CreateFrequencyRuleCpiBuilderInstruction<'a>>,
+pub struct CreateFrequencyRuleCpiBuilder<'a, 'b> {
+    instruction: Box<CreateFrequencyRuleCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateFrequencyRuleCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateFrequencyRuleCpiBuilderInstruction {
             __program: program,
             payer: None,
@@ -301,7 +301,7 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     }
     /// Payer and creator of the Frequency Rule
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -309,7 +309,7 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     #[inline(always)]
     pub fn frequency_pda(
         &mut self,
-        frequency_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        frequency_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.frequency_pda = Some(frequency_pda);
         self
@@ -318,7 +318,7 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -346,7 +346,7 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -354,7 +354,7 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -412,14 +412,14 @@ impl<'a> CreateFrequencyRuleCpiBuilder<'a> {
     }
 }
 
-struct CreateFrequencyRuleCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    frequency_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateFrequencyRuleCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    frequency_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     rule_set_name: Option<String>,
     freq_rule_name: Option<String>,
     last_update: Option<i64>,
     period: Option<i64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -241,57 +241,57 @@ impl CreateMasterEditionBuilder {
 }
 
 /// `create_master_edition` CPI accounts.
-pub struct CreateMasterEditionCpiAccounts<'a> {
+pub struct CreateMasterEditionCpiAccounts<'a, 'b> {
     /// Unallocated edition V2 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_master_edition` CPI instruction.
-pub struct CreateMasterEditionCpi<'a> {
+pub struct CreateMasterEditionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition V2 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateMasterEditionInstructionArgs,
 }
 
-impl<'a> CreateMasterEditionCpi<'a> {
+impl<'a, 'b> CreateMasterEditionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMasterEditionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMasterEditionCpiAccounts<'a, 'b>,
         args: CreateMasterEditionInstructionArgs,
     ) -> Self {
         Self {
@@ -315,7 +315,7 @@ impl<'a> CreateMasterEditionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -331,7 +331,7 @@ impl<'a> CreateMasterEditionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -408,12 +408,12 @@ impl<'a> CreateMasterEditionCpi<'a> {
 }
 
 /// `create_master_edition` CPI instruction builder.
-pub struct CreateMasterEditionCpiBuilder<'a> {
-    instruction: Box<CreateMasterEditionCpiBuilderInstruction<'a>>,
+pub struct CreateMasterEditionCpiBuilder<'a, 'b> {
+    instruction: Box<CreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMasterEditionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMasterEditionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMasterEditionCpiBuilderInstruction {
             __program: program,
             edition: None,
@@ -434,14 +434,14 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Metadata mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -449,7 +449,7 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -458,14 +458,14 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -473,7 +473,7 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -482,7 +482,7 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -491,14 +491,14 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -513,7 +513,7 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -521,7 +521,7 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -586,17 +586,17 @@ impl<'a> CreateMasterEditionCpiBuilder<'a> {
     }
 }
 
-struct CreateMasterEditionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMasterEditionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     create_master_edition_args: Option<CreateMasterEditionArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -246,57 +246,57 @@ impl CreateMasterEditionV3Builder {
 }
 
 /// `create_master_edition_v3` CPI accounts.
-pub struct CreateMasterEditionV3CpiAccounts<'a> {
+pub struct CreateMasterEditionV3CpiAccounts<'a, 'b> {
     /// Unallocated edition V2 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_master_edition_v3` CPI instruction.
-pub struct CreateMasterEditionV3Cpi<'a> {
+pub struct CreateMasterEditionV3Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition V2 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateMasterEditionV3InstructionArgs,
 }
 
-impl<'a> CreateMasterEditionV3Cpi<'a> {
+impl<'a, 'b> CreateMasterEditionV3Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMasterEditionV3CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMasterEditionV3CpiAccounts<'a, 'b>,
         args: CreateMasterEditionV3InstructionArgs,
     ) -> Self {
         Self {
@@ -320,7 +320,7 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -336,7 +336,7 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -421,12 +421,12 @@ impl<'a> CreateMasterEditionV3Cpi<'a> {
 }
 
 /// `create_master_edition_v3` CPI instruction builder.
-pub struct CreateMasterEditionV3CpiBuilder<'a> {
-    instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a>>,
+pub struct CreateMasterEditionV3CpiBuilder<'a, 'b> {
+    instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMasterEditionV3CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMasterEditionV3CpiBuilderInstruction {
             __program: program,
             edition: None,
@@ -447,14 +447,14 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Metadata mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -462,7 +462,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -471,14 +471,14 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -486,7 +486,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -495,7 +495,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -504,7 +504,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -514,7 +514,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -530,7 +530,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -538,7 +538,7 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -603,17 +603,17 @@ impl<'a> CreateMasterEditionV3CpiBuilder<'a> {
     }
 }
 
-struct CreateMasterEditionV3CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMasterEditionV3CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     create_master_edition_args: Option<CreateMasterEditionArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -233,49 +233,49 @@ impl CreateMetadataAccountBuilder {
 }
 
 /// `create_metadata_account` CPI accounts.
-pub struct CreateMetadataAccountCpiAccounts<'a> {
+pub struct CreateMetadataAccountCpiAccounts<'a, 'b> {
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_metadata_account` CPI instruction.
-pub struct CreateMetadataAccountCpi<'a> {
+pub struct CreateMetadataAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateMetadataAccountInstructionArgs,
 }
 
-impl<'a> CreateMetadataAccountCpi<'a> {
+impl<'a, 'b> CreateMetadataAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMetadataAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMetadataAccountCpiAccounts<'a, 'b>,
         args: CreateMetadataAccountInstructionArgs,
     ) -> Self {
         Self {
@@ -297,7 +297,7 @@ impl<'a> CreateMetadataAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -313,7 +313,7 @@ impl<'a> CreateMetadataAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -380,12 +380,12 @@ impl<'a> CreateMetadataAccountCpi<'a> {
 }
 
 /// `create_metadata_account` CPI instruction builder.
-pub struct CreateMetadataAccountCpiBuilder<'a> {
-    instruction: Box<CreateMetadataAccountCpiBuilderInstruction<'a>>,
+pub struct CreateMetadataAccountCpiBuilder<'a, 'b> {
+    instruction: Box<CreateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMetadataAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMetadataAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMetadataAccountCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -406,14 +406,14 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -421,14 +421,14 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -436,7 +436,7 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -445,14 +445,14 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -474,7 +474,7 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -482,7 +482,7 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -546,17 +546,17 @@ impl<'a> CreateMetadataAccountCpiBuilder<'a> {
     }
 }
 
-struct CreateMetadataAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMetadataAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<CreateMetadataAccountInstructionDataData>,
     is_mutable: Option<bool>,
     metadata_bump: Option<u8>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -217,49 +217,49 @@ impl CreateMetadataAccountV2Builder {
 }
 
 /// `create_metadata_account_v2` CPI accounts.
-pub struct CreateMetadataAccountV2CpiAccounts<'a> {
+pub struct CreateMetadataAccountV2CpiAccounts<'a, 'b> {
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_metadata_account_v2` CPI instruction.
-pub struct CreateMetadataAccountV2Cpi<'a> {
+pub struct CreateMetadataAccountV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateMetadataAccountV2InstructionArgs,
 }
 
-impl<'a> CreateMetadataAccountV2Cpi<'a> {
+impl<'a, 'b> CreateMetadataAccountV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMetadataAccountV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMetadataAccountV2CpiAccounts<'a, 'b>,
         args: CreateMetadataAccountV2InstructionArgs,
     ) -> Self {
         Self {
@@ -281,7 +281,7 @@ impl<'a> CreateMetadataAccountV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -297,7 +297,7 @@ impl<'a> CreateMetadataAccountV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -372,12 +372,12 @@ impl<'a> CreateMetadataAccountV2Cpi<'a> {
 }
 
 /// `create_metadata_account_v2` CPI instruction builder.
-pub struct CreateMetadataAccountV2CpiBuilder<'a> {
-    instruction: Box<CreateMetadataAccountV2CpiBuilderInstruction<'a>>,
+pub struct CreateMetadataAccountV2CpiBuilder<'a, 'b> {
+    instruction: Box<CreateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMetadataAccountV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMetadataAccountV2CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -397,14 +397,14 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -412,14 +412,14 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -427,7 +427,7 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -436,7 +436,7 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -446,7 +446,7 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -464,7 +464,7 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -472,7 +472,7 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -531,16 +531,16 @@ impl<'a> CreateMetadataAccountV2CpiBuilder<'a> {
     }
 }
 
-struct CreateMetadataAccountV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMetadataAccountV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<DataV2>,
     is_mutable: Option<bool>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -227,49 +227,49 @@ impl CreateMetadataAccountV3Builder {
 }
 
 /// `create_metadata_account_v3` CPI accounts.
-pub struct CreateMetadataAccountV3CpiAccounts<'a> {
+pub struct CreateMetadataAccountV3CpiAccounts<'a, 'b> {
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `create_metadata_account_v3` CPI instruction.
-pub struct CreateMetadataAccountV3Cpi<'a> {
+pub struct CreateMetadataAccountV3Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: CreateMetadataAccountV3InstructionArgs,
 }
 
-impl<'a> CreateMetadataAccountV3Cpi<'a> {
+impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateMetadataAccountV3CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateMetadataAccountV3CpiAccounts<'a, 'b>,
         args: CreateMetadataAccountV3InstructionArgs,
     ) -> Self {
         Self {
@@ -291,7 +291,7 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -307,7 +307,7 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -382,12 +382,12 @@ impl<'a> CreateMetadataAccountV3Cpi<'a> {
 }
 
 /// `create_metadata_account_v3` CPI instruction builder.
-pub struct CreateMetadataAccountV3CpiBuilder<'a> {
-    instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a>>,
+pub struct CreateMetadataAccountV3CpiBuilder<'a, 'b> {
+    instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateMetadataAccountV3CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateMetadataAccountV3CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -408,14 +408,14 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -423,14 +423,14 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -438,7 +438,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -447,7 +447,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -457,7 +457,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -481,7 +481,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -489,7 +489,7 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -549,17 +549,17 @@ impl<'a> CreateMetadataAccountV3CpiBuilder<'a> {
     }
 }
 
-struct CreateMetadataAccountV3CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<DataV2>,
     is_mutable: Option<bool>,
     collection_details: Option<CollectionDetails>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -200,51 +200,51 @@ impl CreateReservationListBuilder {
 }
 
 /// `create_reservation_list` CPI accounts.
-pub struct CreateReservationListCpiAccounts<'a> {
+pub struct CreateReservationListCpiAccounts<'a, 'b> {
     /// PDA for ReservationList of ['metadata', program id, master edition key, 'reservation', resource-key]
-    pub reservation_list: &'a solana_program::account_info::AccountInfo<'a>,
+    pub reservation_list: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ///  Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// A resource you wish to tie the reservation list to. This is so your later visitors who come to redeem can derive your reservation list PDA with something they can easily get at. You choose what this should be.
-    pub resource: &'a solana_program::account_info::AccountInfo<'a>,
+    pub resource: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_reservation_list` CPI instruction.
-pub struct CreateReservationListCpi<'a> {
+pub struct CreateReservationListCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// PDA for ReservationList of ['metadata', program id, master edition key, 'reservation', resource-key]
-    pub reservation_list: &'a solana_program::account_info::AccountInfo<'a>,
+    pub reservation_list: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ///  Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// A resource you wish to tie the reservation list to. This is so your later visitors who come to redeem can derive your reservation list PDA with something they can easily get at. You choose what this should be.
-    pub resource: &'a solana_program::account_info::AccountInfo<'a>,
+    pub resource: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> CreateReservationListCpi<'a> {
+impl<'a, 'b> CreateReservationListCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateReservationListCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateReservationListCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -265,7 +265,7 @@ impl<'a> CreateReservationListCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -281,7 +281,7 @@ impl<'a> CreateReservationListCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -351,12 +351,12 @@ impl<'a> CreateReservationListCpi<'a> {
 }
 
 /// `create_reservation_list` CPI instruction builder.
-pub struct CreateReservationListCpiBuilder<'a> {
-    instruction: Box<CreateReservationListCpiBuilderInstruction<'a>>,
+pub struct CreateReservationListCpiBuilder<'a, 'b> {
+    instruction: Box<CreateReservationListCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateReservationListCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateReservationListCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateReservationListCpiBuilderInstruction {
             __program: program,
             reservation_list: None,
@@ -375,14 +375,14 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn reservation_list(
         &mut self,
-        reservation_list: &'a solana_program::account_info::AccountInfo<'a>,
+        reservation_list: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reservation_list = Some(reservation_list);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -390,7 +390,7 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -399,7 +399,7 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -408,7 +408,7 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn resource(
         &mut self,
-        resource: &'a solana_program::account_info::AccountInfo<'a>,
+        resource: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.resource = Some(resource);
         self
@@ -417,7 +417,7 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -426,21 +426,21 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -448,7 +448,7 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -503,15 +503,15 @@ impl<'a> CreateReservationListCpiBuilder<'a> {
     }
 }
 
-struct CreateReservationListCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    resource: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct CreateReservationListCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    resource: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -153,33 +153,33 @@ impl CreateRuleSetBuilder {
 }
 
 /// `create_rule_set` CPI accounts.
-pub struct CreateRuleSetCpiAccounts<'a> {
+pub struct CreateRuleSetCpiAccounts<'a, 'b> {
     /// Payer and creator of the RuleSet
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The PDA account where the RuleSet is stored
-    pub rule_set_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rule_set_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_rule_set` CPI instruction.
-pub struct CreateRuleSetCpi<'a> {
+pub struct CreateRuleSetCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer and creator of the RuleSet
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The PDA account where the RuleSet is stored
-    pub rule_set_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rule_set_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateRuleSetInstructionArgs,
 }
 
-impl<'a> CreateRuleSetCpi<'a> {
+impl<'a, 'b> CreateRuleSetCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateRuleSetCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateRuleSetCpiAccounts<'a, 'b>,
         args: CreateRuleSetInstructionArgs,
     ) -> Self {
         Self {
@@ -197,7 +197,7 @@ impl<'a> CreateRuleSetCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -213,7 +213,7 @@ impl<'a> CreateRuleSetCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -258,12 +258,12 @@ impl<'a> CreateRuleSetCpi<'a> {
 }
 
 /// `create_rule_set` CPI instruction builder.
-pub struct CreateRuleSetCpiBuilder<'a> {
-    instruction: Box<CreateRuleSetCpiBuilderInstruction<'a>>,
+pub struct CreateRuleSetCpiBuilder<'a, 'b> {
+    instruction: Box<CreateRuleSetCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateRuleSetCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateRuleSetCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateRuleSetCpiBuilderInstruction {
             __program: program,
             payer: None,
@@ -277,7 +277,7 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     }
     /// Payer and creator of the RuleSet
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -285,7 +285,7 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     #[inline(always)]
     pub fn rule_set_pda(
         &mut self,
-        rule_set_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        rule_set_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.rule_set_pda = Some(rule_set_pda);
         self
@@ -294,7 +294,7 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -312,7 +312,7 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -320,7 +320,7 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -372,12 +372,12 @@ impl<'a> CreateRuleSetCpiBuilder<'a> {
     }
 }
 
-struct CreateRuleSetCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rule_set_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateRuleSetCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rule_set_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     create_args: Option<TaCreateArgs>,
     rule_set_bump: Option<u8>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -274,57 +274,57 @@ impl CreateV1Builder {
 }
 
 /// `create_v1` CPI accounts.
-pub struct CreateV1CpiAccounts<'a> {
+pub struct CreateV1CpiAccounts<'a, 'b> {
     /// Metadata account key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_v1` CPI instruction.
-pub struct CreateV1Cpi<'a> {
+pub struct CreateV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateV1InstructionArgs,
 }
 
-impl<'a> CreateV1Cpi<'a> {
+impl<'a, 'b> CreateV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateV1CpiAccounts<'a, 'b>,
         args: CreateV1InstructionArgs,
     ) -> Self {
         Self {
@@ -348,7 +348,7 @@ impl<'a> CreateV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -364,7 +364,7 @@ impl<'a> CreateV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -448,12 +448,12 @@ impl<'a> CreateV1Cpi<'a> {
 }
 
 /// `create_v1` CPI instruction builder.
-pub struct CreateV1CpiBuilder<'a> {
-    instruction: Box<CreateV1CpiBuilderInstruction<'a>>,
+pub struct CreateV1CpiBuilder<'a, 'b> {
+    instruction: Box<CreateV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateV1CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -476,7 +476,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -486,7 +486,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -495,7 +495,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint(
         &mut self,
-        mint: &'a solana_program::account_info::AccountInfo<'a>,
+        mint: &'b solana_program::account_info::AccountInfo<'a>,
         as_signer: bool,
     ) -> &mut Self {
         self.instruction.mint = Some((mint, as_signer));
@@ -505,14 +505,14 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -520,7 +520,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -529,7 +529,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -538,7 +538,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -547,7 +547,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -572,7 +572,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -580,7 +580,7 @@ impl<'a> CreateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -650,19 +650,19 @@ impl<'a> CreateV1CpiBuilder<'a> {
     }
 }
 
-struct CreateV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     asset_data: Option<AssetData>,
     decimals: Option<u8>,
     max_supply: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -265,57 +265,57 @@ impl CreateV2Builder {
 }
 
 /// `create_v2` CPI accounts.
-pub struct CreateV2CpiAccounts<'a> {
+pub struct CreateV2CpiAccounts<'a, 'b> {
     /// Metadata account key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `create_v2` CPI instruction.
-pub struct CreateV2Cpi<'a> {
+pub struct CreateV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition account with address as pda of ['metadata', program id, mint, 'edition']
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: (&'a solana_program::account_info::AccountInfo<'a>, bool),
+    pub mint: (&'b solana_program::account_info::AccountInfo<'a>, bool),
     /// Mint authority
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: CreateV2InstructionArgs,
 }
 
-impl<'a> CreateV2Cpi<'a> {
+impl<'a, 'b> CreateV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: CreateV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: CreateV2CpiAccounts<'a, 'b>,
         args: CreateV2InstructionArgs,
     ) -> Self {
         Self {
@@ -339,7 +339,7 @@ impl<'a> CreateV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -355,7 +355,7 @@ impl<'a> CreateV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -439,12 +439,12 @@ impl<'a> CreateV2Cpi<'a> {
 }
 
 /// `create_v2` CPI instruction builder.
-pub struct CreateV2CpiBuilder<'a> {
-    instruction: Box<CreateV2CpiBuilderInstruction<'a>>,
+pub struct CreateV2CpiBuilder<'a, 'b> {
+    instruction: Box<CreateV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> CreateV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> CreateV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(CreateV2CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -466,7 +466,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -476,7 +476,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -485,7 +485,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint(
         &mut self,
-        mint: &'a solana_program::account_info::AccountInfo<'a>,
+        mint: &'b solana_program::account_info::AccountInfo<'a>,
         as_signer: bool,
     ) -> &mut Self {
         self.instruction.mint = Some((mint, as_signer));
@@ -495,14 +495,14 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -510,7 +510,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -519,7 +519,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -528,7 +528,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -537,7 +537,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -556,7 +556,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -564,7 +564,7 @@ impl<'a> CreateV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -633,18 +633,18 @@ impl<'a> CreateV2CpiBuilder<'a> {
     }
 }
 
-struct CreateV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct CreateV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     asset_data: Option<AssetData>,
     max_supply: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -342,73 +342,73 @@ impl DelegateBuilder {
 }
 
 /// `delegate` CPI accounts.
-pub struct DelegateCpiAccounts<'a> {
+pub struct DelegateCpiAccounts<'a, 'b> {
     /// Delegate account key (pda of [mint id, delegate role, user id, authority id])
-    pub delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Authority to approve the delegation
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `delegate` CPI instruction.
-pub struct DelegateCpi<'a> {
+pub struct DelegateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate account key (pda of [mint id, delegate role, user id, authority id])
-    pub delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Authority to approve the delegation
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: DelegateInstructionArgs,
 }
 
-impl<'a> DelegateCpi<'a> {
+impl<'a, 'b> DelegateCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DelegateCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DelegateCpiAccounts<'a, 'b>,
         args: DelegateInstructionArgs,
     ) -> Self {
         Self {
@@ -436,7 +436,7 @@ impl<'a> DelegateCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -452,7 +452,7 @@ impl<'a> DelegateCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -591,12 +591,12 @@ impl<'a> DelegateCpi<'a> {
 }
 
 /// `delegate` CPI instruction builder.
-pub struct DelegateCpiBuilder<'a> {
-    instruction: Box<DelegateCpiBuilderInstruction<'a>>,
+pub struct DelegateCpiBuilder<'a, 'b> {
+    instruction: Box<DelegateCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DelegateCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DelegateCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DelegateCpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -621,7 +621,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate_record = Some(delegate_record);
         self
@@ -630,7 +630,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -639,7 +639,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -649,14 +649,14 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -665,7 +665,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -674,14 +674,14 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -689,7 +689,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -698,7 +698,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -708,7 +708,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -718,7 +718,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -728,7 +728,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -741,7 +741,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -749,7 +749,7 @@ impl<'a> DelegateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -819,21 +819,21 @@ impl<'a> DelegateCpiBuilder<'a> {
     }
 }
 
-struct DelegateCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DelegateCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     delegate_args: Option<DelegateArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -313,75 +313,75 @@ impl DeprecatedCreateMasterEditionBuilder {
 }
 
 /// `deprecated_create_master_edition` CPI accounts.
-pub struct DeprecatedCreateMasterEditionCpiAccounts<'a> {
+pub struct DeprecatedCreateMasterEditionCpiAccounts<'a, 'b> {
     /// Unallocated edition V1 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint - A mint you control that can mint tokens that can be exchanged for limited editions of your master edition via the MintNewEditionFromMasterEditionViaToken endpoint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization printing mint - A mint you control that prints tokens that gives the bearer permission to mint any number of tokens from the printing mint one time via an endpoint with the token-metadata program for your metadata. Also burns the token.
-    pub one_time_printing_authorization_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_printing_authorization_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Current Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint authority - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY.
-    pub printing_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization printing mint authority - must be provided if using max supply. THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY.
     pub one_time_printing_authorization_mint_authority:
-        &'a solana_program::account_info::AccountInfo<'a>,
+        &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `deprecated_create_master_edition` CPI instruction.
-pub struct DeprecatedCreateMasterEditionCpi<'a> {
+pub struct DeprecatedCreateMasterEditionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Unallocated edition V1 account with address as pda of ['metadata', program id, mint, 'edition']
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint - A mint you control that can mint tokens that can be exchanged for limited editions of your master edition via the MintNewEditionFromMasterEditionViaToken endpoint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization printing mint - A mint you control that prints tokens that gives the bearer permission to mint any number of tokens from the printing mint one time via an endpoint with the token-metadata program for your metadata. Also burns the token.
-    pub one_time_printing_authorization_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_printing_authorization_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Current Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint authority - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY.
-    pub printing_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority on the metadata's mint - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization printing mint authority - must be provided if using max supply. THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY.
     pub one_time_printing_authorization_mint_authority:
-        &'a solana_program::account_info::AccountInfo<'a>,
+        &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DeprecatedCreateMasterEditionInstructionArgs,
 }
 
-impl<'a> DeprecatedCreateMasterEditionCpi<'a> {
+impl<'a, 'b> DeprecatedCreateMasterEditionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DeprecatedCreateMasterEditionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DeprecatedCreateMasterEditionCpiAccounts<'a, 'b>,
         args: DeprecatedCreateMasterEditionInstructionArgs,
     ) -> Self {
         Self {
@@ -410,7 +410,7 @@ impl<'a> DeprecatedCreateMasterEditionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -426,7 +426,7 @@ impl<'a> DeprecatedCreateMasterEditionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -523,12 +523,12 @@ impl<'a> DeprecatedCreateMasterEditionCpi<'a> {
 }
 
 /// `deprecated_create_master_edition` CPI instruction builder.
-pub struct DeprecatedCreateMasterEditionCpiBuilder<'a> {
-    instruction: Box<DeprecatedCreateMasterEditionCpiBuilderInstruction<'a>>,
+pub struct DeprecatedCreateMasterEditionCpiBuilder<'a, 'b> {
+    instruction: Box<DeprecatedCreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DeprecatedCreateMasterEditionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DeprecatedCreateMasterEditionCpiBuilderInstruction {
             __program: program,
             edition: None,
@@ -553,14 +553,14 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Metadata mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -568,7 +568,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -577,7 +577,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn one_time_printing_authorization_mint(
         &mut self,
-        one_time_printing_authorization_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        one_time_printing_authorization_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.one_time_printing_authorization_mint =
             Some(one_time_printing_authorization_mint);
@@ -587,7 +587,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -596,7 +596,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn printing_mint_authority(
         &mut self,
-        printing_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint_authority = Some(printing_mint_authority);
         self
@@ -605,7 +605,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
@@ -614,14 +614,14 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -629,7 +629,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -638,14 +638,14 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -653,7 +653,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn one_time_printing_authorization_mint_authority(
         &mut self,
-        one_time_printing_authorization_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        one_time_printing_authorization_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction
             .one_time_printing_authorization_mint_authority =
@@ -671,7 +671,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -679,7 +679,7 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -764,22 +764,22 @@ impl<'a> DeprecatedCreateMasterEditionCpiBuilder<'a> {
     }
 }
 
-struct DeprecatedCreateMasterEditionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    one_time_printing_authorization_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DeprecatedCreateMasterEditionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    one_time_printing_authorization_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     one_time_printing_authorization_mint_authority:
-        Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        Option<&'b solana_program::account_info::AccountInfo<'a>>,
     create_master_edition_args: Option<CreateMasterEditionArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -332,83 +332,83 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenBuilder {
 }
 
 /// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI accounts.
-pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a> {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition V1 (pda of ['metadata', program id, mint id, 'edition'])
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing Mint of master record edition
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account containing Printing mint token to be transferred
-    pub master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master mint id, edition_number])
-    pub edition_marker: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker: &'b solana_program::account_info::AccountInfo<'a>,
     /// Burn authority for this token
-    pub burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info for new metadata account
-    pub master_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.
-    pub reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI instruction.
-pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition V1 (pda of ['metadata', program id, mint id, 'edition'])
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V1 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing Mint of master record edition
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account containing Printing mint token to be transferred
-    pub master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master mint id, edition_number])
-    pub edition_marker: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_marker: &'b solana_program::account_info::AccountInfo<'a>,
     /// Burn authority for this token
-    pub burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// update authority info for new metadata account
-    pub master_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.
-    pub reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
+impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -437,7 +437,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -453,7 +453,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(16 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -572,13 +572,13 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a> {
 }
 
 /// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI instruction builder.
-pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a> {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
     instruction:
-        Box<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a>>,
+        Box<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction {
                 __program: program,
@@ -607,7 +607,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -616,7 +616,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
@@ -625,14 +625,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
     }
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -640,7 +640,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
@@ -649,7 +649,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -658,7 +658,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_token_account(
         &mut self,
-        master_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        master_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_token_account = Some(master_token_account);
         self
@@ -667,7 +667,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn edition_marker(
         &mut self,
-        edition_marker: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_marker: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_marker = Some(edition_marker);
         self
@@ -676,14 +676,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn burn_authority(
         &mut self,
-        burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.burn_authority = Some(burn_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -691,7 +691,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_update_authority(
         &mut self,
-        master_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        master_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_update_authority = Some(master_update_authority);
         self
@@ -700,7 +700,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn master_metadata(
         &mut self,
-        master_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        master_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_metadata = Some(master_metadata);
         self
@@ -709,7 +709,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -718,14 +718,14 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -734,7 +734,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn reservation_list(
         &mut self,
-        reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.reservation_list = reservation_list;
         self
@@ -742,7 +742,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -750,7 +750,7 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -839,23 +839,23 @@ impl<'a> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a>
     }
 }
 
-struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_marker: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burn_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_marker: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burn_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -212,49 +212,49 @@ impl DeprecatedMintPrintingTokensBuilder {
 }
 
 /// `deprecated_mint_printing_tokens` CPI accounts.
-pub struct DeprecatedMintPrintingTokensCpiAccounts<'a> {
+pub struct DeprecatedMintPrintingTokensCpiAccounts<'a, 'b> {
     /// Destination account
-    pub destination: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `deprecated_mint_printing_tokens` CPI instruction.
-pub struct DeprecatedMintPrintingTokensCpi<'a> {
+pub struct DeprecatedMintPrintingTokensCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination account
-    pub destination: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DeprecatedMintPrintingTokensInstructionArgs,
 }
 
-impl<'a> DeprecatedMintPrintingTokensCpi<'a> {
+impl<'a, 'b> DeprecatedMintPrintingTokensCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DeprecatedMintPrintingTokensCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DeprecatedMintPrintingTokensCpiAccounts<'a, 'b>,
         args: DeprecatedMintPrintingTokensInstructionArgs,
     ) -> Self {
         Self {
@@ -276,7 +276,7 @@ impl<'a> DeprecatedMintPrintingTokensCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -292,7 +292,7 @@ impl<'a> DeprecatedMintPrintingTokensCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -359,12 +359,12 @@ impl<'a> DeprecatedMintPrintingTokensCpi<'a> {
 }
 
 /// `deprecated_mint_printing_tokens` CPI instruction builder.
-pub struct DeprecatedMintPrintingTokensCpiBuilder<'a> {
-    instruction: Box<DeprecatedMintPrintingTokensCpiBuilderInstruction<'a>>,
+pub struct DeprecatedMintPrintingTokensCpiBuilder<'a, 'b> {
+    instruction: Box<DeprecatedMintPrintingTokensCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DeprecatedMintPrintingTokensCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DeprecatedMintPrintingTokensCpiBuilderInstruction {
             __program: program,
             destination: None,
@@ -383,7 +383,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn destination(
         &mut self,
-        destination: &'a solana_program::account_info::AccountInfo<'a>,
+        destination: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination = Some(destination);
         self
@@ -392,7 +392,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -401,7 +401,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -410,7 +410,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -419,7 +419,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -428,14 +428,14 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     /// Rent
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -451,7 +451,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -459,7 +459,7 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -523,15 +523,15 @@ impl<'a> DeprecatedMintPrintingTokensCpiBuilder<'a> {
     }
 }
 
-struct DeprecatedMintPrintingTokensCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    destination: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DeprecatedMintPrintingTokensCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_printing_tokens_via_token_args: Option<MintPrintingTokensViaTokenArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -241,57 +241,57 @@ impl DeprecatedMintPrintingTokensViaTokenBuilder {
 }
 
 /// `deprecated_mint_printing_tokens_via_token` CPI accounts.
-pub struct DeprecatedMintPrintingTokensViaTokenCpiAccounts<'a> {
+pub struct DeprecatedMintPrintingTokensViaTokenCpiAccounts<'a, 'b> {
     /// Destination account
-    pub destination: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account containing one time authorization token
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization mint
-    pub one_time_printing_authorization_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_printing_authorization_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Burn authority
-    pub burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `deprecated_mint_printing_tokens_via_token` CPI instruction.
-pub struct DeprecatedMintPrintingTokensViaTokenCpi<'a> {
+pub struct DeprecatedMintPrintingTokensViaTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination account
-    pub destination: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account containing one time authorization token
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// One time authorization mint
-    pub one_time_printing_authorization_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub one_time_printing_authorization_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Printing mint
-    pub printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Burn authority
-    pub burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DeprecatedMintPrintingTokensViaTokenInstructionArgs,
 }
 
-impl<'a> DeprecatedMintPrintingTokensViaTokenCpi<'a> {
+impl<'a, 'b> DeprecatedMintPrintingTokensViaTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DeprecatedMintPrintingTokensViaTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DeprecatedMintPrintingTokensViaTokenCpiAccounts<'a, 'b>,
         args: DeprecatedMintPrintingTokensViaTokenInstructionArgs,
     ) -> Self {
         Self {
@@ -315,7 +315,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -331,7 +331,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -408,12 +408,12 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpi<'a> {
 }
 
 /// `deprecated_mint_printing_tokens_via_token` CPI instruction builder.
-pub struct DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
-    instruction: Box<DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a>>,
+pub struct DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a, 'b> {
+    instruction: Box<DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction {
             __program: program,
             destination: None,
@@ -434,14 +434,14 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn destination(
         &mut self,
-        destination: &'a solana_program::account_info::AccountInfo<'a>,
+        destination: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination = Some(destination);
         self
     }
     /// Token account containing one time authorization token
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -449,7 +449,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn one_time_printing_authorization_mint(
         &mut self,
-        one_time_printing_authorization_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        one_time_printing_authorization_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.one_time_printing_authorization_mint =
             Some(one_time_printing_authorization_mint);
@@ -459,7 +459,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn printing_mint(
         &mut self,
-        printing_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        printing_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.printing_mint = Some(printing_mint);
         self
@@ -468,7 +468,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn burn_authority(
         &mut self,
-        burn_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        burn_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.burn_authority = Some(burn_authority);
         self
@@ -477,7 +477,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -486,7 +486,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -495,14 +495,14 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
     }
     /// Rent
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -518,7 +518,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -526,7 +526,7 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -597,17 +597,17 @@ impl<'a> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a> {
     }
 }
 
-struct DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    destination: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    one_time_printing_authorization_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    printing_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burn_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    one_time_printing_authorization_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    printing_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burn_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_printing_tokens_via_token_args: Option<MintPrintingTokensViaTokenArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -173,33 +173,33 @@ impl DeprecatedSetReservationListBuilder {
 }
 
 /// `deprecated_set_reservation_list` CPI accounts.
-pub struct DeprecatedSetReservationListCpiAccounts<'a> {
+pub struct DeprecatedSetReservationListCpiAccounts<'a, 'b> {
     /// Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// PDA for ReservationList of ['metadata', program id, master edition key, 'reservation', resource-key]
-    pub reservation_list: &'a solana_program::account_info::AccountInfo<'a>,
+    pub reservation_list: &'b solana_program::account_info::AccountInfo<'a>,
     /// The resource you tied the reservation list too
-    pub resource: &'a solana_program::account_info::AccountInfo<'a>,
+    pub resource: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `deprecated_set_reservation_list` CPI instruction.
-pub struct DeprecatedSetReservationListCpi<'a> {
+pub struct DeprecatedSetReservationListCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition V1 key (pda of ['metadata', program id, mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// PDA for ReservationList of ['metadata', program id, master edition key, 'reservation', resource-key]
-    pub reservation_list: &'a solana_program::account_info::AccountInfo<'a>,
+    pub reservation_list: &'b solana_program::account_info::AccountInfo<'a>,
     /// The resource you tied the reservation list too
-    pub resource: &'a solana_program::account_info::AccountInfo<'a>,
+    pub resource: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: DeprecatedSetReservationListInstructionArgs,
 }
 
-impl<'a> DeprecatedSetReservationListCpi<'a> {
+impl<'a, 'b> DeprecatedSetReservationListCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DeprecatedSetReservationListCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DeprecatedSetReservationListCpiAccounts<'a, 'b>,
         args: DeprecatedSetReservationListInstructionArgs,
     ) -> Self {
         Self {
@@ -217,7 +217,7 @@ impl<'a> DeprecatedSetReservationListCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -233,7 +233,7 @@ impl<'a> DeprecatedSetReservationListCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -280,12 +280,12 @@ impl<'a> DeprecatedSetReservationListCpi<'a> {
 }
 
 /// `deprecated_set_reservation_list` CPI instruction builder.
-pub struct DeprecatedSetReservationListCpiBuilder<'a> {
-    instruction: Box<DeprecatedSetReservationListCpiBuilderInstruction<'a>>,
+pub struct DeprecatedSetReservationListCpiBuilder<'a, 'b> {
+    instruction: Box<DeprecatedSetReservationListCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DeprecatedSetReservationListCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DeprecatedSetReservationListCpiBuilderInstruction {
             __program: program,
             master_edition: None,
@@ -303,7 +303,7 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -312,7 +312,7 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn reservation_list(
         &mut self,
-        reservation_list: &'a solana_program::account_info::AccountInfo<'a>,
+        reservation_list: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.reservation_list = Some(reservation_list);
         self
@@ -321,7 +321,7 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn resource(
         &mut self,
-        resource: &'a solana_program::account_info::AccountInfo<'a>,
+        resource: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.resource = Some(resource);
         self
@@ -350,7 +350,7 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -358,7 +358,7 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -412,14 +412,14 @@ impl<'a> DeprecatedSetReservationListCpiBuilder<'a> {
     }
 }
 
-struct DeprecatedSetReservationListCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    reservation_list: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    resource: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct DeprecatedSetReservationListCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    resource: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     reservations: Option<Vec<Reservation>>,
     total_reservation_spots: Option<u64>,
     offset: Option<u64>,
     total_spot_offset: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -243,58 +243,58 @@ impl DummyBuilder {
 }
 
 /// `dummy` CPI accounts.
-pub struct DummyCpiAccounts<'a> {
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct DummyCpiAccounts<'a, 'b> {
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub foo: &'a solana_program::account_info::AccountInfo<'a>,
+    pub foo: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub bar: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub bar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub token_or_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_or_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `dummy` CPI instruction.
-pub struct DummyCpi<'a> {
+pub struct DummyCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub foo: &'a solana_program::account_info::AccountInfo<'a>,
+    pub foo: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub bar: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub bar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 
-    pub token_or_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_or_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> DummyCpi<'a> {
+impl<'a, 'b> DummyCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: DummyCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: DummyCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -317,7 +317,7 @@ impl<'a> DummyCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -333,7 +333,7 @@ impl<'a> DummyCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -445,12 +445,12 @@ impl<'a> DummyCpi<'a> {
 }
 
 /// `dummy` CPI instruction builder.
-pub struct DummyCpiBuilder<'a> {
-    instruction: Box<DummyCpiBuilderInstruction<'a>>,
+pub struct DummyCpiBuilder<'a, 'b> {
+    instruction: Box<DummyCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> DummyCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> DummyCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(DummyCpiBuilderInstruction {
             __program: program,
             edition: None,
@@ -470,7 +470,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
@@ -479,7 +479,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint(
         &mut self,
-        mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.mint = mint;
         self
@@ -487,7 +487,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -495,18 +495,18 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     #[inline(always)]
-    pub fn foo(&mut self, foo: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn foo(&mut self, foo: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.foo = Some(foo);
         self
     }
@@ -514,7 +514,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn bar(
         &mut self,
-        bar: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        bar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.bar = bar;
         self
@@ -523,7 +523,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate = delegate;
         self
@@ -532,7 +532,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -540,7 +540,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_or_ata_program(
         &mut self,
-        token_or_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_or_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_or_ata_program = Some(token_or_ata_program);
         self
@@ -548,7 +548,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -556,7 +556,7 @@ impl<'a> DummyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -612,17 +612,17 @@ impl<'a> DummyCpiBuilder<'a> {
     }
 }
 
-struct DummyCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    foo: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    bar: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_or_ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct DummyCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    foo: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    bar: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_or_ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -150,39 +150,39 @@ impl FreezeDelegatedAccountBuilder {
 }
 
 /// `freeze_delegated_account` CPI accounts.
-pub struct FreezeDelegatedAccountCpiAccounts<'a> {
+pub struct FreezeDelegatedAccountCpiAccounts<'a, 'b> {
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to freeze
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `freeze_delegated_account` CPI instruction.
-pub struct FreezeDelegatedAccountCpi<'a> {
+pub struct FreezeDelegatedAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to freeze
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> FreezeDelegatedAccountCpi<'a> {
+impl<'a, 'b> FreezeDelegatedAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: FreezeDelegatedAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: FreezeDelegatedAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -200,7 +200,7 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -216,7 +216,7 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -271,12 +271,12 @@ impl<'a> FreezeDelegatedAccountCpi<'a> {
 }
 
 /// `freeze_delegated_account` CPI instruction builder.
-pub struct FreezeDelegatedAccountCpiBuilder<'a> {
-    instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a>>,
+pub struct FreezeDelegatedAccountCpiBuilder<'a, 'b> {
+    instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> FreezeDelegatedAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(FreezeDelegatedAccountCpiBuilderInstruction {
             __program: program,
             delegate: None,
@@ -292,7 +292,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -301,7 +301,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -310,14 +310,14 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Token mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -325,7 +325,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -333,7 +333,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -341,7 +341,7 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -384,12 +384,12 @@ impl<'a> FreezeDelegatedAccountCpiBuilder<'a> {
     }
 }
 
-struct FreezeDelegatedAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -274,64 +274,64 @@ impl InitializeBuilder {
 }
 
 /// `initialize` CPI accounts.
-pub struct InitializeCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct InitializeCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `initialize` CPI instruction.
-pub struct InitializeCpi<'a> {
+pub struct InitializeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: InitializeInstructionArgs,
 }
 
-impl<'a> InitializeCpi<'a> {
+impl<'a, 'b> InitializeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: InitializeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: InitializeCpiAccounts<'a, 'b>,
         args: InitializeInstructionArgs,
     ) -> Self {
         Self {
@@ -357,7 +357,7 @@ impl<'a> InitializeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -373,7 +373,7 @@ impl<'a> InitializeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -458,12 +458,12 @@ impl<'a> InitializeCpi<'a> {
 }
 
 /// `initialize` CPI instruction builder.
-pub struct InitializeCpiBuilder<'a> {
-    instruction: Box<InitializeCpiBuilderInstruction<'a>>,
+pub struct InitializeCpiBuilder<'a, 'b> {
+    instruction: Box<InitializeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> InitializeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(InitializeCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -485,7 +485,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -493,7 +493,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority_pda(
         &mut self,
-        authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority_pda = Some(authority_pda);
         self
@@ -501,20 +501,20 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -522,7 +522,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -530,7 +530,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition(
         &mut self,
-        collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition = Some(collection_master_edition);
         self
@@ -538,7 +538,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_update_authority(
         &mut self,
-        collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_update_authority = Some(collection_update_authority);
         self
@@ -546,7 +546,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -554,7 +554,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_metadata_program(
         &mut self,
-        token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_metadata_program = Some(token_metadata_program);
         self
@@ -562,7 +562,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -575,7 +575,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -583,7 +583,7 @@ impl<'a> InitializeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -663,19 +663,19 @@ impl<'a> InitializeCpiBuilder<'a> {
     }
 }
 
-struct InitializeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_metadata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct InitializeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<CandyMachineData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -268,61 +268,61 @@ impl MigrateBuilder {
 }
 
 /// `migrate` CPI accounts.
-pub struct MigrateCpiAccounts<'a> {
+pub struct MigrateCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master edition account
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instruction sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `migrate` CPI instruction.
-pub struct MigrateCpi<'a> {
+pub struct MigrateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master edition account
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instruction sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MigrateInstructionArgs,
 }
 
-impl<'a> MigrateCpi<'a> {
+impl<'a, 'b> MigrateCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MigrateCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MigrateCpiAccounts<'a, 'b>,
         args: MigrateInstructionArgs,
     ) -> Self {
         Self {
@@ -347,7 +347,7 @@ impl<'a> MigrateCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -363,7 +363,7 @@ impl<'a> MigrateCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -452,12 +452,12 @@ impl<'a> MigrateCpi<'a> {
 }
 
 /// `migrate` CPI instruction builder.
-pub struct MigrateCpiBuilder<'a> {
-    instruction: Box<MigrateCpiBuilderInstruction<'a>>,
+pub struct MigrateCpiBuilder<'a, 'b> {
+    instruction: Box<MigrateCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MigrateCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MigrateCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MigrateCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -479,7 +479,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -488,7 +488,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -497,14 +497,14 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -512,7 +512,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -521,7 +521,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -530,7 +530,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -539,7 +539,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -548,7 +548,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -558,7 +558,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -571,7 +571,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -579,7 +579,7 @@ impl<'a> MigrateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -655,18 +655,18 @@ impl<'a> MigrateCpiBuilder<'a> {
     }
 }
 
-struct MigrateCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MigrateCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     migrate_args: Option<MigrateArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -317,69 +317,69 @@ impl MintBuilder {
 }
 
 /// `mint` CPI accounts.
-pub struct MintCpiAccounts<'a> {
+pub struct MintCpiAccounts<'a, 'b> {
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// (Mint or Update) authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `mint` CPI instruction.
-pub struct MintCpi<'a> {
+pub struct MintCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// (Mint or Update) authority
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MintInstructionArgs,
 }
 
-impl<'a> MintCpi<'a> {
+impl<'a, 'b> MintCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintCpiAccounts<'a, 'b>,
         args: MintInstructionArgs,
     ) -> Self {
         Self {
@@ -406,7 +406,7 @@ impl<'a> MintCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -422,7 +422,7 @@ impl<'a> MintCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -539,12 +539,12 @@ impl<'a> MintCpi<'a> {
 }
 
 /// `mint` CPI instruction builder.
-pub struct MintCpiBuilder<'a> {
-    instruction: Box<MintCpiBuilderInstruction<'a>>,
+pub struct MintCpiBuilder<'a, 'b> {
+    instruction: Box<MintCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MintCpiBuilderInstruction {
             __program: program,
             token: None,
@@ -566,7 +566,7 @@ impl<'a> MintCpiBuilder<'a> {
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -574,7 +574,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -584,20 +584,20 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -605,7 +605,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -614,7 +614,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -623,7 +623,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -632,7 +632,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -641,7 +641,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_ata_program(
         &mut self,
-        spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_ata_program = Some(spl_ata_program);
         self
@@ -651,7 +651,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -661,7 +661,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -674,7 +674,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -682,7 +682,7 @@ impl<'a> MintCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -753,20 +753,20 @@ impl<'a> MintCpiBuilder<'a> {
     }
 }
 
-struct MintCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MintCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_args: Option<MintArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -350,86 +350,86 @@ impl MintFromCandyMachineBuilder {
 }
 
 /// `mint_from_candy_machine` CPI accounts.
-pub struct MintFromCandyMachineCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct MintFromCandyMachineCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub recent_slothashes: &'a solana_program::account_info::AccountInfo<'a>,
+    pub recent_slothashes: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `mint_from_candy_machine` CPI instruction.
-pub struct MintFromCandyMachineCpi<'a> {
+pub struct MintFromCandyMachineCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub nft_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub nft_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub recent_slothashes: &'a solana_program::account_info::AccountInfo<'a>,
+    pub recent_slothashes: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> MintFromCandyMachineCpi<'a> {
+impl<'a, 'b> MintFromCandyMachineCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintFromCandyMachineCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintFromCandyMachineCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -459,7 +459,7 @@ impl<'a> MintFromCandyMachineCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -475,7 +475,7 @@ impl<'a> MintFromCandyMachineCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -590,12 +590,12 @@ impl<'a> MintFromCandyMachineCpi<'a> {
 }
 
 /// `mint_from_candy_machine` CPI instruction builder.
-pub struct MintFromCandyMachineCpiBuilder<'a> {
-    instruction: Box<MintFromCandyMachineCpiBuilderInstruction<'a>>,
+pub struct MintFromCandyMachineCpiBuilder<'a, 'b> {
+    instruction: Box<MintFromCandyMachineCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintFromCandyMachineCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintFromCandyMachineCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(MintFromCandyMachineCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -622,7 +622,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -630,7 +630,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority_pda(
         &mut self,
-        authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority_pda = Some(authority_pda);
         self
@@ -638,20 +638,20 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     #[inline(always)]
     pub fn nft_mint(
         &mut self,
-        nft_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        nft_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nft_mint = Some(nft_mint);
         self
@@ -659,7 +659,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn nft_mint_authority(
         &mut self,
-        nft_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        nft_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nft_mint_authority = Some(nft_mint_authority);
         self
@@ -667,7 +667,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn nft_metadata(
         &mut self,
-        nft_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        nft_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nft_metadata = Some(nft_metadata);
         self
@@ -675,7 +675,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn nft_master_edition(
         &mut self,
-        nft_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        nft_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.nft_master_edition = Some(nft_master_edition);
         self
@@ -683,7 +683,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -691,7 +691,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -699,7 +699,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -707,7 +707,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition(
         &mut self,
-        collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition = Some(collection_master_edition);
         self
@@ -715,7 +715,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_update_authority(
         &mut self,
-        collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_update_authority = Some(collection_update_authority);
         self
@@ -723,7 +723,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_metadata_program(
         &mut self,
-        token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_metadata_program = Some(token_metadata_program);
         self
@@ -731,7 +731,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -739,7 +739,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -747,7 +747,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn recent_slothashes(
         &mut self,
-        recent_slothashes: &'a solana_program::account_info::AccountInfo<'a>,
+        recent_slothashes: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.recent_slothashes = Some(recent_slothashes);
         self
@@ -755,7 +755,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -763,7 +763,7 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -869,24 +869,24 @@ impl<'a> MintFromCandyMachineCpiBuilder<'a> {
     }
 }
 
-struct MintFromCandyMachineCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    nft_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    nft_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    nft_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    nft_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_metadata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    recent_slothashes: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct MintFromCandyMachineCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    nft_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    nft_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    nft_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    nft_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    recent_slothashes: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -335,77 +335,77 @@ impl MintNewEditionFromMasterEditionViaTokenBuilder {
 }
 
 /// `mint_new_edition_from_master_edition_via_token` CPI accounts.
-pub struct MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a> {
+pub struct MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// owner of token account containing master token (#8)
-    pub token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token account containing token from master metadata mint
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `mint_new_edition_from_master_edition_via_token` CPI instruction.
-pub struct MintNewEditionFromMasterEditionViaTokenCpi<'a> {
+pub struct MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition'])
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// owner of token account containing master token (#8)
-    pub token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// token account containing token from master metadata mint
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MintNewEditionFromMasterEditionViaTokenInstructionArgs,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintNewEditionFromMasterEditionViaTokenCpiAccounts<'a, 'b>,
         args: MintNewEditionFromMasterEditionViaTokenInstructionArgs,
     ) -> Self {
         Self {
@@ -434,7 +434,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -450,7 +450,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -560,12 +560,12 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpi<'a> {
 }
 
 /// `mint_new_edition_from_master_edition_via_token` CPI instruction builder.
-pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
-    instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a>>,
+pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
+    instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction {
                 __program: program,
@@ -593,7 +593,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata(
         &mut self,
-        new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata = Some(new_metadata);
         self
@@ -602,7 +602,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_edition(
         &mut self,
-        new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_edition = Some(new_edition);
         self
@@ -611,7 +611,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -620,7 +620,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint(
         &mut self,
-        new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint = Some(new_mint);
         self
@@ -629,7 +629,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_mark_pda(
         &mut self,
-        edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_mark_pda = Some(edition_mark_pda);
         self
@@ -638,14 +638,14 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint_authority(
         &mut self,
-        new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint_authority = Some(new_mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -653,7 +653,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account_owner(
         &mut self,
-        token_account_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account_owner = Some(token_account_owner);
         self
@@ -662,7 +662,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -671,7 +671,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata_update_authority(
         &mut self,
-        new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata_update_authority = Some(new_metadata_update_authority);
         self
@@ -680,7 +680,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -689,7 +689,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -698,7 +698,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -708,7 +708,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -726,7 +726,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -734,7 +734,7 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -827,23 +827,23 @@ impl<'a> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a> {
     }
 }
 
-struct MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    new_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_mark_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_metadata_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    new_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_mark_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_metadata_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_new_edition_from_master_edition_via_token_args:
         Option<MintNewEditionFromMasterEditionViaTokenArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -389,89 +389,89 @@ impl MintNewEditionFromMasterEditionViaVaultProxyBuilder {
 }
 
 /// `mint_new_edition_from_master_edition_via_vault_proxy` CPI accounts.
-pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a> {
+pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a, 'b> {
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition']
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault authority
-    pub vault_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit token store account
-    pub safety_deposit_store: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_store: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit box
-    pub safety_deposit_box: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_box: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault
-    pub vault: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token vault program
-    pub token_vault_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `mint_new_edition_from_master_edition_via_vault_proxy` CPI instruction.
-pub struct MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
+pub struct MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Metadata key (pda of ['metadata', program id, mint id])
-    pub new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// New Edition (pda of ['metadata', program id, mint id, 'edition'])
-    pub new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Record Edition V2 (pda of ['metadata', program id, master metadata mint id, 'edition']
-    pub master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of new token - THIS WILL TRANSFER AUTHORITY AWAY FROM THIS KEY
-    pub new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition pda to mark creation - will be checked for pre-existence. (pda of ['metadata', program id, master metadata mint id, 'edition', edition_number]) where edition_number is NOT the edition number you pass in args but actually edition_number = floor(edition/EDITION_MARKER_BIT_SIZE).
-    pub edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint authority of new mint
-    pub new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault authority
-    pub vault_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit token store account
-    pub safety_deposit_store: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_store: &'b solana_program::account_info::AccountInfo<'a>,
     /// Safety deposit box
-    pub safety_deposit_box: &'a solana_program::account_info::AccountInfo<'a>,
+    pub safety_deposit_box: &'b solana_program::account_info::AccountInfo<'a>,
     /// Vault
-    pub vault: &'a solana_program::account_info::AccountInfo<'a>,
+    pub vault: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority info for new metadata
-    pub new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master record metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token vault program
-    pub token_vault_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_vault_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: MintNewEditionFromMasterEditionViaVaultProxyCpiAccounts<'a, 'b>,
         args: MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs,
     ) -> Self {
         Self {
@@ -503,7 +503,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -519,7 +519,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(17 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -644,12 +644,12 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a> {
 }
 
 /// `mint_new_edition_from_master_edition_via_vault_proxy` CPI instruction builder.
-pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
-    instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a>>,
+pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
+    instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(
             MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction {
                 __program: program,
@@ -680,7 +680,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata(
         &mut self,
-        new_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata = Some(new_metadata);
         self
@@ -689,7 +689,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_edition(
         &mut self,
-        new_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        new_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_edition = Some(new_edition);
         self
@@ -698,7 +698,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.master_edition = Some(master_edition);
         self
@@ -707,7 +707,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint(
         &mut self,
-        new_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint = Some(new_mint);
         self
@@ -716,7 +716,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition_mark_pda(
         &mut self,
-        edition_mark_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        edition_mark_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition_mark_pda = Some(edition_mark_pda);
         self
@@ -725,14 +725,14 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_mint_authority(
         &mut self,
-        new_mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_mint_authority = Some(new_mint_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -740,7 +740,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn vault_authority(
         &mut self,
-        vault_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        vault_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.vault_authority = Some(vault_authority);
         self
@@ -749,7 +749,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn safety_deposit_store(
         &mut self,
-        safety_deposit_store: &'a solana_program::account_info::AccountInfo<'a>,
+        safety_deposit_store: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.safety_deposit_store = Some(safety_deposit_store);
         self
@@ -758,14 +758,14 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn safety_deposit_box(
         &mut self,
-        safety_deposit_box: &'a solana_program::account_info::AccountInfo<'a>,
+        safety_deposit_box: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.safety_deposit_box = Some(safety_deposit_box);
         self
     }
     /// Vault
     #[inline(always)]
-    pub fn vault(&mut self, vault: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn vault(&mut self, vault: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.vault = Some(vault);
         self
     }
@@ -773,7 +773,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_metadata_update_authority(
         &mut self,
-        new_metadata_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_metadata_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_metadata_update_authority = Some(new_metadata_update_authority);
         self
@@ -782,7 +782,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -791,7 +791,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -800,7 +800,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_vault_program(
         &mut self,
-        token_vault_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_vault_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_vault_program = Some(token_vault_program);
         self
@@ -809,7 +809,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -819,7 +819,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -837,7 +837,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -845,7 +845,7 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -950,26 +950,26 @@ impl<'a> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a> {
     }
 }
 
-struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    new_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition_mark_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    vault_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    safety_deposit_store: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    safety_deposit_box: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    vault: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_metadata_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_vault_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    new_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition_mark_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    vault_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    safety_deposit_store: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    safety_deposit_box: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_metadata_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_vault_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     mint_new_edition_from_master_edition_via_token_args:
         Option<MintNewEditionFromMasterEditionViaTokenArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mod.rs
+++ b/test/packages/rust/src/generated/instructions/mod.rs
@@ -161,14 +161,14 @@ impl InstructionAccount {
 }
 
 #[derive(Clone, Copy)]
-pub enum InstructionAccountInfo<'a> {
-    Readonly(&'a solana_program::account_info::AccountInfo<'a>),
-    ReadonlySigner(&'a solana_program::account_info::AccountInfo<'a>),
-    Writable(&'a solana_program::account_info::AccountInfo<'a>),
-    WritableSigner(&'a solana_program::account_info::AccountInfo<'a>),
+pub enum InstructionAccountInfo<'a, 'b> {
+    Readonly(&'b solana_program::account_info::AccountInfo<'a>),
+    ReadonlySigner(&'b solana_program::account_info::AccountInfo<'a>),
+    Writable(&'b solana_program::account_info::AccountInfo<'a>),
+    WritableSigner(&'b solana_program::account_info::AccountInfo<'a>),
 }
 
-impl<'a> InstructionAccountInfo<'a> {
+impl<'a, 'b> InstructionAccountInfo<'a, 'b> {
     pub fn to_account_meta(&self) -> solana_program::instruction::AccountMeta {
         let (pubkey, writable, signer) = match self {
             InstructionAccountInfo::Readonly(account_info) => (account_info.key, false, false),
@@ -183,7 +183,7 @@ impl<'a> InstructionAccountInfo<'a> {
             solana_program::instruction::AccountMeta::new_readonly(*pubkey, signer)
         }
     }
-    pub fn account_info(&self) -> &'a solana_program::account_info::AccountInfo<'a> {
+    pub fn account_info(&self) -> &'b solana_program::account_info::AccountInfo<'a> {
         match self {
             InstructionAccountInfo::Readonly(account_info)
             | InstructionAccountInfo::ReadonlySigner(account_info)

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -90,23 +90,23 @@ impl PuffMetadataBuilder {
 }
 
 /// `puff_metadata` CPI accounts.
-pub struct PuffMetadataCpiAccounts<'a> {
+pub struct PuffMetadataCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `puff_metadata` CPI instruction.
-pub struct PuffMetadataCpi<'a> {
+pub struct PuffMetadataCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> PuffMetadataCpi<'a> {
+impl<'a, 'b> PuffMetadataCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: PuffMetadataCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: PuffMetadataCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -120,7 +120,7 @@ impl<'a> PuffMetadataCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -136,7 +136,7 @@ impl<'a> PuffMetadataCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(1 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -169,12 +169,12 @@ impl<'a> PuffMetadataCpi<'a> {
 }
 
 /// `puff_metadata` CPI instruction builder.
-pub struct PuffMetadataCpiBuilder<'a> {
-    instruction: Box<PuffMetadataCpiBuilderInstruction<'a>>,
+pub struct PuffMetadataCpiBuilder<'a, 'b> {
+    instruction: Box<PuffMetadataCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> PuffMetadataCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> PuffMetadataCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(PuffMetadataCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -186,7 +186,7 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -194,7 +194,7 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -202,7 +202,7 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -231,8 +231,8 @@ impl<'a> PuffMetadataCpiBuilder<'a> {
     }
 }
 
-struct PuffMetadataCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct PuffMetadataCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -106,27 +106,27 @@ impl RemoveCreatorVerificationBuilder {
 }
 
 /// `remove_creator_verification` CPI accounts.
-pub struct RemoveCreatorVerificationCpiAccounts<'a> {
+pub struct RemoveCreatorVerificationCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `remove_creator_verification` CPI instruction.
-pub struct RemoveCreatorVerificationCpi<'a> {
+pub struct RemoveCreatorVerificationCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> RemoveCreatorVerificationCpi<'a> {
+impl<'a, 'b> RemoveCreatorVerificationCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RemoveCreatorVerificationCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RemoveCreatorVerificationCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -141,7 +141,7 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -157,7 +157,7 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -197,12 +197,12 @@ impl<'a> RemoveCreatorVerificationCpi<'a> {
 }
 
 /// `remove_creator_verification` CPI instruction builder.
-pub struct RemoveCreatorVerificationCpiBuilder<'a> {
-    instruction: Box<RemoveCreatorVerificationCpiBuilderInstruction<'a>>,
+pub struct RemoveCreatorVerificationCpiBuilder<'a, 'b> {
+    instruction: Box<RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RemoveCreatorVerificationCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RemoveCreatorVerificationCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -215,7 +215,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -224,7 +224,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn creator(
         &mut self,
-        creator: &'a solana_program::account_info::AccountInfo<'a>,
+        creator: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.creator = Some(creator);
         self
@@ -232,7 +232,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -240,7 +240,7 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -271,9 +271,9 @@ impl<'a> RemoveCreatorVerificationCpiBuilder<'a> {
     }
 }
 
-struct RemoveCreatorVerificationCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    creator: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    creator: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -339,73 +339,73 @@ impl RevokeBuilder {
 }
 
 /// `revoke` CPI accounts.
-pub struct RevokeCpiAccounts<'a> {
+pub struct RevokeCpiAccounts<'a, 'b> {
     /// Delegate account key (pda of [mint id, delegate role, user id, authority id])
-    pub delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Authority to approve the delegation
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke` CPI instruction.
-pub struct RevokeCpi<'a> {
+pub struct RevokeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate account key (pda of [mint id, delegate role, user id, authority id])
-    pub delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner of the delegated account
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint of metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account of mint
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Authority to approve the delegation
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token Program
-    pub spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: RevokeInstructionArgs,
 }
 
-impl<'a> RevokeCpi<'a> {
+impl<'a, 'b> RevokeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeCpiAccounts<'a, 'b>,
         args: RevokeInstructionArgs,
     ) -> Self {
         Self {
@@ -433,7 +433,7 @@ impl<'a> RevokeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -449,7 +449,7 @@ impl<'a> RevokeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -588,12 +588,12 @@ impl<'a> RevokeCpi<'a> {
 }
 
 /// `revoke` CPI instruction builder.
-pub struct RevokeCpiBuilder<'a> {
-    instruction: Box<RevokeCpiBuilderInstruction<'a>>,
+pub struct RevokeCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeCpiBuilderInstruction {
             __program: program,
             delegate_record: None,
@@ -618,7 +618,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate_record = Some(delegate_record);
         self
@@ -627,7 +627,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -636,7 +636,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -646,14 +646,14 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
     }
     /// Mint of metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -662,7 +662,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -671,14 +671,14 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -686,7 +686,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -695,7 +695,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -705,7 +705,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.spl_token_program = spl_token_program;
         self
@@ -715,7 +715,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -725,7 +725,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -738,7 +738,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -746,7 +746,7 @@ impl<'a> RevokeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -816,21 +816,21 @@ impl<'a> RevokeCpiBuilder<'a> {
     }
 }
 
-struct RevokeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct RevokeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     revoke_args: Option<RevokeArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -160,39 +160,39 @@ impl RevokeCollectionAuthorityBuilder {
 }
 
 /// `revoke_collection_authority` CPI accounts.
-pub struct RevokeCollectionAuthorityCpiAccounts<'a> {
+pub struct RevokeCollectionAuthorityCpiAccounts<'a, 'b> {
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegated Collection Authority
-    pub delegate_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority, or Delegated Authority, of Collection NFT
-    pub revoke_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub revoke_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `revoke_collection_authority` CPI instruction.
-pub struct RevokeCollectionAuthorityCpi<'a> {
+pub struct RevokeCollectionAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegated Collection Authority
-    pub delegate_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority, or Delegated Authority, of Collection NFT
-    pub revoke_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub revoke_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> RevokeCollectionAuthorityCpi<'a> {
+impl<'a, 'b> RevokeCollectionAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeCollectionAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeCollectionAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -210,7 +210,7 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -226,7 +226,7 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -281,12 +281,12 @@ impl<'a> RevokeCollectionAuthorityCpi<'a> {
 }
 
 /// `revoke_collection_authority` CPI instruction builder.
-pub struct RevokeCollectionAuthorityCpiBuilder<'a> {
-    instruction: Box<RevokeCollectionAuthorityCpiBuilderInstruction<'a>>,
+pub struct RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeCollectionAuthorityCpiBuilderInstruction {
             __program: program,
             collection_authority_record: None,
@@ -302,7 +302,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -311,7 +311,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_authority(
         &mut self,
-        delegate_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate_authority = Some(delegate_authority);
         self
@@ -320,7 +320,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn revoke_authority(
         &mut self,
-        revoke_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        revoke_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.revoke_authority = Some(revoke_authority);
         self
@@ -329,21 +329,21 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Mint of Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -351,7 +351,7 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -397,12 +397,12 @@ impl<'a> RevokeCollectionAuthorityCpiBuilder<'a> {
     }
 }
 
-struct RevokeCollectionAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    revoke_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    revoke_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -224,55 +224,55 @@ impl RevokeUseAuthorityBuilder {
 }
 
 /// `revoke_use_authority` CPI accounts.
-pub struct RevokeUseAuthorityCpiAccounts<'a> {
+pub struct RevokeUseAuthorityCpiAccounts<'a, 'b> {
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `revoke_use_authority` CPI instruction.
-pub struct RevokeUseAuthorityCpi<'a> {
+pub struct RevokeUseAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA
-    pub use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority
-    pub user: &'a solana_program::account_info::AccountInfo<'a>,
+    pub user: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owned Token Account Of Mint
-    pub owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> RevokeUseAuthorityCpi<'a> {
+impl<'a, 'b> RevokeUseAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: RevokeUseAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: RevokeUseAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -294,7 +294,7 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -310,7 +310,7 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(9 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -393,12 +393,12 @@ impl<'a> RevokeUseAuthorityCpi<'a> {
 }
 
 /// `revoke_use_authority` CPI instruction builder.
-pub struct RevokeUseAuthorityCpiBuilder<'a> {
-    instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a>>,
+pub struct RevokeUseAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> RevokeUseAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(RevokeUseAuthorityCpiBuilderInstruction {
             __program: program,
             use_authority_record: None,
@@ -418,20 +418,20 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority_record = Some(use_authority_record);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// A Use Authority
     #[inline(always)]
-    pub fn user(&mut self, user: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn user(&mut self, user: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.user = Some(user);
         self
     }
@@ -439,14 +439,14 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn owner_token_account(
         &mut self,
-        owner_token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        owner_token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.owner_token_account = Some(owner_token_account);
         self
     }
     /// Mint of Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -454,7 +454,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -463,7 +463,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -472,7 +472,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -482,7 +482,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn rent(
         &mut self,
-        rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.rent = rent;
         self
@@ -490,7 +490,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -498,7 +498,7 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -555,16 +555,16 @@ impl<'a> RevokeUseAuthorityCpiBuilder<'a> {
     }
 }
 
-struct RevokeUseAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    user: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner_token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct RevokeUseAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    user: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner_token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -216,51 +216,51 @@ impl SetAndVerifyCollectionBuilder {
 }
 
 /// `set_and_verify_collection` CPI accounts.
-pub struct SetAndVerifyCollectionCpiAccounts<'a> {
+pub struct SetAndVerifyCollectionCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_and_verify_collection` CPI instruction.
-pub struct SetAndVerifyCollectionCpi<'a> {
+pub struct SetAndVerifyCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> SetAndVerifyCollectionCpi<'a> {
+impl<'a, 'b> SetAndVerifyCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetAndVerifyCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetAndVerifyCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -281,7 +281,7 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -297,7 +297,7 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -376,12 +376,12 @@ impl<'a> SetAndVerifyCollectionCpi<'a> {
 }
 
 /// `set_and_verify_collection` CPI instruction builder.
-pub struct SetAndVerifyCollectionCpiBuilder<'a> {
-    instruction: Box<SetAndVerifyCollectionCpiBuilderInstruction<'a>>,
+pub struct SetAndVerifyCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetAndVerifyCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetAndVerifyCollectionCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -400,7 +400,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -409,14 +409,14 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// Payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -424,7 +424,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -433,7 +433,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -442,7 +442,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -451,7 +451,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -462,7 +462,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -470,7 +470,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -478,7 +478,7 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -533,15 +533,15 @@ impl<'a> SetAndVerifyCollectionCpiBuilder<'a> {
     }
 }
 
-struct SetAndVerifyCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -216,51 +216,51 @@ impl SetAndVerifySizedCollectionItemBuilder {
 }
 
 /// `set_and_verify_sized_collection_item` CPI accounts.
-pub struct SetAndVerifySizedCollectionItemCpiAccounts<'a> {
+pub struct SetAndVerifySizedCollectionItemCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_and_verify_sized_collection_item` CPI instruction.
-pub struct SetAndVerifySizedCollectionItemCpi<'a> {
+pub struct SetAndVerifySizedCollectionItemCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update Authority of Collection NFT and NFT
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
+impl<'a, 'b> SetAndVerifySizedCollectionItemCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetAndVerifySizedCollectionItemCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetAndVerifySizedCollectionItemCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -281,7 +281,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -297,7 +297,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(8 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -376,12 +376,12 @@ impl<'a> SetAndVerifySizedCollectionItemCpi<'a> {
 }
 
 /// `set_and_verify_sized_collection_item` CPI instruction builder.
-pub struct SetAndVerifySizedCollectionItemCpiBuilder<'a> {
-    instruction: Box<SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a>>,
+pub struct SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    instruction: Box<SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetAndVerifySizedCollectionItemCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -400,7 +400,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -409,14 +409,14 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -424,7 +424,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -433,7 +433,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -442,7 +442,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -451,7 +451,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -462,7 +462,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -470,7 +470,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -478,7 +478,7 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -533,15 +533,15 @@ impl<'a> SetAndVerifySizedCollectionItemCpiBuilder<'a> {
     }
 }
 
-struct SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -128,28 +128,28 @@ impl SetAuthorityBuilder {
 }
 
 /// `set_authority` CPI accounts.
-pub struct SetAuthorityCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct SetAuthorityCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `set_authority` CPI instruction.
-pub struct SetAuthorityCpi<'a> {
+pub struct SetAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: SetAuthorityInstructionArgs,
 }
 
-impl<'a> SetAuthorityCpi<'a> {
+impl<'a, 'b> SetAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetAuthorityCpiAccounts<'a, 'b>,
         args: SetAuthorityInstructionArgs,
     ) -> Self {
         Self {
@@ -166,7 +166,7 @@ impl<'a> SetAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -182,7 +182,7 @@ impl<'a> SetAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -222,12 +222,12 @@ impl<'a> SetAuthorityCpi<'a> {
 }
 
 /// `set_authority` CPI instruction builder.
-pub struct SetAuthorityCpiBuilder<'a> {
-    instruction: Box<SetAuthorityCpiBuilderInstruction<'a>>,
+pub struct SetAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<SetAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetAuthorityCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -240,7 +240,7 @@ impl<'a> SetAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -248,7 +248,7 @@ impl<'a> SetAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -261,7 +261,7 @@ impl<'a> SetAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -269,7 +269,7 @@ impl<'a> SetAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -311,10 +311,10 @@ impl<'a> SetAuthorityCpiBuilder<'a> {
     }
 }
 
-struct SetAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct SetAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     new_authority: Option<Pubkey>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -306,74 +306,74 @@ impl SetCollectionBuilder {
 }
 
 /// `set_collection` CPI accounts.
-pub struct SetCollectionCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct SetCollectionCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `set_collection` CPI instruction.
-pub struct SetCollectionCpi<'a> {
+pub struct SetCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub new_collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+    pub new_collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> SetCollectionCpi<'a> {
+impl<'a, 'b> SetCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -400,7 +400,7 @@ impl<'a> SetCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -416,7 +416,7 @@ impl<'a> SetCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(14 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -514,12 +514,12 @@ impl<'a> SetCollectionCpi<'a> {
 }
 
 /// `set_collection` CPI instruction builder.
-pub struct SetCollectionCpiBuilder<'a> {
-    instruction: Box<SetCollectionCpiBuilderInstruction<'a>>,
+pub struct SetCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<SetCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetCollectionCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -543,7 +543,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -551,7 +551,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -559,20 +559,20 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority_pda(
         &mut self,
-        authority_pda: &'a solana_program::account_info::AccountInfo<'a>,
+        authority_pda: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority_pda = Some(authority_pda);
         self
     }
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -580,7 +580,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -588,7 +588,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = Some(collection_authority_record);
         self
@@ -596,7 +596,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_update_authority(
         &mut self,
-        new_collection_update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_update_authority = Some(new_collection_update_authority);
         self
@@ -604,7 +604,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_metadata(
         &mut self,
-        new_collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_metadata = Some(new_collection_metadata);
         self
@@ -612,7 +612,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_mint(
         &mut self,
-        new_collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_mint = Some(new_collection_mint);
         self
@@ -620,7 +620,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_master_edition(
         &mut self,
-        new_collection_master_edition: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_master_edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_master_edition = Some(new_collection_master_edition);
         self
@@ -628,7 +628,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn new_collection_authority_record(
         &mut self,
-        new_collection_authority_record: &'a solana_program::account_info::AccountInfo<'a>,
+        new_collection_authority_record: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.new_collection_authority_record = Some(new_collection_authority_record);
         self
@@ -636,7 +636,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_metadata_program(
         &mut self,
-        token_metadata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_metadata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_metadata_program = Some(token_metadata_program);
         self
@@ -644,7 +644,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -652,7 +652,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -660,7 +660,7 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -751,21 +751,21 @@ impl<'a> SetCollectionCpiBuilder<'a> {
     }
 }
 
-struct SetCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority_pda: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    new_collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_metadata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority_pda: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    new_collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -186,37 +186,37 @@ impl SetCollectionSizeBuilder {
 }
 
 /// `set_collection_size` CPI accounts.
-pub struct SetCollectionSizeCpiAccounts<'a> {
+pub struct SetCollectionSizeCpiAccounts<'a, 'b> {
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_collection_size` CPI instruction.
-pub struct SetCollectionSizeCpi<'a> {
+pub struct SetCollectionSizeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Metadata account
-    pub collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: SetCollectionSizeInstructionArgs,
 }
 
-impl<'a> SetCollectionSizeCpi<'a> {
+impl<'a, 'b> SetCollectionSizeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetCollectionSizeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetCollectionSizeCpiAccounts<'a, 'b>,
         args: SetCollectionSizeInstructionArgs,
     ) -> Self {
         Self {
@@ -235,7 +235,7 @@ impl<'a> SetCollectionSizeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -251,7 +251,7 @@ impl<'a> SetCollectionSizeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -312,12 +312,12 @@ impl<'a> SetCollectionSizeCpi<'a> {
 }
 
 /// `set_collection_size` CPI instruction builder.
-pub struct SetCollectionSizeCpiBuilder<'a> {
-    instruction: Box<SetCollectionSizeCpiBuilderInstruction<'a>>,
+pub struct SetCollectionSizeCpiBuilder<'a, 'b> {
+    instruction: Box<SetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetCollectionSizeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetCollectionSizeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetCollectionSizeCpiBuilderInstruction {
             __program: program,
             collection_metadata: None,
@@ -333,7 +333,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_metadata(
         &mut self,
-        collection_metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_metadata = Some(collection_metadata);
         self
@@ -342,7 +342,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
@@ -351,7 +351,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -361,7 +361,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -377,7 +377,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -385,7 +385,7 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -437,12 +437,12 @@ impl<'a> SetCollectionSizeCpiBuilder<'a> {
     }
 }
 
-struct SetCollectionSizeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    collection_metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct SetCollectionSizeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     set_collection_size_args: Option<SetCollectionSizeArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -116,30 +116,30 @@ impl SetMintAuthorityBuilder {
 }
 
 /// `set_mint_authority` CPI accounts.
-pub struct SetMintAuthorityCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct SetMintAuthorityCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `set_mint_authority` CPI instruction.
-pub struct SetMintAuthorityCpi<'a> {
+pub struct SetMintAuthorityCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> SetMintAuthorityCpi<'a> {
+impl<'a, 'b> SetMintAuthorityCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetMintAuthorityCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetMintAuthorityCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -155,7 +155,7 @@ impl<'a> SetMintAuthorityCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -171,7 +171,7 @@ impl<'a> SetMintAuthorityCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -214,12 +214,12 @@ impl<'a> SetMintAuthorityCpi<'a> {
 }
 
 /// `set_mint_authority` CPI instruction builder.
-pub struct SetMintAuthorityCpiBuilder<'a> {
-    instruction: Box<SetMintAuthorityCpiBuilderInstruction<'a>>,
+pub struct SetMintAuthorityCpiBuilder<'a, 'b> {
+    instruction: Box<SetMintAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetMintAuthorityCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetMintAuthorityCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetMintAuthorityCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -232,7 +232,7 @@ impl<'a> SetMintAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -240,7 +240,7 @@ impl<'a> SetMintAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -248,7 +248,7 @@ impl<'a> SetMintAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn mint_authority(
         &mut self,
-        mint_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        mint_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.mint_authority = Some(mint_authority);
         self
@@ -256,7 +256,7 @@ impl<'a> SetMintAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -264,7 +264,7 @@ impl<'a> SetMintAuthorityCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -303,10 +303,10 @@ impl<'a> SetMintAuthorityCpiBuilder<'a> {
     }
 }
 
-struct SetMintAuthorityCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetMintAuthorityCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -141,35 +141,35 @@ impl SetTokenStandardBuilder {
 }
 
 /// `set_token_standard` CPI accounts.
-pub struct SetTokenStandardCpiAccounts<'a> {
+pub struct SetTokenStandardCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `set_token_standard` CPI instruction.
-pub struct SetTokenStandardCpi<'a> {
+pub struct SetTokenStandardCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata update authority
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition account
-    pub edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> SetTokenStandardCpi<'a> {
+impl<'a, 'b> SetTokenStandardCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SetTokenStandardCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SetTokenStandardCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -186,7 +186,7 @@ impl<'a> SetTokenStandardCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -202,7 +202,7 @@ impl<'a> SetTokenStandardCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(4 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -259,12 +259,12 @@ impl<'a> SetTokenStandardCpi<'a> {
 }
 
 /// `set_token_standard` CPI instruction builder.
-pub struct SetTokenStandardCpiBuilder<'a> {
-    instruction: Box<SetTokenStandardCpiBuilderInstruction<'a>>,
+pub struct SetTokenStandardCpiBuilder<'a, 'b> {
+    instruction: Box<SetTokenStandardCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SetTokenStandardCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SetTokenStandardCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SetTokenStandardCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -279,7 +279,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -288,14 +288,14 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -304,7 +304,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.edition = edition;
         self
@@ -312,7 +312,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -320,7 +320,7 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -358,11 +358,11 @@ impl<'a> SetTokenStandardCpiBuilder<'a> {
     }
 }
 
-struct SetTokenStandardCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SetTokenStandardCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -104,27 +104,27 @@ impl SignMetadataBuilder {
 }
 
 /// `sign_metadata` CPI accounts.
-pub struct SignMetadataCpiAccounts<'a> {
+pub struct SignMetadataCpiAccounts<'a, 'b> {
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `sign_metadata` CPI instruction.
-pub struct SignMetadataCpi<'a> {
+pub struct SignMetadataCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Creator
-    pub creator: &'a solana_program::account_info::AccountInfo<'a>,
+    pub creator: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> SignMetadataCpi<'a> {
+impl<'a, 'b> SignMetadataCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: SignMetadataCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: SignMetadataCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -139,7 +139,7 @@ impl<'a> SignMetadataCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -155,7 +155,7 @@ impl<'a> SignMetadataCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -193,12 +193,12 @@ impl<'a> SignMetadataCpi<'a> {
 }
 
 /// `sign_metadata` CPI instruction builder.
-pub struct SignMetadataCpiBuilder<'a> {
-    instruction: Box<SignMetadataCpiBuilderInstruction<'a>>,
+pub struct SignMetadataCpiBuilder<'a, 'b> {
+    instruction: Box<SignMetadataCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> SignMetadataCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> SignMetadataCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(SignMetadataCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -211,7 +211,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -220,7 +220,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn creator(
         &mut self,
-        creator: &'a solana_program::account_info::AccountInfo<'a>,
+        creator: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.creator = Some(creator);
         self
@@ -228,7 +228,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -236,7 +236,7 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -267,9 +267,9 @@ impl<'a> SignMetadataCpiBuilder<'a> {
     }
 }
 
-struct SignMetadataCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    creator: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct SignMetadataCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    creator: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -150,39 +150,39 @@ impl ThawDelegatedAccountBuilder {
 }
 
 /// `thaw_delegated_account` CPI accounts.
-pub struct ThawDelegatedAccountCpiAccounts<'a> {
+pub struct ThawDelegatedAccountCpiAccounts<'a, 'b> {
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to thaw
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `thaw_delegated_account` CPI instruction.
-pub struct ThawDelegatedAccountCpi<'a> {
+pub struct ThawDelegatedAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate
-    pub delegate: &'a solana_program::account_info::AccountInfo<'a>,
+    pub delegate: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account to thaw
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Edition
-    pub edition: &'a solana_program::account_info::AccountInfo<'a>,
+    pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token mint
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> ThawDelegatedAccountCpi<'a> {
+impl<'a, 'b> ThawDelegatedAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ThawDelegatedAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ThawDelegatedAccountCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -200,7 +200,7 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -216,7 +216,7 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -271,12 +271,12 @@ impl<'a> ThawDelegatedAccountCpi<'a> {
 }
 
 /// `thaw_delegated_account` CPI instruction builder.
-pub struct ThawDelegatedAccountCpiBuilder<'a> {
-    instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a>>,
+pub struct ThawDelegatedAccountCpiBuilder<'a, 'b> {
+    instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ThawDelegatedAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ThawDelegatedAccountCpiBuilderInstruction {
             __program: program,
             delegate: None,
@@ -292,7 +292,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate(
         &mut self,
-        delegate: &'a solana_program::account_info::AccountInfo<'a>,
+        delegate: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.delegate = Some(delegate);
         self
@@ -301,7 +301,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
@@ -310,14 +310,14 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn edition(
         &mut self,
-        edition: &'a solana_program::account_info::AccountInfo<'a>,
+        edition: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.edition = Some(edition);
         self
     }
     /// Token mint
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -325,7 +325,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -333,7 +333,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -341,7 +341,7 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -384,12 +384,12 @@ impl<'a> ThawDelegatedAccountCpiBuilder<'a> {
     }
 }
 
-struct ThawDelegatedAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    delegate: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct ThawDelegatedAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -379,81 +379,81 @@ impl TransferBuilder {
 }
 
 /// `transfer` CPI accounts.
-pub struct TransferCpiAccounts<'a> {
+pub struct TransferCpiAccounts<'a, 'b> {
     /// Transfer authority (token or delegate owner)
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner
-    pub token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account
-    pub destination: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account owner
-    pub destination_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition of token asset
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `transfer` CPI instruction.
-pub struct TransferCpi<'a> {
+pub struct TransferCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Transfer authority (token or delegate owner)
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token account
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account owner
-    pub token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account
-    pub destination: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination: &'b solana_program::account_info::AccountInfo<'a>,
     /// Destination token account owner
-    pub destination_owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub destination_owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of token asset
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition of token asset
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// SPL Token Program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Associated Token Account program
-    pub spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System Program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: TransferInstructionArgs,
 }
 
-impl<'a> TransferCpi<'a> {
+impl<'a, 'b> TransferCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: TransferCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: TransferCpiAccounts<'a, 'b>,
         args: TransferInstructionArgs,
     ) -> Self {
         Self {
@@ -483,7 +483,7 @@ impl<'a> TransferCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -499,7 +499,7 @@ impl<'a> TransferCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(15 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -640,12 +640,12 @@ impl<'a> TransferCpi<'a> {
 }
 
 /// `transfer` CPI instruction builder.
-pub struct TransferCpiBuilder<'a> {
-    instruction: Box<TransferCpiBuilderInstruction<'a>>,
+pub struct TransferCpiBuilder<'a, 'b> {
+    instruction: Box<TransferCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> TransferCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> TransferCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TransferCpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -672,7 +672,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -682,14 +682,14 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
     }
     /// Token account
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
@@ -697,7 +697,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_owner(
         &mut self,
-        token_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        token_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_owner = Some(token_owner);
         self
@@ -706,7 +706,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn destination(
         &mut self,
-        destination: &'a solana_program::account_info::AccountInfo<'a>,
+        destination: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination = Some(destination);
         self
@@ -715,14 +715,14 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn destination_owner(
         &mut self,
-        destination_owner: &'a solana_program::account_info::AccountInfo<'a>,
+        destination_owner: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.destination_owner = Some(destination_owner);
         self
     }
     /// Mint of token asset
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -730,7 +730,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -740,7 +740,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
@@ -749,7 +749,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -758,7 +758,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_ata_program(
         &mut self,
-        spl_ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_ata_program = Some(spl_ata_program);
         self
@@ -767,7 +767,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -776,7 +776,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -786,7 +786,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -796,7 +796,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -809,7 +809,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -817,7 +817,7 @@ impl<'a> TransferCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -903,23 +903,23 @@ impl<'a> TransferCpiBuilder<'a> {
     }
 }
 
-struct TransferCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    destination: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    destination_owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct TransferCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    destination_owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     transfer_args: Option<TransferArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -302,73 +302,73 @@ impl TransferOutOfEscrowBuilder {
 }
 
 /// `transfer_out_of_escrow` CPI accounts.
-pub struct TransferOutOfEscrowCpiAccounts<'a> {
+pub struct TransferOutOfEscrowCpiAccounts<'a, 'b> {
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account for the new attribute
-    pub attribute_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account source for the new attribute
-    pub attribute_src: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_src: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account, owned by TM, destination for the new attribute
-    pub attribute_dst: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_dst: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account that the escrow is attached
-    pub escrow_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account that holds the token the escrow is attached to
-    pub escrow_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `transfer_out_of_escrow` CPI instruction.
-pub struct TransferOutOfEscrowCpi<'a> {
+pub struct TransferOutOfEscrowCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Escrow account
-    pub escrow: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Wallet paying for the transaction and new account
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account for the new attribute
-    pub attribute_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account source for the new attribute
-    pub attribute_src: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_src: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account, owned by TM, destination for the new attribute
-    pub attribute_dst: &'a solana_program::account_info::AccountInfo<'a>,
+    pub attribute_dst: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint account that the escrow is attached
-    pub escrow_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account that holds the token the escrow is attached to
-    pub escrow_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub escrow_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Instructions sysvar account
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Authority/creator of the escrow account
-    pub authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: TransferOutOfEscrowInstructionArgs,
 }
 
-impl<'a> TransferOutOfEscrowCpi<'a> {
+impl<'a, 'b> TransferOutOfEscrowCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: TransferOutOfEscrowCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: TransferOutOfEscrowCpiAccounts<'a, 'b>,
         args: TransferOutOfEscrowInstructionArgs,
     ) -> Self {
         Self {
@@ -396,7 +396,7 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -412,7 +412,7 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -518,12 +518,12 @@ impl<'a> TransferOutOfEscrowCpi<'a> {
 }
 
 /// `transfer_out_of_escrow` CPI instruction builder.
-pub struct TransferOutOfEscrowCpiBuilder<'a> {
-    instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a>>,
+pub struct TransferOutOfEscrowCpiBuilder<'a, 'b> {
+    instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> TransferOutOfEscrowCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(TransferOutOfEscrowCpiBuilderInstruction {
             __program: program,
             escrow: None,
@@ -548,7 +548,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow(
         &mut self,
-        escrow: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow = Some(escrow);
         self
@@ -557,14 +557,14 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Wallet paying for the transaction and new account
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -572,7 +572,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn attribute_mint(
         &mut self,
-        attribute_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        attribute_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.attribute_mint = Some(attribute_mint);
         self
@@ -581,7 +581,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn attribute_src(
         &mut self,
-        attribute_src: &'a solana_program::account_info::AccountInfo<'a>,
+        attribute_src: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.attribute_src = Some(attribute_src);
         self
@@ -590,7 +590,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn attribute_dst(
         &mut self,
-        attribute_dst: &'a solana_program::account_info::AccountInfo<'a>,
+        attribute_dst: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.attribute_dst = Some(attribute_dst);
         self
@@ -599,7 +599,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow_mint(
         &mut self,
-        escrow_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow_mint = Some(escrow_mint);
         self
@@ -608,7 +608,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn escrow_account(
         &mut self,
-        escrow_account: &'a solana_program::account_info::AccountInfo<'a>,
+        escrow_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.escrow_account = Some(escrow_account);
         self
@@ -617,7 +617,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -626,7 +626,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn ata_program(
         &mut self,
-        ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.ata_program = Some(ata_program);
         self
@@ -635,7 +635,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -644,7 +644,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -654,7 +654,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authority = authority;
         self
@@ -667,7 +667,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -675,7 +675,7 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -759,21 +759,21 @@ impl<'a> TransferOutOfEscrowCpiBuilder<'a> {
     }
 }
 
-struct TransferOutOfEscrowCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    escrow: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    attribute_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    attribute_src: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    attribute_dst: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    escrow_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    escrow_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct TransferOutOfEscrowCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    attribute_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    attribute_src: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    attribute_dst: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    escrow_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    escrow_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     amount: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -186,43 +186,43 @@ impl UnverifyCollectionBuilder {
 }
 
 /// `unverify_collection` CPI accounts.
-pub struct UnverifyCollectionCpiAccounts<'a> {
+pub struct UnverifyCollectionCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `unverify_collection` CPI instruction.
-pub struct UnverifyCollectionCpi<'a> {
+pub struct UnverifyCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> UnverifyCollectionCpi<'a> {
+impl<'a, 'b> UnverifyCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnverifyCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnverifyCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -241,7 +241,7 @@ impl<'a> UnverifyCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -257,7 +257,7 @@ impl<'a> UnverifyCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -326,12 +326,12 @@ impl<'a> UnverifyCollectionCpi<'a> {
 }
 
 /// `unverify_collection` CPI instruction builder.
-pub struct UnverifyCollectionCpiBuilder<'a> {
-    instruction: Box<UnverifyCollectionCpiBuilderInstruction<'a>>,
+pub struct UnverifyCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<UnverifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnverifyCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnverifyCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnverifyCollectionCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -348,7 +348,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -357,7 +357,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
@@ -366,7 +366,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -375,7 +375,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -384,7 +384,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -395,7 +395,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -403,7 +403,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -411,7 +411,7 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -459,13 +459,13 @@ impl<'a> UnverifyCollectionCpiBuilder<'a> {
     }
 }
 
-struct UnverifyCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UnverifyCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -199,47 +199,47 @@ impl UnverifySizedCollectionItemBuilder {
 }
 
 /// `unverify_sized_collection_item` CPI accounts.
-pub struct UnverifySizedCollectionItemCpiAccounts<'a> {
+pub struct UnverifySizedCollectionItemCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `unverify_sized_collection_item` CPI instruction.
-pub struct UnverifySizedCollectionItemCpi<'a> {
+pub struct UnverifySizedCollectionItemCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> UnverifySizedCollectionItemCpi<'a> {
+impl<'a, 'b> UnverifySizedCollectionItemCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UnverifySizedCollectionItemCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UnverifySizedCollectionItemCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -259,7 +259,7 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -275,7 +275,7 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -349,12 +349,12 @@ impl<'a> UnverifySizedCollectionItemCpi<'a> {
 }
 
 /// `unverify_sized_collection_item` CPI instruction builder.
-pub struct UnverifySizedCollectionItemCpiBuilder<'a> {
-    instruction: Box<UnverifySizedCollectionItemCpiBuilderInstruction<'a>>,
+pub struct UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
+    instruction: Box<UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UnverifySizedCollectionItemCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -372,7 +372,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -381,14 +381,14 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -396,7 +396,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -405,7 +405,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -414,7 +414,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -425,7 +425,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -433,7 +433,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -441,7 +441,7 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -491,14 +491,14 @@ impl<'a> UnverifySizedCollectionItemCpiBuilder<'a> {
     }
 }
 
-struct UnverifySizedCollectionItemCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -127,28 +127,28 @@ impl UpdateCandyMachineBuilder {
 }
 
 /// `update_candy_machine` CPI accounts.
-pub struct UpdateCandyMachineCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct UpdateCandyMachineCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `update_candy_machine` CPI instruction.
-pub struct UpdateCandyMachineCpi<'a> {
+pub struct UpdateCandyMachineCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: UpdateCandyMachineInstructionArgs,
 }
 
-impl<'a> UpdateCandyMachineCpi<'a> {
+impl<'a, 'b> UpdateCandyMachineCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateCandyMachineCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateCandyMachineCpiAccounts<'a, 'b>,
         args: UpdateCandyMachineInstructionArgs,
     ) -> Self {
         Self {
@@ -165,7 +165,7 @@ impl<'a> UpdateCandyMachineCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -181,7 +181,7 @@ impl<'a> UpdateCandyMachineCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -223,12 +223,12 @@ impl<'a> UpdateCandyMachineCpi<'a> {
 }
 
 /// `update_candy_machine` CPI instruction builder.
-pub struct UpdateCandyMachineCpiBuilder<'a> {
-    instruction: Box<UpdateCandyMachineCpiBuilderInstruction<'a>>,
+pub struct UpdateCandyMachineCpiBuilder<'a, 'b> {
+    instruction: Box<UpdateCandyMachineCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateCandyMachineCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateCandyMachineCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateCandyMachineCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -241,7 +241,7 @@ impl<'a> UpdateCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -249,7 +249,7 @@ impl<'a> UpdateCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -262,7 +262,7 @@ impl<'a> UpdateCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -270,7 +270,7 @@ impl<'a> UpdateCandyMachineCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -308,10 +308,10 @@ impl<'a> UpdateCandyMachineCpiBuilder<'a> {
     }
 }
 
-struct UpdateCandyMachineCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateCandyMachineCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<CandyMachineData>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -161,29 +161,29 @@ impl UpdateMetadataAccountBuilder {
 }
 
 /// `update_metadata_account` CPI accounts.
-pub struct UpdateMetadataAccountCpiAccounts<'a> {
+pub struct UpdateMetadataAccountCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `update_metadata_account` CPI instruction.
-pub struct UpdateMetadataAccountCpi<'a> {
+pub struct UpdateMetadataAccountCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: UpdateMetadataAccountInstructionArgs,
 }
 
-impl<'a> UpdateMetadataAccountCpi<'a> {
+impl<'a, 'b> UpdateMetadataAccountCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateMetadataAccountCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateMetadataAccountCpiAccounts<'a, 'b>,
         args: UpdateMetadataAccountInstructionArgs,
     ) -> Self {
         Self {
@@ -200,7 +200,7 @@ impl<'a> UpdateMetadataAccountCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -216,7 +216,7 @@ impl<'a> UpdateMetadataAccountCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -258,12 +258,12 @@ impl<'a> UpdateMetadataAccountCpi<'a> {
 }
 
 /// `update_metadata_account` CPI instruction builder.
-pub struct UpdateMetadataAccountCpiBuilder<'a> {
-    instruction: Box<UpdateMetadataAccountCpiBuilderInstruction<'a>>,
+pub struct UpdateMetadataAccountCpiBuilder<'a, 'b> {
+    instruction: Box<UpdateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateMetadataAccountCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateMetadataAccountCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -279,7 +279,7 @@ impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -288,7 +288,7 @@ impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -314,7 +314,7 @@ impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -322,7 +322,7 @@ impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -362,12 +362,12 @@ impl<'a> UpdateMetadataAccountCpiBuilder<'a> {
     }
 }
 
-struct UpdateMetadataAccountCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateMetadataAccountCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<UpdateMetadataAccountInstructionDataData>,
     update_authority_arg: Option<Pubkey>,
     primary_sale_happened: Option<bool>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -160,29 +160,29 @@ impl UpdateMetadataAccountV2Builder {
 }
 
 /// `update_metadata_account_v2` CPI accounts.
-pub struct UpdateMetadataAccountV2CpiAccounts<'a> {
+pub struct UpdateMetadataAccountV2CpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `update_metadata_account_v2` CPI instruction.
-pub struct UpdateMetadataAccountV2Cpi<'a> {
+pub struct UpdateMetadataAccountV2Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority key
-    pub update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// The arguments for the instruction.
     pub __args: UpdateMetadataAccountV2InstructionArgs,
 }
 
-impl<'a> UpdateMetadataAccountV2Cpi<'a> {
+impl<'a, 'b> UpdateMetadataAccountV2Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateMetadataAccountV2CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateMetadataAccountV2CpiAccounts<'a, 'b>,
         args: UpdateMetadataAccountV2InstructionArgs,
     ) -> Self {
         Self {
@@ -199,7 +199,7 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -215,7 +215,7 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -257,12 +257,12 @@ impl<'a> UpdateMetadataAccountV2Cpi<'a> {
 }
 
 /// `update_metadata_account_v2` CPI instruction builder.
-pub struct UpdateMetadataAccountV2CpiBuilder<'a> {
-    instruction: Box<UpdateMetadataAccountV2CpiBuilderInstruction<'a>>,
+pub struct UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateMetadataAccountV2CpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -279,7 +279,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -288,7 +288,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn update_authority(
         &mut self,
-        update_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        update_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.update_authority = Some(update_authority);
         self
@@ -320,7 +320,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -328,7 +328,7 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -369,13 +369,13 @@ impl<'a> UpdateMetadataAccountV2CpiBuilder<'a> {
     }
 }
 
-struct UpdateMetadataAccountV2CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    update_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    update_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     data: Option<DataV2>,
     update_authority_arg: Option<Pubkey>,
     primary_sale_happened: Option<bool>,
     is_mutable: Option<bool>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -118,31 +118,31 @@ impl UpdatePrimarySaleHappenedViaTokenBuilder {
 }
 
 /// `update_primary_sale_happened_via_token` CPI accounts.
-pub struct UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a> {
+pub struct UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a, 'b> {
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner on the token account
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Account containing tokens from the metadata's mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `update_primary_sale_happened_via_token` CPI instruction.
-pub struct UpdatePrimarySaleHappenedViaTokenCpi<'a> {
+pub struct UpdatePrimarySaleHappenedViaTokenCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata key (pda of ['metadata', program id, mint id])
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner on the token account
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Account containing tokens from the metadata's mint
-    pub token: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
+impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdatePrimarySaleHappenedViaTokenCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -158,7 +158,7 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -174,7 +174,7 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(3 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -219,12 +219,12 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpi<'a> {
 }
 
 /// `update_primary_sale_happened_via_token` CPI instruction builder.
-pub struct UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
-    instruction: Box<UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a>>,
+pub struct UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
+    instruction: Box<UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -238,27 +238,27 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
     }
     /// Owner on the token account
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
     /// Account containing tokens from the metadata's mint
     #[inline(always)]
-    pub fn token(&mut self, token: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn token(&mut self, token: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.token = Some(token);
         self
     }
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -266,7 +266,7 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -299,10 +299,10 @@ impl<'a> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a> {
     }
 }
 
-struct UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -422,61 +422,61 @@ impl UpdateV1Builder {
 }
 
 /// `update_v1` CPI accounts.
-pub struct UpdateV1CpiAccounts<'a> {
+pub struct UpdateV1CpiAccounts<'a, 'b> {
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `update_v1` CPI instruction.
-pub struct UpdateV1Cpi<'a> {
+pub struct UpdateV1Cpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Update authority or delegate
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Master Edition account
-    pub master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Mint account
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+    pub sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token account
-    pub token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Delegate record PDA
-    pub delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UpdateV1InstructionArgs,
 }
 
-impl<'a> UpdateV1Cpi<'a> {
+impl<'a, 'b> UpdateV1Cpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UpdateV1CpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UpdateV1CpiAccounts<'a, 'b>,
         args: UpdateV1InstructionArgs,
     ) -> Self {
         Self {
@@ -501,7 +501,7 @@ impl<'a> UpdateV1Cpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -517,7 +517,7 @@ impl<'a> UpdateV1Cpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(10 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new_readonly(
@@ -641,12 +641,12 @@ impl<'a> UpdateV1Cpi<'a> {
 }
 
 /// `update_v1` CPI instruction builder.
-pub struct UpdateV1CpiBuilder<'a> {
-    instruction: Box<UpdateV1CpiBuilderInstruction<'a>>,
+pub struct UpdateV1CpiBuilder<'a, 'b> {
+    instruction: Box<UpdateV1CpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UpdateV1CpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UpdateV1CpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UpdateV1CpiBuilderInstruction {
             __program: program,
             authority: None,
@@ -679,7 +679,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -688,7 +688,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -698,14 +698,14 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn master_edition(
         &mut self,
-        master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.master_edition = master_edition;
         self
     }
     /// Mint account
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -713,7 +713,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -722,7 +722,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn sysvar_instructions(
         &mut self,
-        sysvar_instructions: &'a solana_program::account_info::AccountInfo<'a>,
+        sysvar_instructions: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.sysvar_instructions = Some(sysvar_instructions);
         self
@@ -732,7 +732,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn token(
         &mut self,
-        token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.token = token;
         self
@@ -742,7 +742,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn delegate_record(
         &mut self,
-        delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.delegate_record = delegate_record;
         self
@@ -752,7 +752,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -762,7 +762,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -841,7 +841,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -849,7 +849,7 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -921,18 +921,18 @@ impl<'a> UpdateV1CpiBuilder<'a> {
     }
 }
 
-struct UpdateV1CpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    master_edition: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    sysvar_instructions: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    delegate_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UpdateV1CpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    sysvar_instructions: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     authorization_data: Option<AuthorizationData>,
     new_update_authority: Option<Pubkey>,
     data: Option<UpdateV1InstructionDataData>,
@@ -945,5 +945,5 @@ struct UpdateV1CpiBuilderInstruction<'a> {
     programmable_config: Option<ProgrammableConfig>,
     delegate_state: Option<DelegateState>,
     authority_type: Option<AuthorityType>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -298,65 +298,65 @@ impl UseAssetBuilder {
 }
 
 /// `use_asset` CPI accounts.
-pub struct UseAssetCpiAccounts<'a> {
+pub struct UseAssetCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Account Of NFT
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use authority or current owner of the asset
-    pub use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA (if present the program assumes a delegated use authority)
-    pub use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `use_asset` CPI instruction.
-pub struct UseAssetCpi<'a> {
+pub struct UseAssetCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Account Of NFT
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use authority or current owner of the asset
-    pub use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// SPL Token program
-    pub spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA (if present the program assumes a delegated use authority)
-    pub use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UseAssetInstructionArgs,
 }
 
-impl<'a> UseAssetCpi<'a> {
+impl<'a, 'b> UseAssetCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UseAssetCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UseAssetCpiAccounts<'a, 'b>,
         args: UseAssetInstructionArgs,
     ) -> Self {
         Self {
@@ -382,7 +382,7 @@ impl<'a> UseAssetCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -398,7 +398,7 @@ impl<'a> UseAssetCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -510,12 +510,12 @@ impl<'a> UseAssetCpi<'a> {
 }
 
 /// `use_asset` CPI instruction builder.
-pub struct UseAssetCpiBuilder<'a> {
-    instruction: Box<UseAssetCpiBuilderInstruction<'a>>,
+pub struct UseAssetCpiBuilder<'a, 'b> {
+    instruction: Box<UseAssetCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UseAssetCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UseAssetCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UseAssetCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -538,7 +538,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -547,14 +547,14 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
     }
     /// Mint of the Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -562,14 +562,14 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority(
         &mut self,
-        use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority = Some(use_authority);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
@@ -577,7 +577,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn spl_token_program(
         &mut self,
-        spl_token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        spl_token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.spl_token_program = Some(spl_token_program);
         self
@@ -586,7 +586,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn ata_program(
         &mut self,
-        ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.ata_program = Some(ata_program);
         self
@@ -595,7 +595,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -605,7 +605,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.use_authority_record = use_authority_record;
         self
@@ -615,7 +615,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -625,7 +625,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -638,7 +638,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -646,7 +646,7 @@ impl<'a> UseAssetCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -718,19 +718,19 @@ impl<'a> UseAssetCpiBuilder<'a> {
     }
 }
 
-struct UseAssetCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    use_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    spl_token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UseAssetCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    use_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    spl_token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     use_asset_args: Option<UseAssetArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -281,65 +281,65 @@ impl UtilizeBuilder {
 }
 
 /// `utilize` CPI accounts.
-pub struct UtilizeCpiAccounts<'a> {
+pub struct UtilizeCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Account Of NFT
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority / Can be the current Owner of the NFT
-    pub use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA If present the program Assumes a delegated use authority
-    pub use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Program As Signer (Burner)
-    pub burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `utilize` CPI instruction.
-pub struct UtilizeCpi<'a> {
+pub struct UtilizeCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Account Of NFT
-    pub token_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Metadata
-    pub mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// A Use Authority / Can be the current Owner of the NFT
-    pub use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// Owner
-    pub owner: &'a solana_program::account_info::AccountInfo<'a>,
+    pub owner: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token program
-    pub token_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub token_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Associated Token program
-    pub ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Rent info
-    pub rent: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rent: &'b solana_program::account_info::AccountInfo<'a>,
     /// Use Authority Record PDA If present the program Assumes a delegated use authority
-    pub use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Program As Signer (Burner)
-    pub burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: UtilizeInstructionArgs,
 }
 
-impl<'a> UtilizeCpi<'a> {
+impl<'a, 'b> UtilizeCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: UtilizeCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: UtilizeCpiAccounts<'a, 'b>,
         args: UtilizeInstructionArgs,
     ) -> Self {
         Self {
@@ -365,7 +365,7 @@ impl<'a> UtilizeCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -381,7 +381,7 @@ impl<'a> UtilizeCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(11 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -484,12 +484,12 @@ impl<'a> UtilizeCpi<'a> {
 }
 
 /// `utilize` CPI instruction builder.
-pub struct UtilizeCpiBuilder<'a> {
-    instruction: Box<UtilizeCpiBuilderInstruction<'a>>,
+pub struct UtilizeCpiBuilder<'a, 'b> {
+    instruction: Box<UtilizeCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> UtilizeCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> UtilizeCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(UtilizeCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -512,7 +512,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -521,14 +521,14 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_account(
         &mut self,
-        token_account: &'a solana_program::account_info::AccountInfo<'a>,
+        token_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_account = Some(token_account);
         self
     }
     /// Mint of the Metadata
     #[inline(always)]
-    pub fn mint(&mut self, mint: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn mint(&mut self, mint: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.mint = Some(mint);
         self
     }
@@ -536,14 +536,14 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority(
         &mut self,
-        use_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        use_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.use_authority = Some(use_authority);
         self
     }
     /// Owner
     #[inline(always)]
-    pub fn owner(&mut self, owner: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn owner(&mut self, owner: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.owner = Some(owner);
         self
     }
@@ -551,7 +551,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn token_program(
         &mut self,
-        token_program: &'a solana_program::account_info::AccountInfo<'a>,
+        token_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.token_program = Some(token_program);
         self
@@ -560,7 +560,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn ata_program(
         &mut self,
-        ata_program: &'a solana_program::account_info::AccountInfo<'a>,
+        ata_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.ata_program = Some(ata_program);
         self
@@ -569,14 +569,14 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
     }
     /// Rent info
     #[inline(always)]
-    pub fn rent(&mut self, rent: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn rent(&mut self, rent: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.rent = Some(rent);
         self
     }
@@ -585,7 +585,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn use_authority_record(
         &mut self,
-        use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.use_authority_record = use_authority_record;
         self
@@ -595,7 +595,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn burner(
         &mut self,
-        burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.burner = burner;
         self
@@ -608,7 +608,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -616,7 +616,7 @@ impl<'a> UtilizeCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -688,19 +688,19 @@ impl<'a> UtilizeCpiBuilder<'a> {
     }
 }
 
-struct UtilizeCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    use_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    owner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    token_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    ata_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rent: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    use_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    burner: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct UtilizeCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    use_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    owner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    token_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    ata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rent: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    burner: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     number_of_uses: Option<u64>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -366,73 +366,73 @@ impl ValidateBuilder {
 }
 
 /// `validate` CPI accounts.
-pub struct ValidateCpiAccounts<'a> {
+pub struct ValidateCpiAccounts<'a, 'b> {
     /// Payer and creator of the RuleSet
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The PDA account where the RuleSet is stored
-    pub rule_set: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rule_set: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub opt_rule_signer1: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
+    pub opt_rule_signer1: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
     /// Optional rule validation signer 2
-    pub opt_rule_signer2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation signer 3
-    pub opt_rule_signer3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation signer 4
-    pub opt_rule_signer4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation signer 5
-    pub opt_rule_signer5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 1
-    pub opt_rule_nonsigner1: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 2
-    pub opt_rule_nonsigner2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 3
-    pub opt_rule_nonsigner3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 4
-    pub opt_rule_nonsigner4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 5
-    pub opt_rule_nonsigner5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `validate` CPI instruction.
-pub struct ValidateCpi<'a> {
+pub struct ValidateCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Payer and creator of the RuleSet
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// The PDA account where the RuleSet is stored
-    pub rule_set: &'a solana_program::account_info::AccountInfo<'a>,
+    pub rule_set: &'b solana_program::account_info::AccountInfo<'a>,
     /// System program
-    pub system_program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub opt_rule_signer1: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
+    pub opt_rule_signer1: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
     /// Optional rule validation signer 2
-    pub opt_rule_signer2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation signer 3
-    pub opt_rule_signer3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation signer 4
-    pub opt_rule_signer4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation signer 5
-    pub opt_rule_signer5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_signer5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 1
-    pub opt_rule_nonsigner1: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 2
-    pub opt_rule_nonsigner2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 3
-    pub opt_rule_nonsigner3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 4
-    pub opt_rule_nonsigner4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Optional rule validation non-signer 5
-    pub opt_rule_nonsigner5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub opt_rule_nonsigner5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: ValidateInstructionArgs,
 }
 
-impl<'a> ValidateCpi<'a> {
+impl<'a, 'b> ValidateCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: ValidateCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: ValidateCpiAccounts<'a, 'b>,
         args: ValidateInstructionArgs,
     ) -> Self {
         Self {
@@ -460,7 +460,7 @@ impl<'a> ValidateCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -476,7 +476,7 @@ impl<'a> ValidateCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(13 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -611,12 +611,12 @@ impl<'a> ValidateCpi<'a> {
 }
 
 /// `validate` CPI instruction builder.
-pub struct ValidateCpiBuilder<'a> {
-    instruction: Box<ValidateCpiBuilderInstruction<'a>>,
+pub struct ValidateCpiBuilder<'a, 'b> {
+    instruction: Box<ValidateCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> ValidateCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> ValidateCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(ValidateCpiBuilderInstruction {
             __program: program,
             payer: None,
@@ -641,7 +641,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     }
     /// Payer and creator of the RuleSet
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -649,7 +649,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn rule_set(
         &mut self,
-        rule_set: &'a solana_program::account_info::AccountInfo<'a>,
+        rule_set: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.rule_set = Some(rule_set);
         self
@@ -658,7 +658,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn system_program(
         &mut self,
-        system_program: &'a solana_program::account_info::AccountInfo<'a>,
+        system_program: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.system_program = Some(system_program);
         self
@@ -667,7 +667,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_signer1(
         &mut self,
-        opt_rule_signer1: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_signer1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
         as_signer: bool,
     ) -> &mut Self {
         if let Some(opt_rule_signer1) = opt_rule_signer1 {
@@ -682,7 +682,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_signer2(
         &mut self,
-        opt_rule_signer2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_signer2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_signer2 = opt_rule_signer2;
         self
@@ -692,7 +692,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_signer3(
         &mut self,
-        opt_rule_signer3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_signer3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_signer3 = opt_rule_signer3;
         self
@@ -702,7 +702,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_signer4(
         &mut self,
-        opt_rule_signer4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_signer4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_signer4 = opt_rule_signer4;
         self
@@ -712,7 +712,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_signer5(
         &mut self,
-        opt_rule_signer5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_signer5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_signer5 = opt_rule_signer5;
         self
@@ -722,7 +722,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_nonsigner1(
         &mut self,
-        opt_rule_nonsigner1: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_nonsigner1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_nonsigner1 = opt_rule_nonsigner1;
         self
@@ -732,7 +732,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_nonsigner2(
         &mut self,
-        opt_rule_nonsigner2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_nonsigner2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_nonsigner2 = opt_rule_nonsigner2;
         self
@@ -742,7 +742,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_nonsigner3(
         &mut self,
-        opt_rule_nonsigner3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_nonsigner3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_nonsigner3 = opt_rule_nonsigner3;
         self
@@ -752,7 +752,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_nonsigner4(
         &mut self,
-        opt_rule_nonsigner4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_nonsigner4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_nonsigner4 = opt_rule_nonsigner4;
         self
@@ -762,7 +762,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn opt_rule_nonsigner5(
         &mut self,
-        opt_rule_nonsigner5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        opt_rule_nonsigner5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.opt_rule_nonsigner5 = opt_rule_nonsigner5;
         self
@@ -785,7 +785,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -793,7 +793,7 @@ impl<'a> ValidateCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -867,23 +867,23 @@ impl<'a> ValidateCpiBuilder<'a> {
     }
 }
 
-struct ValidateCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    rule_set: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    system_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_signer1: Option<(&'a solana_program::account_info::AccountInfo<'a>, bool)>,
-    opt_rule_signer2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_signer3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_signer4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_signer5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_nonsigner1: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_nonsigner2: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_nonsigner3: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_nonsigner4: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    opt_rule_nonsigner5: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct ValidateCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    rule_set: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_signer1: Option<(&'b solana_program::account_info::AccountInfo<'a>, bool)>,
+    opt_rule_signer2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_signer3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_signer4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_signer5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_nonsigner1: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_nonsigner2: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_nonsigner3: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_nonsigner4: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    opt_rule_nonsigner5: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     rule_set_name: Option<String>,
     operation: Option<Operation>,
     payload: Option<Payload>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -194,41 +194,41 @@ impl VerifyBuilder {
 }
 
 /// `verify` CPI accounts.
-pub struct VerifyCpiAccounts<'a> {
+pub struct VerifyCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `verify` CPI instruction.
-pub struct VerifyCpi<'a> {
+pub struct VerifyCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Token Authorization Rules account
-    pub authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// Token Authorization Rules Program
-    pub authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
     pub __args: VerifyInstructionArgs,
 }
 
-impl<'a> VerifyCpi<'a> {
+impl<'a, 'b> VerifyCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifyCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifyCpiAccounts<'a, 'b>,
         args: VerifyInstructionArgs,
     ) -> Self {
         Self {
@@ -248,7 +248,7 @@ impl<'a> VerifyCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -264,7 +264,7 @@ impl<'a> VerifyCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(5 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -337,12 +337,12 @@ impl<'a> VerifyCpi<'a> {
 }
 
 /// `verify` CPI instruction builder.
-pub struct VerifyCpiBuilder<'a> {
-    instruction: Box<VerifyCpiBuilderInstruction<'a>>,
+pub struct VerifyCpiBuilder<'a, 'b> {
+    instruction: Box<VerifyCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifyCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifyCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifyCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -359,7 +359,7 @@ impl<'a> VerifyCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -368,14 +368,14 @@ impl<'a> VerifyCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -384,7 +384,7 @@ impl<'a> VerifyCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules(
         &mut self,
-        authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules = authorization_rules;
         self
@@ -394,7 +394,7 @@ impl<'a> VerifyCpiBuilder<'a> {
     #[inline(always)]
     pub fn authorization_rules_program(
         &mut self,
-        authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.authorization_rules_program = authorization_rules_program;
         self
@@ -407,7 +407,7 @@ impl<'a> VerifyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -415,7 +415,7 @@ impl<'a> VerifyCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -463,13 +463,13 @@ impl<'a> VerifyCpiBuilder<'a> {
     }
 }
 
-struct VerifyCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authorization_rules_program: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+struct VerifyCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authorization_rules_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     verify_args: Option<VerifyArgs>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -172,43 +172,43 @@ impl VerifyCollectionBuilder {
 }
 
 /// `verify_collection` CPI accounts.
-pub struct VerifyCollectionCpiAccounts<'a> {
+pub struct VerifyCollectionCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `verify_collection` CPI instruction.
-pub struct VerifyCollectionCpi<'a> {
+pub struct VerifyCollectionCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> VerifyCollectionCpi<'a> {
+impl<'a, 'b> VerifyCollectionCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifyCollectionCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifyCollectionCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -227,7 +227,7 @@ impl<'a> VerifyCollectionCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -243,7 +243,7 @@ impl<'a> VerifyCollectionCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(6 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -301,12 +301,12 @@ impl<'a> VerifyCollectionCpi<'a> {
 }
 
 /// `verify_collection` CPI instruction builder.
-pub struct VerifyCollectionCpiBuilder<'a> {
-    instruction: Box<VerifyCollectionCpiBuilderInstruction<'a>>,
+pub struct VerifyCollectionCpiBuilder<'a, 'b> {
+    instruction: Box<VerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifyCollectionCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifyCollectionCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifyCollectionCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -323,7 +323,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -332,14 +332,14 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -347,7 +347,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -356,7 +356,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -365,7 +365,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -374,7 +374,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -382,7 +382,7 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -430,13 +430,13 @@ impl<'a> VerifyCollectionCpiBuilder<'a> {
     }
 }
 
-struct VerifyCollectionCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct VerifyCollectionCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -199,47 +199,47 @@ impl VerifySizedCollectionItemBuilder {
 }
 
 /// `verify_sized_collection_item` CPI accounts.
-pub struct VerifySizedCollectionItemCpiAccounts<'a> {
+pub struct VerifySizedCollectionItemCpiAccounts<'a, 'b> {
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
 /// `verify_sized_collection_item` CPI instruction.
-pub struct VerifySizedCollectionItemCpi<'a> {
+pub struct VerifySizedCollectionItemCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata account
-    pub metadata: &'a solana_program::account_info::AccountInfo<'a>,
+    pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Update authority
-    pub collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     /// payer
-    pub payer: &'a solana_program::account_info::AccountInfo<'a>,
+    pub payer: &'b solana_program::account_info::AccountInfo<'a>,
     /// Mint of the Collection
-    pub collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     /// Metadata Account of the Collection
-    pub collection: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection: &'b solana_program::account_info::AccountInfo<'a>,
     /// MasterEdition2 Account of the Collection Token
-    pub collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+    pub collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     /// Collection Authority Record PDA
-    pub collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+    pub collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-impl<'a> VerifySizedCollectionItemCpi<'a> {
+impl<'a, 'b> VerifySizedCollectionItemCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: VerifySizedCollectionItemCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: VerifySizedCollectionItemCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -259,7 +259,7 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -275,7 +275,7 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(7 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -349,12 +349,12 @@ impl<'a> VerifySizedCollectionItemCpi<'a> {
 }
 
 /// `verify_sized_collection_item` CPI instruction builder.
-pub struct VerifySizedCollectionItemCpiBuilder<'a> {
-    instruction: Box<VerifySizedCollectionItemCpiBuilderInstruction<'a>>,
+pub struct VerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    instruction: Box<VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> VerifySizedCollectionItemCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(VerifySizedCollectionItemCpiBuilderInstruction {
             __program: program,
             metadata: None,
@@ -372,7 +372,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn metadata(
         &mut self,
-        metadata: &'a solana_program::account_info::AccountInfo<'a>,
+        metadata: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.metadata = Some(metadata);
         self
@@ -381,14 +381,14 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority(
         &mut self,
-        collection_authority: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_authority = Some(collection_authority);
         self
     }
     /// payer
     #[inline(always)]
-    pub fn payer(&mut self, payer: &'a solana_program::account_info::AccountInfo<'a>) -> &mut Self {
+    pub fn payer(&mut self, payer: &'b solana_program::account_info::AccountInfo<'a>) -> &mut Self {
         self.instruction.payer = Some(payer);
         self
     }
@@ -396,7 +396,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_mint(
         &mut self,
-        collection_mint: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_mint: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_mint = Some(collection_mint);
         self
@@ -405,7 +405,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection(
         &mut self,
-        collection: &'a solana_program::account_info::AccountInfo<'a>,
+        collection: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection = Some(collection);
         self
@@ -414,7 +414,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_master_edition_account(
         &mut self,
-        collection_master_edition_account: &'a solana_program::account_info::AccountInfo<'a>,
+        collection_master_edition_account: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.collection_master_edition_account =
             Some(collection_master_edition_account);
@@ -425,7 +425,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn collection_authority_record(
         &mut self,
-        collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
+        collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     ) -> &mut Self {
         self.instruction.collection_authority_record = collection_authority_record;
         self
@@ -433,7 +433,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -441,7 +441,7 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -491,14 +491,14 @@ impl<'a> VerifySizedCollectionItemCpiBuilder<'a> {
     }
 }
 
-struct VerifySizedCollectionItemCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    metadata: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    payer: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_mint: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_master_edition_account: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    collection_authority_record: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_mint: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_master_edition_account: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -103,26 +103,26 @@ impl WithdrawBuilder {
 }
 
 /// `withdraw` CPI accounts.
-pub struct WithdrawCpiAccounts<'a> {
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+pub struct WithdrawCpiAccounts<'a, 'b> {
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
 /// `withdraw` CPI instruction.
-pub struct WithdrawCpi<'a> {
+pub struct WithdrawCpi<'a, 'b> {
     /// The program to invoke.
-    pub __program: &'a solana_program::account_info::AccountInfo<'a>,
+    pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+    pub candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
 
-    pub authority: &'a solana_program::account_info::AccountInfo<'a>,
+    pub authority: &'b solana_program::account_info::AccountInfo<'a>,
 }
 
-impl<'a> WithdrawCpi<'a> {
+impl<'a, 'b> WithdrawCpi<'a, 'b> {
     pub fn new(
-        program: &'a solana_program::account_info::AccountInfo<'a>,
-        accounts: WithdrawCpiAccounts<'a>,
+        program: &'b solana_program::account_info::AccountInfo<'a>,
+        accounts: WithdrawCpiAccounts<'a, 'b>,
     ) -> Self {
         Self {
             __program: program,
@@ -137,7 +137,7 @@ impl<'a> WithdrawCpi<'a> {
     #[inline(always)]
     pub fn invoke_with_remaining_accounts(
         &self,
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         self.invoke_signed_with_remaining_accounts(&[], remaining_accounts)
     }
@@ -153,7 +153,7 @@ impl<'a> WithdrawCpi<'a> {
     pub fn invoke_signed_with_remaining_accounts(
         &self,
         signers_seeds: &[&[&[u8]]],
-        remaining_accounts: &[super::InstructionAccountInfo<'a>],
+        remaining_accounts: &[super::InstructionAccountInfo<'a, '_>],
     ) -> solana_program::entrypoint::ProgramResult {
         let mut accounts = Vec::with_capacity(2 + remaining_accounts.len());
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -191,12 +191,12 @@ impl<'a> WithdrawCpi<'a> {
 }
 
 /// `withdraw` CPI instruction builder.
-pub struct WithdrawCpiBuilder<'a> {
-    instruction: Box<WithdrawCpiBuilderInstruction<'a>>,
+pub struct WithdrawCpiBuilder<'a, 'b> {
+    instruction: Box<WithdrawCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a> WithdrawCpiBuilder<'a> {
-    pub fn new(program: &'a solana_program::account_info::AccountInfo<'a>) -> Self {
+impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
+    pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
         let instruction = Box::new(WithdrawCpiBuilderInstruction {
             __program: program,
             candy_machine: None,
@@ -208,7 +208,7 @@ impl<'a> WithdrawCpiBuilder<'a> {
     #[inline(always)]
     pub fn candy_machine(
         &mut self,
-        candy_machine: &'a solana_program::account_info::AccountInfo<'a>,
+        candy_machine: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.candy_machine = Some(candy_machine);
         self
@@ -216,7 +216,7 @@ impl<'a> WithdrawCpiBuilder<'a> {
     #[inline(always)]
     pub fn authority(
         &mut self,
-        authority: &'a solana_program::account_info::AccountInfo<'a>,
+        authority: &'b solana_program::account_info::AccountInfo<'a>,
     ) -> &mut Self {
         self.instruction.authority = Some(authority);
         self
@@ -224,7 +224,7 @@ impl<'a> WithdrawCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,
-        account: super::InstructionAccountInfo<'a>,
+        account: super::InstructionAccountInfo<'a, 'b>,
     ) -> &mut Self {
         self.instruction.__remaining_accounts.push(account);
         self
@@ -232,7 +232,7 @@ impl<'a> WithdrawCpiBuilder<'a> {
     #[inline(always)]
     pub fn add_remaining_accounts(
         &mut self,
-        accounts: &[super::InstructionAccountInfo<'a>],
+        accounts: &[super::InstructionAccountInfo<'a, 'b>],
     ) -> &mut Self {
         self.instruction
             .__remaining_accounts
@@ -266,9 +266,9 @@ impl<'a> WithdrawCpiBuilder<'a> {
     }
 }
 
-struct WithdrawCpiBuilderInstruction<'a> {
-    __program: &'a solana_program::account_info::AccountInfo<'a>,
-    candy_machine: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    authority: Option<&'a solana_program::account_info::AccountInfo<'a>>,
-    __remaining_accounts: Vec<super::InstructionAccountInfo<'a>>,
+struct WithdrawCpiBuilderInstruction<'a, 'b> {
+    __program: &'b solana_program::account_info::AccountInfo<'a>,
+    candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
+    __remaining_accounts: Vec<super::InstructionAccountInfo<'a, 'b>>,
 }


### PR DESCRIPTION
CPI builders currently assume that `AccountInfo` type and references have the same lifetimes (`&'a AccountInfo<'a>`). This causes issues in Anchor programs since Anchor separates the lifetime of the reference from the type – this PR changes the CPI builders to follow this pattern.