### PR TITLE
Fix argument object when resolving defaults in JS renderer

### DIFF
--- a/.changeset/six-colts-dream.md
+++ b/.changeset/six-colts-dream.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi-dummy-generated': patch
+---
+
+Fix argument object when resolving defaults in JS renderer


### PR DESCRIPTION
Currently, it can happen that `resolvedArgs` is used by a default value even though it's not actually being generated. This fixes it by using the `input` or `args` object instead when appropriate.