### PR TITLE
Add decimal indices to error comments in Rust client

### DIFF
--- a/.changeset/hot-moons-breathe.md
+++ b/.changeset/hot-moons-breathe.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add decimal indices to error comments in Rust client

--- a/src/renderers/rust/templates/errorsPage.njk
+++ b/src/renderers/rust/templates/errorsPage.njk
@@ -8,7 +8,7 @@ use thiserror::Error;
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum {{ program.name | pascalCase }}Error {
 {% for error in errors | sort(false, false, 'code') %}
-    /// 0x{{ error.code.toString(16) | upper }} - {{ error.message }}
+    /// {{ error.code }} (0x{{ error.code.toString(16) | upper }}) - {{ error.message }}
     #[error("{{ error.message }}")]
     {{ error.name | pascalCase }},
 {% endfor %}

--- a/test/packages/rust/src/generated/errors/mpl_candy_machine_core.rs
+++ b/test/packages/rust/src/generated/errors/mpl_candy_machine_core.rs
@@ -10,67 +10,67 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplCandyMachineCoreError {
-    /// 0x1770 - Account does not have correct owner
+    /// 6000 (0x1770) - Account does not have correct owner
     #[error("Account does not have correct owner")]
     IncorrectOwner,
-    /// 0x1771 - Account is not initialized
+    /// 6001 (0x1771) - Account is not initialized
     #[error("Account is not initialized")]
     Uninitialized,
-    /// 0x1772 - Mint Mismatch
+    /// 6002 (0x1772) - Mint Mismatch
     #[error("Mint Mismatch")]
     MintMismatch,
-    /// 0x1773 - Index greater than length
+    /// 6003 (0x1773) - Index greater than length
     #[error("Index greater than length")]
     IndexGreaterThanLength,
-    /// 0x1774 - Numerical overflow error
+    /// 6004 (0x1774) - Numerical overflow error
     #[error("Numerical overflow error")]
     NumericalOverflowError,
-    /// 0x1775 - Can only provide up to 4 creators to candy machine (because candy machine is one)
+    /// 6005 (0x1775) - Can only provide up to 4 creators to candy machine (because candy machine is one)
     #[error("Can only provide up to 4 creators to candy machine (because candy machine is one)")]
     TooManyCreators,
-    /// 0x1776 - Candy machine is empty
+    /// 6006 (0x1776) - Candy machine is empty
     #[error("Candy machine is empty")]
     CandyMachineEmpty,
-    /// 0x1777 - Candy machines using hidden uris do not have config lines, they have a single hash representing hashed order
+    /// 6007 (0x1777) - Candy machines using hidden uris do not have config lines, they have a single hash representing hashed order
     #[error("Candy machines using hidden uris do not have config lines, they have a single hash representing hashed order")]
     HiddenSettingsDoNotHaveConfigLines,
-    /// 0x1778 - Cannot change number of lines unless is a hidden config
+    /// 6008 (0x1778) - Cannot change number of lines unless is a hidden config
     #[error("Cannot change number of lines unless is a hidden config")]
     CannotChangeNumberOfLines,
-    /// 0x1779 - Cannot switch to hidden settings after items available is greater than 0
+    /// 6009 (0x1779) - Cannot switch to hidden settings after items available is greater than 0
     #[error("Cannot switch to hidden settings after items available is greater than 0")]
     CannotSwitchToHiddenSettings,
-    /// 0x177A - Incorrect collection NFT authority
+    /// 6010 (0x177A) - Incorrect collection NFT authority
     #[error("Incorrect collection NFT authority")]
     IncorrectCollectionAuthority,
-    /// 0x177B - The metadata account has data in it, and this must be empty to mint a new NFT
+    /// 6011 (0x177B) - The metadata account has data in it, and this must be empty to mint a new NFT
     #[error("The metadata account has data in it, and this must be empty to mint a new NFT")]
     MetadataAccountMustBeEmpty,
-    /// 0x177C - Can't change collection settings after items have begun to be minted
+    /// 6012 (0x177C) - Can't change collection settings after items have begun to be minted
     #[error("Can't change collection settings after items have begun to be minted")]
     NoChangingCollectionDuringMint,
-    /// 0x177D - Value longer than expected maximum value
+    /// 6013 (0x177D) - Value longer than expected maximum value
     #[error("Value longer than expected maximum value")]
     ExceededLengthError,
-    /// 0x177E - Missing config lines settings
+    /// 6014 (0x177E) - Missing config lines settings
     #[error("Missing config lines settings")]
     MissingConfigLinesSettings,
-    /// 0x177F - Cannot increase the length in config lines settings
+    /// 6015 (0x177F) - Cannot increase the length in config lines settings
     #[error("Cannot increase the length in config lines settings")]
     CannotIncreaseLength,
-    /// 0x1780 - Cannot switch from hidden settings
+    /// 6016 (0x1780) - Cannot switch from hidden settings
     #[error("Cannot switch from hidden settings")]
     CannotSwitchFromHiddenSettings,
-    /// 0x1781 - Cannot change sequential index generation after items have begun to be minted
+    /// 6017 (0x1781) - Cannot change sequential index generation after items have begun to be minted
     #[error("Cannot change sequential index generation after items have begun to be minted")]
     CannotChangeSequentialIndexGeneration,
-    /// 0x1782 - Collection public key mismatch
+    /// 6018 (0x1782) - Collection public key mismatch
     #[error("Collection public key mismatch")]
     CollectionKeyMismatch,
-    /// 0x1783 - Could not retrive config line data
+    /// 6019 (0x1783) - Could not retrive config line data
     #[error("Could not retrive config line data")]
     CouldNotRetrieveConfigLineData,
-    /// 0x1784 - Not all config lines were added to the candy machine
+    /// 6020 (0x1784) - Not all config lines were added to the candy machine
     #[error("Not all config lines were added to the candy machine")]
     NotFullyLoaded,
 }

--- a/test/packages/rust/src/generated/errors/mpl_token_auth_rules.rs
+++ b/test/packages/rust/src/generated/errors/mpl_token_auth_rules.rs
@@ -10,49 +10,49 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplTokenAuthRulesError {
-    /// 0x0 - Numerical Overflow
+    /// 0 (0x0) - Numerical Overflow
     #[error("Numerical Overflow")]
     NumericalOverflow,
-    /// 0x1 - Data type mismatch
+    /// 1 (0x1) - Data type mismatch
     #[error("Data type mismatch")]
     DataTypeMismatch,
-    /// 0x2 - Incorrect account owner
+    /// 2 (0x2) - Incorrect account owner
     #[error("Incorrect account owner")]
     IncorrectOwner,
-    /// 0x3 - Could not index into PayloadVec
+    /// 3 (0x3) - Could not index into PayloadVec
     #[error("Could not index into PayloadVec")]
     PayloadVecIndexError,
-    /// 0x4 - Derived key invalid
+    /// 4 (0x4) - Derived key invalid
     #[error("Derived key invalid")]
     DerivedKeyInvalid,
-    /// 0x5 - Additional Signer check failed
+    /// 5 (0x5) - Additional Signer check failed
     #[error("Additional Signer check failed")]
     AdditionalSignerCheckFailed,
-    /// 0x6 - Pubkey Match check failed
+    /// 6 (0x6) - Pubkey Match check failed
     #[error("Pubkey Match check failed")]
     PubkeyMatchCheckFailed,
-    /// 0x7 - Derived Key Match check failed
+    /// 7 (0x7) - Derived Key Match check failed
     #[error("Derived Key Match check failed")]
     DerivedKeyMatchCheckFailed,
-    /// 0x8 - Program Owned check failed
+    /// 8 (0x8) - Program Owned check failed
     #[error("Program Owned check failed")]
     ProgramOwnedCheckFailed,
-    /// 0x9 - Amount checked failed
+    /// 9 (0x9) - Amount checked failed
     #[error("Amount checked failed")]
     AmountCheckFailed,
-    /// 0xA - Frequency check failed
+    /// 10 (0xA) - Frequency check failed
     #[error("Frequency check failed")]
     FrequencyCheckFailed,
-    /// 0xB - Pubkey Tree Match check failed
+    /// 11 (0xB) - Pubkey Tree Match check failed
     #[error("Pubkey Tree Match check failed")]
     PubkeyTreeMatchCheckFailed,
-    /// 0xC - Payer is not a signer
+    /// 12 (0xC) - Payer is not a signer
     #[error("Payer is not a signer")]
     PayerIsNotSigner,
-    /// 0xD -
+    /// 13 (0xD) -
     #[error("")]
     NotImplemented,
-    /// 0xE - Borsh Serialization Error
+    /// 14 (0xE) - Borsh Serialization Error
     #[error("Borsh Serialization Error")]
     BorshSerializationError,
 }

--- a/test/packages/rust/src/generated/errors/mpl_token_metadata.rs
+++ b/test/packages/rust/src/generated/errors/mpl_token_metadata.rs
@@ -10,461 +10,461 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum MplTokenMetadataError {
-    /// 0x0 - Failed to unpack instruction data
+    /// 0 (0x0) - Failed to unpack instruction data
     #[error("Failed to unpack instruction data")]
     InstructionUnpackError,
-    /// 0x1 - Failed to pack instruction data
+    /// 1 (0x1) - Failed to pack instruction data
     #[error("Failed to pack instruction data")]
     InstructionPackError,
-    /// 0x2 - Lamport balance below rent-exempt threshold
+    /// 2 (0x2) - Lamport balance below rent-exempt threshold
     #[error("Lamport balance below rent-exempt threshold")]
     NotRentExempt,
-    /// 0x3 - Already initialized
+    /// 3 (0x3) - Already initialized
     #[error("Already initialized")]
     AlreadyInitialized,
-    /// 0x4 - Uninitialized
+    /// 4 (0x4) - Uninitialized
     #[error("Uninitialized")]
     Uninitialized,
-    /// 0x5 -  Metadata's key must match seed of ['metadata', program id, mint] provided
+    /// 5 (0x5) -  Metadata's key must match seed of ['metadata', program id, mint] provided
     #[error(" Metadata's key must match seed of ['metadata', program id, mint] provided")]
     InvalidMetadataKey,
-    /// 0x6 - Edition's key must match seed of ['metadata', program id, name, 'edition'] provided
+    /// 6 (0x6) - Edition's key must match seed of ['metadata', program id, name, 'edition'] provided
     #[error("Edition's key must match seed of ['metadata', program id, name, 'edition'] provided")]
     InvalidEditionKey,
-    /// 0x7 - Update Authority given does not match
+    /// 7 (0x7) - Update Authority given does not match
     #[error("Update Authority given does not match")]
     UpdateAuthorityIncorrect,
-    /// 0x8 - Update Authority needs to be signer to update metadata
+    /// 8 (0x8) - Update Authority needs to be signer to update metadata
     #[error("Update Authority needs to be signer to update metadata")]
     UpdateAuthorityIsNotSigner,
-    /// 0x9 - You must be the mint authority and signer on this transaction
+    /// 9 (0x9) - You must be the mint authority and signer on this transaction
     #[error("You must be the mint authority and signer on this transaction")]
     NotMintAuthority,
-    /// 0xA - Mint authority provided does not match the authority on the mint
+    /// 10 (0xA) - Mint authority provided does not match the authority on the mint
     #[error("Mint authority provided does not match the authority on the mint")]
     InvalidMintAuthority,
-    /// 0xB - Name too long
+    /// 11 (0xB) - Name too long
     #[error("Name too long")]
     NameTooLong,
-    /// 0xC - Symbol too long
+    /// 12 (0xC) - Symbol too long
     #[error("Symbol too long")]
     SymbolTooLong,
-    /// 0xD - URI too long
+    /// 13 (0xD) - URI too long
     #[error("URI too long")]
     UriTooLong,
-    /// 0xE - Update authority must be equivalent to the metadata's authority and also signer of this transaction
+    /// 14 (0xE) - Update authority must be equivalent to the metadata's authority and also signer of this transaction
     #[error("Update authority must be equivalent to the metadata's authority and also signer of this transaction")]
     UpdateAuthorityMustBeEqualToMetadataAuthorityAndSigner,
-    /// 0xF - Mint given does not match mint on Metadata
+    /// 15 (0xF) - Mint given does not match mint on Metadata
     #[error("Mint given does not match mint on Metadata")]
     MintMismatch,
-    /// 0x10 - Editions must have exactly one token
+    /// 16 (0x10) - Editions must have exactly one token
     #[error("Editions must have exactly one token")]
     EditionsMustHaveExactlyOneToken,
-    /// 0x11 - Maximum editions printed already
+    /// 17 (0x11) - Maximum editions printed already
     #[error("Maximum editions printed already")]
     MaxEditionsMintedAlready,
-    /// 0x12 - Token mint to failed
+    /// 18 (0x12) - Token mint to failed
     #[error("Token mint to failed")]
     TokenMintToFailed,
-    /// 0x13 - The master edition record passed must match the master record on the edition given
+    /// 19 (0x13) - The master edition record passed must match the master record on the edition given
     #[error("The master edition record passed must match the master record on the edition given")]
     MasterRecordMismatch,
-    /// 0x14 - The destination account does not have the right mint
+    /// 20 (0x14) - The destination account does not have the right mint
     #[error("The destination account does not have the right mint")]
     DestinationMintMismatch,
-    /// 0x15 - An edition can only mint one of its kind!
+    /// 21 (0x15) - An edition can only mint one of its kind!
     #[error("An edition can only mint one of its kind!")]
     EditionAlreadyMinted,
-    /// 0x16 - Printing mint decimals should be zero
+    /// 22 (0x16) - Printing mint decimals should be zero
     #[error("Printing mint decimals should be zero")]
     PrintingMintDecimalsShouldBeZero,
-    /// 0x17 - OneTimePrintingAuthorization mint decimals should be zero
+    /// 23 (0x17) - OneTimePrintingAuthorization mint decimals should be zero
     #[error("OneTimePrintingAuthorization mint decimals should be zero")]
     OneTimePrintingAuthorizationMintDecimalsShouldBeZero,
-    /// 0x18 - EditionMintDecimalsShouldBeZero
+    /// 24 (0x18) - EditionMintDecimalsShouldBeZero
     #[error("EditionMintDecimalsShouldBeZero")]
     EditionMintDecimalsShouldBeZero,
-    /// 0x19 - Token burn failed
+    /// 25 (0x19) - Token burn failed
     #[error("Token burn failed")]
     TokenBurnFailed,
-    /// 0x1A - The One Time authorization mint does not match that on the token account!
+    /// 26 (0x1A) - The One Time authorization mint does not match that on the token account!
     #[error("The One Time authorization mint does not match that on the token account!")]
     TokenAccountOneTimeAuthMintMismatch,
-    /// 0x1B - Derived key invalid
+    /// 27 (0x1B) - Derived key invalid
     #[error("Derived key invalid")]
     DerivedKeyInvalid,
-    /// 0x1C - The Printing mint does not match that on the master edition!
+    /// 28 (0x1C) - The Printing mint does not match that on the master edition!
     #[error("The Printing mint does not match that on the master edition!")]
     PrintingMintMismatch,
-    /// 0x1D - The One Time Printing Auth mint does not match that on the master edition!
+    /// 29 (0x1D) - The One Time Printing Auth mint does not match that on the master edition!
     #[error("The One Time Printing Auth mint does not match that on the master edition!")]
     OneTimePrintingAuthMintMismatch,
-    /// 0x1E - The mint of the token account does not match the Printing mint!
+    /// 30 (0x1E) - The mint of the token account does not match the Printing mint!
     #[error("The mint of the token account does not match the Printing mint!")]
     TokenAccountMintMismatch,
-    /// 0x1F - The mint of the token account does not match the master metadata mint!
+    /// 31 (0x1F) - The mint of the token account does not match the master metadata mint!
     #[error("The mint of the token account does not match the master metadata mint!")]
     TokenAccountMintMismatchV2,
-    /// 0x20 - Not enough tokens to mint a limited edition
+    /// 32 (0x20) - Not enough tokens to mint a limited edition
     #[error("Not enough tokens to mint a limited edition")]
     NotEnoughTokens,
-    /// 0x21 - The mint on your authorization token holding account does not match your Printing mint!
+    /// 33 (0x21) - The mint on your authorization token holding account does not match your Printing mint!
     #[error(
         "The mint on your authorization token holding account does not match your Printing mint!"
     )]
     PrintingMintAuthorizationAccountMismatch,
-    /// 0x22 - The authorization token account has a different owner than the update authority for the master edition!
+    /// 34 (0x22) - The authorization token account has a different owner than the update authority for the master edition!
     #[error("The authorization token account has a different owner than the update authority for the master edition!")]
     AuthorizationTokenAccountOwnerMismatch,
-    /// 0x23 - This feature is currently disabled.
+    /// 35 (0x23) - This feature is currently disabled.
     #[error("This feature is currently disabled.")]
     Disabled,
-    /// 0x24 - Creators list too long
+    /// 36 (0x24) - Creators list too long
     #[error("Creators list too long")]
     CreatorsTooLong,
-    /// 0x25 - Creators must be at least one if set
+    /// 37 (0x25) - Creators must be at least one if set
     #[error("Creators must be at least one if set")]
     CreatorsMustBeAtleastOne,
-    /// 0x26 - If using a creators array, you must be one of the creators listed
+    /// 38 (0x26) - If using a creators array, you must be one of the creators listed
     #[error("If using a creators array, you must be one of the creators listed")]
     MustBeOneOfCreators,
-    /// 0x27 - This metadata does not have creators
+    /// 39 (0x27) - This metadata does not have creators
     #[error("This metadata does not have creators")]
     NoCreatorsPresentOnMetadata,
-    /// 0x28 - This creator address was not found
+    /// 40 (0x28) - This creator address was not found
     #[error("This creator address was not found")]
     CreatorNotFound,
-    /// 0x29 - Basis points cannot be more than 10000
+    /// 41 (0x29) - Basis points cannot be more than 10000
     #[error("Basis points cannot be more than 10000")]
     InvalidBasisPoints,
-    /// 0x2A - Primary sale can only be flipped to true and is immutable
+    /// 42 (0x2A) - Primary sale can only be flipped to true and is immutable
     #[error("Primary sale can only be flipped to true and is immutable")]
     PrimarySaleCanOnlyBeFlippedToTrue,
-    /// 0x2B - Owner does not match that on the account given
+    /// 43 (0x2B) - Owner does not match that on the account given
     #[error("Owner does not match that on the account given")]
     OwnerMismatch,
-    /// 0x2C - This account has no tokens to be used for authorization
+    /// 44 (0x2C) - This account has no tokens to be used for authorization
     #[error("This account has no tokens to be used for authorization")]
     NoBalanceInAccountForAuthorization,
-    /// 0x2D - Share total must equal 100 for creator array
+    /// 45 (0x2D) - Share total must equal 100 for creator array
     #[error("Share total must equal 100 for creator array")]
     ShareTotalMustBe100,
-    /// 0x2E - This reservation list already exists!
+    /// 46 (0x2E) - This reservation list already exists!
     #[error("This reservation list already exists!")]
     ReservationExists,
-    /// 0x2F - This reservation list does not exist!
+    /// 47 (0x2F) - This reservation list does not exist!
     #[error("This reservation list does not exist!")]
     ReservationDoesNotExist,
-    /// 0x30 - This reservation list exists but was never set with reservations
+    /// 48 (0x30) - This reservation list exists but was never set with reservations
     #[error("This reservation list exists but was never set with reservations")]
     ReservationNotSet,
-    /// 0x31 - This reservation list has already been set!
+    /// 49 (0x31) - This reservation list has already been set!
     #[error("This reservation list has already been set!")]
     ReservationAlreadyMade,
-    /// 0x32 - Provided more addresses than max allowed in single reservation
+    /// 50 (0x32) - Provided more addresses than max allowed in single reservation
     #[error("Provided more addresses than max allowed in single reservation")]
     BeyondMaxAddressSize,
-    /// 0x33 - NumericalOverflowError
+    /// 51 (0x33) - NumericalOverflowError
     #[error("NumericalOverflowError")]
     NumericalOverflowError,
-    /// 0x34 - This reservation would go beyond the maximum supply of the master edition!
+    /// 52 (0x34) - This reservation would go beyond the maximum supply of the master edition!
     #[error("This reservation would go beyond the maximum supply of the master edition!")]
     ReservationBreachesMaximumSupply,
-    /// 0x35 - Address not in reservation!
+    /// 53 (0x35) - Address not in reservation!
     #[error("Address not in reservation!")]
     AddressNotInReservation,
-    /// 0x36 - You cannot unilaterally verify another creator, they must sign
+    /// 54 (0x36) - You cannot unilaterally verify another creator, they must sign
     #[error("You cannot unilaterally verify another creator, they must sign")]
     CannotVerifyAnotherCreator,
-    /// 0x37 - You cannot unilaterally unverify another creator
+    /// 55 (0x37) - You cannot unilaterally unverify another creator
     #[error("You cannot unilaterally unverify another creator")]
     CannotUnverifyAnotherCreator,
-    /// 0x38 - In initial reservation setting, spots remaining should equal total spots
+    /// 56 (0x38) - In initial reservation setting, spots remaining should equal total spots
     #[error("In initial reservation setting, spots remaining should equal total spots")]
     SpotMismatch,
-    /// 0x39 - Incorrect account owner
+    /// 57 (0x39) - Incorrect account owner
     #[error("Incorrect account owner")]
     IncorrectOwner,
-    /// 0x3A - printing these tokens would breach the maximum supply limit of the master edition
+    /// 58 (0x3A) - printing these tokens would breach the maximum supply limit of the master edition
     #[error("printing these tokens would breach the maximum supply limit of the master edition")]
     PrintingWouldBreachMaximumSupply,
-    /// 0x3B - Data is immutable
+    /// 59 (0x3B) - Data is immutable
     #[error("Data is immutable")]
     DataIsImmutable,
-    /// 0x3C - No duplicate creator addresses
+    /// 60 (0x3C) - No duplicate creator addresses
     #[error("No duplicate creator addresses")]
     DuplicateCreatorAddress,
-    /// 0x3D - Reservation spots remaining should match total spots when first being created
+    /// 61 (0x3D) - Reservation spots remaining should match total spots when first being created
     #[error("Reservation spots remaining should match total spots when first being created")]
     ReservationSpotsRemainingShouldMatchTotalSpotsAtStart,
-    /// 0x3E - Invalid token program
+    /// 62 (0x3E) - Invalid token program
     #[error("Invalid token program")]
     InvalidTokenProgram,
-    /// 0x3F - Data type mismatch
+    /// 63 (0x3F) - Data type mismatch
     #[error("Data type mismatch")]
     DataTypeMismatch,
-    /// 0x40 - Beyond alotted address size in reservation!
+    /// 64 (0x40) - Beyond alotted address size in reservation!
     #[error("Beyond alotted address size in reservation!")]
     BeyondAlottedAddressSize,
-    /// 0x41 - The reservation has only been partially alotted
+    /// 65 (0x41) - The reservation has only been partially alotted
     #[error("The reservation has only been partially alotted")]
     ReservationNotComplete,
-    /// 0x42 - You cannot splice over an existing reservation!
+    /// 66 (0x42) - You cannot splice over an existing reservation!
     #[error("You cannot splice over an existing reservation!")]
     TriedToReplaceAnExistingReservation,
-    /// 0x43 - Invalid operation
+    /// 67 (0x43) - Invalid operation
     #[error("Invalid operation")]
     InvalidOperation,
-    /// 0x44 - Invalid Owner
+    /// 68 (0x44) - Invalid Owner
     #[error("Invalid Owner")]
     InvalidOwner,
-    /// 0x45 - Printing mint supply must be zero for conversion
+    /// 69 (0x45) - Printing mint supply must be zero for conversion
     #[error("Printing mint supply must be zero for conversion")]
     PrintingMintSupplyMustBeZeroForConversion,
-    /// 0x46 - One Time Auth mint supply must be zero for conversion
+    /// 70 (0x46) - One Time Auth mint supply must be zero for conversion
     #[error("One Time Auth mint supply must be zero for conversion")]
     OneTimeAuthMintSupplyMustBeZeroForConversion,
-    /// 0x47 - You tried to insert one edition too many into an edition mark pda
+    /// 71 (0x47) - You tried to insert one edition too many into an edition mark pda
     #[error("You tried to insert one edition too many into an edition mark pda")]
     InvalidEditionIndex,
-    /// 0x48 - In the legacy system the reservation needs to be of size one for cpu limit reasons
+    /// 72 (0x48) - In the legacy system the reservation needs to be of size one for cpu limit reasons
     #[error("In the legacy system the reservation needs to be of size one for cpu limit reasons")]
     ReservationArrayShouldBeSizeOne,
-    /// 0x49 - Is Mutable can only be flipped to false
+    /// 73 (0x49) - Is Mutable can only be flipped to false
     #[error("Is Mutable can only be flipped to false")]
     IsMutableCanOnlyBeFlippedToFalse,
-    /// 0x4A - Collection cannot be verified in this instruction
+    /// 74 (0x4A) - Collection cannot be verified in this instruction
     #[error("Collection cannot be verified in this instruction")]
     CollectionCannotBeVerifiedInThisInstruction,
-    /// 0x4B - This instruction was deprecated in a previous release and is now removed
+    /// 75 (0x4B) - This instruction was deprecated in a previous release and is now removed
     #[error("This instruction was deprecated in a previous release and is now removed")]
     Removed,
-    /// 0x4C - This token use method is burn and there are no remaining uses, it must be burned
+    /// 76 (0x4C) - This token use method is burn and there are no remaining uses, it must be burned
     #[error("This token use method is burn and there are no remaining uses, it must be burned")]
     MustBeBurned,
-    /// 0x4D - This use method is invalid
+    /// 77 (0x4D) - This use method is invalid
     #[error("This use method is invalid")]
     InvalidUseMethod,
-    /// 0x4E - Cannot Change Use Method after the first use
+    /// 78 (0x4E) - Cannot Change Use Method after the first use
     #[error("Cannot Change Use Method after the first use")]
     CannotChangeUseMethodAfterFirstUse,
-    /// 0x4F - Cannot Change Remaining or Available uses after the first use
+    /// 79 (0x4F) - Cannot Change Remaining or Available uses after the first use
     #[error("Cannot Change Remaining or Available uses after the first use")]
     CannotChangeUsesAfterFirstUse,
-    /// 0x50 - Collection Not Found on Metadata
+    /// 80 (0x50) - Collection Not Found on Metadata
     #[error("Collection Not Found on Metadata")]
     CollectionNotFound,
-    /// 0x51 - Collection Update Authority is invalid
+    /// 81 (0x51) - Collection Update Authority is invalid
     #[error("Collection Update Authority is invalid")]
     InvalidCollectionUpdateAuthority,
-    /// 0x52 - Collection Must Be a Unique Master Edition v2
+    /// 82 (0x52) - Collection Must Be a Unique Master Edition v2
     #[error("Collection Must Be a Unique Master Edition v2")]
     CollectionMustBeAUniqueMasterEdition,
-    /// 0x53 - The Use Authority Record Already Exists, to modify it Revoke, then Approve
+    /// 83 (0x53) - The Use Authority Record Already Exists, to modify it Revoke, then Approve
     #[error("The Use Authority Record Already Exists, to modify it Revoke, then Approve")]
     UseAuthorityRecordAlreadyExists,
-    /// 0x54 - The Use Authority Record is empty or already revoked
+    /// 84 (0x54) - The Use Authority Record is empty or already revoked
     #[error("The Use Authority Record is empty or already revoked")]
     UseAuthorityRecordAlreadyRevoked,
-    /// 0x55 - This token has no uses
+    /// 85 (0x55) - This token has no uses
     #[error("This token has no uses")]
     Unusable,
-    /// 0x56 - There are not enough Uses left on this token.
+    /// 86 (0x56) - There are not enough Uses left on this token.
     #[error("There are not enough Uses left on this token.")]
     NotEnoughUses,
-    /// 0x57 - This Collection Authority Record Already Exists.
+    /// 87 (0x57) - This Collection Authority Record Already Exists.
     #[error("This Collection Authority Record Already Exists.")]
     CollectionAuthorityRecordAlreadyExists,
-    /// 0x58 - This Collection Authority Record Does Not Exist.
+    /// 88 (0x58) - This Collection Authority Record Does Not Exist.
     #[error("This Collection Authority Record Does Not Exist.")]
     CollectionAuthorityDoesNotExist,
-    /// 0x59 - This Use Authority Record is invalid.
+    /// 89 (0x59) - This Use Authority Record is invalid.
     #[error("This Use Authority Record is invalid.")]
     InvalidUseAuthorityRecord,
-    /// 0x5A - This Collection Authority Record is invalid.
+    /// 90 (0x5A) - This Collection Authority Record is invalid.
     #[error("This Collection Authority Record is invalid.")]
     InvalidCollectionAuthorityRecord,
-    /// 0x5B - Metadata does not match the freeze authority on the mint
+    /// 91 (0x5B) - Metadata does not match the freeze authority on the mint
     #[error("Metadata does not match the freeze authority on the mint")]
     InvalidFreezeAuthority,
-    /// 0x5C - All tokens in this account have not been delegated to this user.
+    /// 92 (0x5C) - All tokens in this account have not been delegated to this user.
     #[error("All tokens in this account have not been delegated to this user.")]
     InvalidDelegate,
-    /// 0x5D - Creator can not be adjusted once they are verified.
+    /// 93 (0x5D) - Creator can not be adjusted once they are verified.
     #[error("Creator can not be adjusted once they are verified.")]
     CannotAdjustVerifiedCreator,
-    /// 0x5E - Verified creators cannot be removed.
+    /// 94 (0x5E) - Verified creators cannot be removed.
     #[error("Verified creators cannot be removed.")]
     CannotRemoveVerifiedCreator,
-    /// 0x5F - Can not wipe verified creators.
+    /// 95 (0x5F) - Can not wipe verified creators.
     #[error("Can not wipe verified creators.")]
     CannotWipeVerifiedCreators,
-    /// 0x60 - Not allowed to change seller fee basis points.
+    /// 96 (0x60) - Not allowed to change seller fee basis points.
     #[error("Not allowed to change seller fee basis points.")]
     NotAllowedToChangeSellerFeeBasisPoints,
-    /// 0x61 - Edition override cannot be zero
+    /// 97 (0x61) - Edition override cannot be zero
     #[error("Edition override cannot be zero")]
     EditionOverrideCannotBeZero,
-    /// 0x62 - Invalid User
+    /// 98 (0x62) - Invalid User
     #[error("Invalid User")]
     InvalidUser,
-    /// 0x63 - Revoke Collection Authority signer is incorrect
+    /// 99 (0x63) - Revoke Collection Authority signer is incorrect
     #[error("Revoke Collection Authority signer is incorrect")]
     RevokeCollectionAuthoritySignerIncorrect,
-    /// 0x64 - Token close failed
+    /// 100 (0x64) - Token close failed
     #[error("Token close failed")]
     TokenCloseFailed,
-    /// 0x65 - Can't use this function on unsized collection
+    /// 101 (0x65) - Can't use this function on unsized collection
     #[error("Can't use this function on unsized collection")]
     UnsizedCollection,
-    /// 0x66 - Can't use this function on a sized collection
+    /// 102 (0x66) - Can't use this function on a sized collection
     #[error("Can't use this function on a sized collection")]
     SizedCollection,
-    /// 0x67 - Can't burn a verified member of a collection w/o providing collection metadata account
+    /// 103 (0x67) - Can't burn a verified member of a collection w/o providing collection metadata account
     #[error(
         "Can't burn a verified member of a collection w/o providing collection metadata account"
     )]
     MissingCollectionMetadata,
-    /// 0x68 - This NFT is not a member of the specified collection.
+    /// 104 (0x68) - This NFT is not a member of the specified collection.
     #[error("This NFT is not a member of the specified collection.")]
     NotAMemberOfCollection,
-    /// 0x69 - This NFT is not a verified member of the specified collection.
+    /// 105 (0x69) - This NFT is not a verified member of the specified collection.
     #[error("This NFT is not a verified member of the specified collection.")]
     NotVerifiedMemberOfCollection,
-    /// 0x6A - This NFT is not a collection parent NFT.
+    /// 106 (0x6A) - This NFT is not a collection parent NFT.
     #[error("This NFT is not a collection parent NFT.")]
     NotACollectionParent,
-    /// 0x6B - Could not determine a TokenStandard type.
+    /// 107 (0x6B) - Could not determine a TokenStandard type.
     #[error("Could not determine a TokenStandard type.")]
     CouldNotDetermineTokenStandard,
-    /// 0x6C - This mint account has an edition but none was provided.
+    /// 108 (0x6C) - This mint account has an edition but none was provided.
     #[error("This mint account has an edition but none was provided.")]
     MissingEditionAccount,
-    /// 0x6D - This edition is not a Master Edition
+    /// 109 (0x6D) - This edition is not a Master Edition
     #[error("This edition is not a Master Edition")]
     NotAMasterEdition,
-    /// 0x6E - This Master Edition has existing prints
+    /// 110 (0x6E) - This Master Edition has existing prints
     #[error("This Master Edition has existing prints")]
     MasterEditionHasPrints,
-    /// 0x6F - Borsh Deserialization Error
+    /// 111 (0x6F) - Borsh Deserialization Error
     #[error("Borsh Deserialization Error")]
     BorshDeserializationError,
-    /// 0x70 - Cannot update a verified collection in this command
+    /// 112 (0x70) - Cannot update a verified collection in this command
     #[error("Cannot update a verified collection in this command")]
     CannotUpdateVerifiedCollection,
-    /// 0x71 - Edition account doesnt match collection
+    /// 113 (0x71) - Edition account doesnt match collection
     #[error("Edition account doesnt match collection ")]
     CollectionMasterEditionAccountInvalid,
-    /// 0x72 - Item is already verified.
+    /// 114 (0x72) - Item is already verified.
     #[error("Item is already verified.")]
     AlreadyVerified,
-    /// 0x73 - Item is already unverified.
+    /// 115 (0x73) - Item is already unverified.
     #[error("Item is already unverified.")]
     AlreadyUnverified,
-    /// 0x74 - This edition is not a Print Edition
+    /// 116 (0x74) - This edition is not a Print Edition
     #[error("This edition is not a Print Edition")]
     NotAPrintEdition,
-    /// 0x75 - Invalid Master Edition
+    /// 117 (0x75) - Invalid Master Edition
     #[error("Invalid Master Edition")]
     InvalidMasterEdition,
-    /// 0x76 - Invalid Print Edition
+    /// 118 (0x76) - Invalid Print Edition
     #[error("Invalid Print Edition")]
     InvalidPrintEdition,
-    /// 0x77 - Invalid Edition Marker
+    /// 119 (0x77) - Invalid Edition Marker
     #[error("Invalid Edition Marker")]
     InvalidEditionMarker,
-    /// 0x78 - Reservation List is Deprecated
+    /// 120 (0x78) - Reservation List is Deprecated
     #[error("Reservation List is Deprecated")]
     ReservationListDeprecated,
-    /// 0x79 - Print Edition does not match Master Edition
+    /// 121 (0x79) - Print Edition does not match Master Edition
     #[error("Print Edition does not match Master Edition")]
     PrintEditionDoesNotMatchMasterEdition,
-    /// 0x7A - Edition Number greater than max supply
+    /// 122 (0x7A) - Edition Number greater than max supply
     #[error("Edition Number greater than max supply")]
     EditionNumberGreaterThanMaxSupply,
-    /// 0x7B - Must unverify before migrating collections.
+    /// 123 (0x7B) - Must unverify before migrating collections.
     #[error("Must unverify before migrating collections.")]
     MustUnverify,
-    /// 0x7C - Invalid Escrow Account Bump Seed
+    /// 124 (0x7C) - Invalid Escrow Account Bump Seed
     #[error("Invalid Escrow Account Bump Seed")]
     InvalidEscrowBumpSeed,
-    /// 0x7D - Must Escrow Authority
+    /// 125 (0x7D) - Must Escrow Authority
     #[error("Must Escrow Authority")]
     MustBeEscrowAuthority,
-    /// 0x7E - Invalid System Program
+    /// 126 (0x7E) - Invalid System Program
     #[error("Invalid System Program")]
     InvalidSystemProgram,
-    /// 0x7F - Must be a Non Fungible Token
+    /// 127 (0x7F) - Must be a Non Fungible Token
     #[error("Must be a Non Fungible Token")]
     MustBeNonFungible,
-    /// 0x80 - Insufficient tokens for transfer
+    /// 128 (0x80) - Insufficient tokens for transfer
     #[error("Insufficient tokens for transfer")]
     InsufficientTokens,
-    /// 0x81 - Borsh Serialization Error
+    /// 129 (0x81) - Borsh Serialization Error
     #[error("Borsh Serialization Error")]
     BorshSerializationError,
-    /// 0x82 - Cannot create NFT with no Freeze Authority.
+    /// 130 (0x82) - Cannot create NFT with no Freeze Authority.
     #[error("Cannot create NFT with no Freeze Authority.")]
     NoFreezeAuthoritySet,
-    /// 0x83 - Invalid collection size change
+    /// 131 (0x83) - Invalid collection size change
     #[error("Invalid collection size change")]
     InvalidCollectionSizeChange,
-    /// 0x84 - Invalid bubblegum signer
+    /// 132 (0x84) - Invalid bubblegum signer
     #[error("Invalid bubblegum signer")]
     InvalidBubblegumSigner,
-    /// 0x85 - Mint needs to be signer to initialize the account
+    /// 133 (0x85) - Mint needs to be signer to initialize the account
     #[error("Mint needs to be signer to initialize the account")]
     MintIsNotSigner,
-    /// 0x86 - Invalid token standard
+    /// 134 (0x86) - Invalid token standard
     #[error("Invalid token standard")]
     InvalidTokenStandard,
-    /// 0x87 - Invalid mint account for specified token standard
+    /// 135 (0x87) - Invalid mint account for specified token standard
     #[error("Invalid mint account for specified token standard")]
     InvalidMintForTokenStandard,
-    /// 0x88 - Invalid authorization rules account
+    /// 136 (0x88) - Invalid authorization rules account
     #[error("Invalid authorization rules account")]
     InvalidAuthorizationRules,
-    /// 0x89 - Missing authorization rules account
+    /// 137 (0x89) - Missing authorization rules account
     #[error("Missing authorization rules account")]
     MissingAuthorizationRules,
-    /// 0x8A - Missing programmable configuration
+    /// 138 (0x8A) - Missing programmable configuration
     #[error("Missing programmable configuration")]
     MissingProgrammableConfig,
-    /// 0x8B - Invalid programmable configuration
+    /// 139 (0x8B) - Invalid programmable configuration
     #[error("Invalid programmable configuration")]
     InvalidProgrammableConfig,
-    /// 0x8C - Delegate already exists
+    /// 140 (0x8C) - Delegate already exists
     #[error("Delegate already exists")]
     DelegateAlreadyExists,
-    /// 0x8D - Delegate not found
+    /// 141 (0x8D) - Delegate not found
     #[error("Delegate not found")]
     DelegateNotFound,
-    /// 0x8E - Required account not set in instruction builder
+    /// 142 (0x8E) - Required account not set in instruction builder
     #[error("Required account not set in instruction builder")]
     MissingAccountInBuilder,
-    /// 0x8F - Required argument not set in instruction builder
+    /// 143 (0x8F) - Required argument not set in instruction builder
     #[error("Required argument not set in instruction builder")]
     MissingArgumentInBuilder,
-    /// 0x90 - Feature not supported currently
+    /// 144 (0x90) - Feature not supported currently
     #[error("Feature not supported currently")]
     FeatureNotSupported,
-    /// 0x91 - Invalid system wallet
+    /// 145 (0x91) - Invalid system wallet
     #[error("Invalid system wallet")]
     InvalidSystemWallet,
-    /// 0x92 - Only the sale delegate can transfer while its set
+    /// 146 (0x92) - Only the sale delegate can transfer while its set
     #[error("Only the sale delegate can transfer while its set")]
     OnlySaleDelegateCanTransfer,
-    /// 0x93 - Missing token account
+    /// 147 (0x93) - Missing token account
     #[error("Missing token account")]
     MissingTokenAccount,
-    /// 0x94 - Missing SPL token program
+    /// 148 (0x94) - Missing SPL token program
     #[error("Missing SPL token program")]
     MissingSplTokenProgram,
-    /// 0x95 - Missing SPL token program
+    /// 149 (0x95) - Missing SPL token program
     #[error("Missing SPL token program")]
     MissingAuthorizationRulesProgram,
-    /// 0x96 - Invalid delegate role for transfer
+    /// 150 (0x96) - Invalid delegate role for transfer
     #[error("Invalid delegate role for transfer")]
     InvalidDelegateRoleForTransfer,
 }


### PR DESCRIPTION
PR to add decimal indices to error comments. This can be helpful when debugging, since it would be easier to identify an error by its index from the documentation.