### PR TITLE
Generate builder docs

### DIFF
--- a/.changeset/brave-crabs-drop.md
+++ b/.changeset/brave-crabs-drop.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add account list output to builder docs in Rust client

--- a/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
@@ -10,7 +10,7 @@
   {% if account.isSigner %}
     {% set modifiers = modifiers + ', signer' if modifiers.length > 0 else 'signer' %}
   {% endif %}
-  {% if account.isOptional or account.defaultsTo.kind === 'program' or account.defaultsTo.kind === 'publicKey' %}
+  {% if account.isOptional %}
     {% set modifiers = modifiers + ', optional' if modifiers.length > 0 else 'optional' %}
   {% endif %}
   {{ '///   ' + loop.index0 + '. `[' + modifiers + ']` ' + account.name | snakeCase }}

--- a/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
@@ -1,4 +1,20 @@
-/// `{{ instruction.name | snakeCase }}` CPI instruction builder.
+/// Instruction builder for `{{ instruction.name | pascalCase }}` via CPI.
+///
+/// ### Accounts:
+///
+{% for account in instruction.accounts %}
+  {% set modifiers = '' %}
+  {% if account.isWritable %}
+    {% set modifiers = 'writable' %}
+  {% endif %}
+  {% if account.isSigner %}
+    {% set modifiers = modifiers + ', signer' if modifiers.length > 0 else 'signer' %}
+  {% endif %}
+  {% if account.isOptional or account.defaultsTo.kind === 'program' or account.defaultsTo.kind === 'publicKey' %}
+    {% set modifiers = modifiers + ', optional' if modifiers.length > 0 else 'optional' %}
+  {% endif %}
+  {{ '///   ' + loop.index0 + '. `[' + modifiers + ']` ' + account.name | snakeCase }}
+{% endfor %}
 pub struct {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
   instruction: Box<{{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b>>,
 }

--- a/src/renderers/rust/templates/instructionsPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsPageBuilder.njk
@@ -1,4 +1,22 @@
-/// Instruction builder.
+/// Instruction builder for `{{ instruction.name | pascalCase }}`.
+///
+/// ### Accounts:
+///
+{% for account in instruction.accounts %}
+  {% set modifiers = '' %}
+  {% if account.isWritable %}
+    {% set modifiers = 'writable' %}
+  {% endif %}
+  {% if account.isSigner %}
+    {% set modifiers = modifiers + ', signer' if modifiers.length > 0 else 'signer' %}
+  {% endif %}
+  {% if account.isOptional or account.defaultsTo.kind === 'program' or account.defaultsTo.kind === 'publicKey' %}
+    {% set modifiers = modifiers + ', optional' if modifiers.length > 0 else 'optional' %}
+  {% endif %}
+  {{ '///   ' + loop.index0 + '. `[' + modifiers + ']` ' + account.name | snakeCase }}
+  {{- " (default to `" + account.defaultsTo.program.publicKey + "`)" if account.defaultsTo.kind === 'program' }}
+  {{- " (default to `" + account.defaultsTo.publicKey + "`)" if account.defaultsTo.kind === 'publicKey' }}
+{% endfor %}
 #[derive(Default)]
 pub struct {{ instruction.name | pascalCase }}Builder {
   {% for account in instruction.accounts %}

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -73,7 +73,12 @@ pub struct AddConfigLinesInstructionArgs {
     pub more_lines: U64PrefixVec<ConfigLine>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `AddConfigLines`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
 #[derive(Default)]
 pub struct AddConfigLinesBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -253,7 +258,12 @@ impl<'a, 'b> AddConfigLinesCpi<'a, 'b> {
     }
 }
 
-/// `add_config_lines` CPI instruction builder.
+/// Instruction builder for `AddConfigLines` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
 pub struct AddConfigLinesCpiBuilder<'a, 'b> {
     instruction: Box<AddConfigLinesCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -98,7 +98,18 @@ impl ApproveCollectionAuthorityInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `ApproveCollectionAuthority`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_authority_record
+///   1. `[]` new_collection_authority
+///   2. `[writable, signer]` update_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` metadata
+///   5. `[]` mint
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` rent
 #[derive(Default)]
 pub struct ApproveCollectionAuthorityBuilder {
     collection_authority_record: Option<solana_program::pubkey::Pubkey>,
@@ -387,7 +398,18 @@ impl<'a, 'b> ApproveCollectionAuthorityCpi<'a, 'b> {
     }
 }
 
-/// `approve_collection_authority` CPI instruction builder.
+/// Instruction builder for `ApproveCollectionAuthority` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_authority_record
+///   1. `[]` new_collection_authority
+///   2. `[writable, signer]` update_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` metadata
+///   5. `[]` mint
+///   6. `[optional]` system_program
+///   7. `[optional]` rent
 pub struct ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -408,7 +408,7 @@ impl<'a, 'b> ApproveCollectionAuthorityCpi<'a, 'b> {
 ///   3. `[writable, signer]` payer
 ///   4. `[]` metadata
 ///   5. `[]` mint
-///   6. `[optional]` system_program
+///   6. `[]` system_program
 ///   7. `[optional]` rent
 pub struct ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -126,7 +126,21 @@ pub struct ApproveUseAuthorityInstructionArgs {
     pub number_of_uses: u64,
 }
 
-/// Instruction builder.
+/// Instruction builder for `ApproveUseAuthority`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` use_authority_record
+///   1. `[writable, signer]` owner
+///   2. `[writable, signer]` payer
+///   3. `[]` user
+///   4. `[writable]` owner_token_account
+///   5. `[]` metadata
+///   6. `[]` mint
+///   7. `[]` burner
+///   8. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   9. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   10. `[optional]` rent
 #[derive(Default)]
 pub struct ApproveUseAuthorityBuilder {
     use_authority_record: Option<solana_program::pubkey::Pubkey>,
@@ -487,7 +501,21 @@ impl<'a, 'b> ApproveUseAuthorityCpi<'a, 'b> {
     }
 }
 
-/// `approve_use_authority` CPI instruction builder.
+/// Instruction builder for `ApproveUseAuthority` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` use_authority_record
+///   1. `[writable, signer]` owner
+///   2. `[writable, signer]` payer
+///   3. `[]` user
+///   4. `[writable]` owner_token_account
+///   5. `[]` metadata
+///   6. `[]` mint
+///   7. `[]` burner
+///   8. `[optional]` token_program
+///   9. `[optional]` system_program
+///   10. `[optional]` rent
 pub struct ApproveUseAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -513,8 +513,8 @@ impl<'a, 'b> ApproveUseAuthorityCpi<'a, 'b> {
 ///   5. `[]` metadata
 ///   6. `[]` mint
 ///   7. `[]` burner
-///   8. `[optional]` token_program
-///   9. `[optional]` system_program
+///   8. `[]` token_program
+///   9. `[]` system_program
 ///   10. `[optional]` rent
 pub struct ApproveUseAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -96,7 +96,15 @@ pub struct BubblegumSetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `BubblegumSetCollectionSize`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[]` collection_mint
+///   3. `[signer]` bubblegum_signer
+///   4. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct BubblegumSetCollectionSizeBuilder {
     collection_metadata: Option<solana_program::pubkey::Pubkey>,
@@ -356,7 +364,15 @@ impl<'a, 'b> BubblegumSetCollectionSizeCpi<'a, 'b> {
     }
 }
 
-/// `bubblegum_set_collection_size` CPI instruction builder.
+/// Instruction builder for `BubblegumSetCollectionSize` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[]` collection_mint
+///   3. `[signer]` bubblegum_signer
+///   4. `[optional]` collection_authority_record
 pub struct BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
     instruction: Box<BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -496,7 +496,7 @@ impl<'a, 'b> BurnCpi<'a, 'b> {
 ///   2. `[writable]` mint
 ///   3. `[writable]` token_account
 ///   4. `[writable]` master_edition_account
-///   5. `[optional]` spl_token_program
+///   5. `[]` spl_token_program
 ///   6. `[writable, optional]` collection_metadata
 ///   7. `[optional]` authorization_rules
 ///   8. `[optional]` authorization_rules_program

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -130,7 +130,19 @@ pub struct BurnInstructionArgs {
     pub burn_args: BurnArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Burn`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` owner
+///   2. `[writable]` mint
+///   3. `[writable]` token_account
+///   4. `[writable]` master_edition_account
+///   5. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   6. `[writable, optional]` collection_metadata
+///   7. `[optional]` authorization_rules
+///   8. `[optional]` authorization_rules_program
 #[derive(Default)]
 pub struct BurnBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -475,7 +487,19 @@ impl<'a, 'b> BurnCpi<'a, 'b> {
     }
 }
 
-/// `burn` CPI instruction builder.
+/// Instruction builder for `Burn` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` owner
+///   2. `[writable]` mint
+///   3. `[writable]` token_account
+///   4. `[writable]` master_edition_account
+///   5. `[optional]` spl_token_program
+///   6. `[writable, optional]` collection_metadata
+///   7. `[optional]` authorization_rules
+///   8. `[optional]` authorization_rules_program
 pub struct BurnCpiBuilder<'a, 'b> {
     instruction: Box<BurnCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -103,7 +103,20 @@ impl BurnEditionNftInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `BurnEditionNft`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` owner
+///   2. `[writable]` print_edition_mint
+///   3. `[]` master_edition_mint
+///   4. `[writable]` print_edition_token_account
+///   5. `[]` master_edition_token_account
+///   6. `[writable]` master_edition_account
+///   7. `[writable]` print_edition_account
+///   8. `[writable]` edition_marker_account
+///   9. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Default)]
 pub struct BurnEditionNftBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -442,7 +455,20 @@ impl<'a, 'b> BurnEditionNftCpi<'a, 'b> {
     }
 }
 
-/// `burn_edition_nft` CPI instruction builder.
+/// Instruction builder for `BurnEditionNft` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` owner
+///   2. `[writable]` print_edition_mint
+///   3. `[]` master_edition_mint
+///   4. `[writable]` print_edition_token_account
+///   5. `[]` master_edition_token_account
+///   6. `[writable]` master_edition_account
+///   7. `[writable]` print_edition_account
+///   8. `[writable]` edition_marker_account
+///   9. `[optional]` spl_token_program
 pub struct BurnEditionNftCpiBuilder<'a, 'b> {
     instruction: Box<BurnEditionNftCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -468,7 +468,7 @@ impl<'a, 'b> BurnEditionNftCpi<'a, 'b> {
 ///   6. `[writable]` master_edition_account
 ///   7. `[writable]` print_edition_account
 ///   8. `[writable]` edition_marker_account
-///   9. `[optional]` spl_token_program
+///   9. `[]` spl_token_program
 pub struct BurnEditionNftCpiBuilder<'a, 'b> {
     instruction: Box<BurnEditionNftCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -91,7 +91,17 @@ impl BurnNftInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `BurnNft`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` owner
+///   2. `[writable]` mint
+///   3. `[writable]` token_account
+///   4. `[writable]` master_edition_account
+///   5. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   6. `[writable, optional]` collection_metadata
 #[derive(Default)]
 pub struct BurnNftBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -359,7 +369,17 @@ impl<'a, 'b> BurnNftCpi<'a, 'b> {
     }
 }
 
-/// `burn_nft` CPI instruction builder.
+/// Instruction builder for `BurnNft` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` owner
+///   2. `[writable]` mint
+///   3. `[writable]` token_account
+///   4. `[writable]` master_edition_account
+///   5. `[optional]` spl_token_program
+///   6. `[writable, optional]` collection_metadata
 pub struct BurnNftCpiBuilder<'a, 'b> {
     instruction: Box<BurnNftCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -378,7 +378,7 @@ impl<'a, 'b> BurnNftCpi<'a, 'b> {
 ///   2. `[writable]` mint
 ///   3. `[writable]` token_account
 ///   4. `[writable]` master_edition_account
-///   5. `[optional]` spl_token_program
+///   5. `[]` spl_token_program
 ///   6. `[writable, optional]` collection_metadata
 pub struct BurnNftCpiBuilder<'a, 'b> {
     instruction: Box<BurnNftCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -92,7 +92,18 @@ impl CloseEscrowAccountInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `CloseEscrowAccount`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` escrow
+///   1. `[writable]` metadata
+///   2. `[]` mint
+///   3. `[]` token_account
+///   4. `[]` edition
+///   5. `[writable, signer]` payer
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 #[derive(Default)]
 pub struct CloseEscrowAccountBuilder {
     escrow: Option<solana_program::pubkey::Pubkey>,
@@ -365,7 +376,18 @@ impl<'a, 'b> CloseEscrowAccountCpi<'a, 'b> {
     }
 }
 
-/// `close_escrow_account` CPI instruction builder.
+/// Instruction builder for `CloseEscrowAccount` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` escrow
+///   1. `[writable]` metadata
+///   2. `[]` mint
+///   3. `[]` token_account
+///   4. `[]` edition
+///   5. `[writable, signer]` payer
+///   6. `[optional]` system_program
+///   7. `[optional]` sysvar_instructions
 pub struct CloseEscrowAccountCpiBuilder<'a, 'b> {
     instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -386,8 +386,8 @@ impl<'a, 'b> CloseEscrowAccountCpi<'a, 'b> {
 ///   3. `[]` token_account
 ///   4. `[]` edition
 ///   5. `[writable, signer]` payer
-///   6. `[optional]` system_program
-///   7. `[optional]` sysvar_instructions
+///   6. `[]` system_program
+///   7. `[]` sysvar_instructions
 pub struct CloseEscrowAccountCpiBuilder<'a, 'b> {
     instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -64,7 +64,13 @@ impl ConvertMasterEditionV1ToV2InstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `ConvertMasterEditionV1ToV2`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` master_edition
+///   1. `[writable]` one_time_auth
+///   2. `[writable]` printing_mint
 #[derive(Default)]
 pub struct ConvertMasterEditionV1ToV2Builder {
     master_edition: Option<solana_program::pubkey::Pubkey>,
@@ -238,7 +244,13 @@ impl<'a, 'b> ConvertMasterEditionV1ToV2Cpi<'a, 'b> {
     }
 }
 
-/// `convert_master_edition_v1_to_v2` CPI instruction builder.
+/// Instruction builder for `ConvertMasterEditionV1ToV2` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` master_edition
+///   1. `[writable]` one_time_auth
+///   2. `[writable]` printing_mint
 pub struct ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
     instruction: Box<ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -104,7 +104,19 @@ impl CreateEscrowAccountInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateEscrowAccount`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` escrow
+///   1. `[writable]` metadata
+///   2. `[]` mint
+///   3. `[]` token_account
+///   4. `[]` edition
+///   5. `[writable, signer]` payer
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   8. `[signer, optional]` authority
 #[derive(Default)]
 pub struct CreateEscrowAccountBuilder {
     escrow: Option<solana_program::pubkey::Pubkey>,
@@ -405,7 +417,19 @@ impl<'a, 'b> CreateEscrowAccountCpi<'a, 'b> {
     }
 }
 
-/// `create_escrow_account` CPI instruction builder.
+/// Instruction builder for `CreateEscrowAccount` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` escrow
+///   1. `[writable]` metadata
+///   2. `[]` mint
+///   3. `[]` token_account
+///   4. `[]` edition
+///   5. `[writable, signer]` payer
+///   6. `[optional]` system_program
+///   7. `[optional]` sysvar_instructions
+///   8. `[signer, optional]` authority
 pub struct CreateEscrowAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -427,8 +427,8 @@ impl<'a, 'b> CreateEscrowAccountCpi<'a, 'b> {
 ///   3. `[]` token_account
 ///   4. `[]` edition
 ///   5. `[writable, signer]` payer
-///   6. `[optional]` system_program
-///   7. `[optional]` sysvar_instructions
+///   6. `[]` system_program
+///   7. `[]` sysvar_instructions
 ///   8. `[signer, optional]` authority
 pub struct CreateEscrowAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -309,7 +309,7 @@ impl<'a, 'b> CreateFrequencyRuleCpi<'a, 'b> {
 ///
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` frequency_pda
-///   2. `[optional]` system_program
+///   2. `[]` system_program
 pub struct CreateFrequencyRuleCpiBuilder<'a, 'b> {
     instruction: Box<CreateFrequencyRuleCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -78,7 +78,13 @@ pub struct CreateFrequencyRuleInstructionArgs {
     pub period: i64,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateFrequencyRule`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` payer
+///   1. `[writable]` frequency_pda
+///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Default)]
 pub struct CreateFrequencyRuleBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -297,7 +303,13 @@ impl<'a, 'b> CreateFrequencyRuleCpi<'a, 'b> {
     }
 }
 
-/// `create_frequency_rule` CPI instruction builder.
+/// Instruction builder for `CreateFrequencyRule` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` payer
+///   1. `[writable]` frequency_pda
+///   2. `[optional]` system_program
 pub struct CreateFrequencyRuleCpiBuilder<'a, 'b> {
     instruction: Box<CreateFrequencyRuleCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -447,9 +447,9 @@ impl<'a, 'b> CreateMasterEditionCpi<'a, 'b> {
 ///   3. `[signer]` mint_authority
 ///   4. `[writable, signer]` payer
 ///   5. `[]` metadata
-///   6. `[optional]` token_program
-///   7. `[optional]` system_program
-///   8. `[optional]` rent
+///   6. `[]` token_program
+///   7. `[]` system_program
+///   8. `[]` rent
 pub struct CreateMasterEditionCpiBuilder<'a, 'b> {
     instruction: Box<CreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -110,7 +110,19 @@ pub struct CreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateMasterEdition`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` edition
+///   1. `[writable]` mint
+///   2. `[signer]` update_authority
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[]` metadata
+///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Default)]
 pub struct CreateMasterEditionBuilder {
     edition: Option<solana_program::pubkey::Pubkey>,
@@ -425,7 +437,19 @@ impl<'a, 'b> CreateMasterEditionCpi<'a, 'b> {
     }
 }
 
-/// `create_master_edition` CPI instruction builder.
+/// Instruction builder for `CreateMasterEdition` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` edition
+///   1. `[writable]` mint
+///   2. `[signer]` update_authority
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[]` metadata
+///   6. `[optional]` token_program
+///   7. `[optional]` system_program
+///   8. `[optional]` rent
 pub struct CreateMasterEditionCpiBuilder<'a, 'b> {
     instruction: Box<CreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -117,7 +117,19 @@ pub struct CreateMasterEditionV3InstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateMasterEditionV3`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` edition
+///   1. `[writable]` mint
+///   2. `[signer]` update_authority
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[writable]` metadata
+///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   8. `[optional]` rent
 #[derive(Default)]
 pub struct CreateMasterEditionV3Builder {
     edition: Option<solana_program::pubkey::Pubkey>,
@@ -438,7 +450,19 @@ impl<'a, 'b> CreateMasterEditionV3Cpi<'a, 'b> {
     }
 }
 
-/// `create_master_edition_v3` CPI instruction builder.
+/// Instruction builder for `CreateMasterEditionV3` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` edition
+///   1. `[writable]` mint
+///   2. `[signer]` update_authority
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[writable]` metadata
+///   6. `[optional]` token_program
+///   7. `[optional]` system_program
+///   8. `[optional]` rent
 pub struct CreateMasterEditionV3CpiBuilder<'a, 'b> {
     instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -460,8 +460,8 @@ impl<'a, 'b> CreateMasterEditionV3Cpi<'a, 'b> {
 ///   3. `[signer]` mint_authority
 ///   4. `[writable, signer]` payer
 ///   5. `[writable]` metadata
-///   6. `[optional]` token_program
-///   7. `[optional]` system_program
+///   6. `[]` token_program
+///   7. `[]` system_program
 ///   8. `[optional]` rent
 pub struct CreateMasterEditionV3CpiBuilder<'a, 'b> {
     instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -416,8 +416,8 @@ impl<'a, 'b> CreateMetadataAccountCpi<'a, 'b> {
 ///   2. `[signer]` mint_authority
 ///   3. `[writable, signer]` payer
 ///   4. `[]` update_authority
-///   5. `[optional]` system_program
-///   6. `[optional]` rent
+///   5. `[]` system_program
+///   6. `[]` rent
 pub struct CreateMetadataAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -110,7 +110,17 @@ pub struct CreateMetadataAccountInstructionDataData {
     pub creators: Option<Vec<Creator>>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateMetadataAccount`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` mint
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` update_authority
+///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   6. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Default)]
 pub struct CreateMetadataAccountBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -397,7 +407,17 @@ impl<'a, 'b> CreateMetadataAccountCpi<'a, 'b> {
     }
 }
 
-/// `create_metadata_account` CPI instruction builder.
+/// Instruction builder for `CreateMetadataAccount` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` mint
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` update_authority
+///   5. `[optional]` system_program
+///   6. `[optional]` rent
 pub struct CreateMetadataAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -106,7 +106,17 @@ pub struct CreateMetadataAccountV2InstructionArgs {
     pub is_mutable: bool,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateMetadataAccountV2`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` mint
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` update_authority
+///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   6. `[optional]` rent
 #[derive(Default)]
 pub struct CreateMetadataAccountV2Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -389,7 +399,17 @@ impl<'a, 'b> CreateMetadataAccountV2Cpi<'a, 'b> {
     }
 }
 
-/// `create_metadata_account_v2` CPI instruction builder.
+/// Instruction builder for `CreateMetadataAccountV2` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` mint
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` update_authority
+///   5. `[optional]` system_program
+///   6. `[optional]` rent
 pub struct CreateMetadataAccountV2CpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -408,7 +408,7 @@ impl<'a, 'b> CreateMetadataAccountV2Cpi<'a, 'b> {
 ///   2. `[signer]` mint_authority
 ///   3. `[writable, signer]` payer
 ///   4. `[]` update_authority
-///   5. `[optional]` system_program
+///   5. `[]` system_program
 ///   6. `[optional]` rent
 pub struct CreateMetadataAccountV2CpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -108,7 +108,17 @@ pub struct CreateMetadataAccountV3InstructionArgs {
     pub collection_details: Option<CollectionDetails>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateMetadataAccountV3`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` mint
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` update_authority
+///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   6. `[optional]` rent
 #[derive(Default)]
 pub struct CreateMetadataAccountV3Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -399,7 +409,17 @@ impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
     }
 }
 
-/// `create_metadata_account_v3` CPI instruction builder.
+/// Instruction builder for `CreateMetadataAccountV3` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` mint
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[]` update_authority
+///   5. `[optional]` system_program
+///   6. `[optional]` rent
 pub struct CreateMetadataAccountV3CpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -418,7 +418,7 @@ impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
 ///   2. `[signer]` mint_authority
 ///   3. `[writable, signer]` payer
 ///   4. `[]` update_authority
-///   5. `[optional]` system_program
+///   5. `[]` system_program
 ///   6. `[optional]` rent
 pub struct CreateMetadataAccountV3CpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -92,7 +92,18 @@ impl CreateReservationListInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateReservationList`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` reservation_list
+///   1. `[signer]` payer
+///   2. `[signer]` update_authority
+///   3. `[]` master_edition
+///   4. `[]` resource
+///   5. `[]` metadata
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Default)]
 pub struct CreateReservationListBuilder {
     reservation_list: Option<solana_program::pubkey::Pubkey>,
@@ -368,7 +379,18 @@ impl<'a, 'b> CreateReservationListCpi<'a, 'b> {
     }
 }
 
-/// `create_reservation_list` CPI instruction builder.
+/// Instruction builder for `CreateReservationList` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` reservation_list
+///   1. `[signer]` payer
+///   2. `[signer]` update_authority
+///   3. `[]` master_edition
+///   4. `[]` resource
+///   5. `[]` metadata
+///   6. `[optional]` system_program
+///   7. `[optional]` rent
 pub struct CreateReservationListCpiBuilder<'a, 'b> {
     instruction: Box<CreateReservationListCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -389,8 +389,8 @@ impl<'a, 'b> CreateReservationListCpi<'a, 'b> {
 ///   3. `[]` master_edition
 ///   4. `[]` resource
 ///   5. `[]` metadata
-///   6. `[optional]` system_program
-///   7. `[optional]` rent
+///   6. `[]` system_program
+///   7. `[]` rent
 pub struct CreateReservationListCpiBuilder<'a, 'b> {
     instruction: Box<CreateReservationListCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -75,7 +75,13 @@ pub struct CreateRuleSetInstructionArgs {
     pub rule_set_bump: u8,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateRuleSet`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` payer
+///   1. `[writable]` rule_set_pda
+///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Default)]
 pub struct CreateRuleSetBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -275,7 +281,13 @@ impl<'a, 'b> CreateRuleSetCpi<'a, 'b> {
     }
 }
 
-/// `create_rule_set` CPI instruction builder.
+/// Instruction builder for `CreateRuleSet` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` payer
+///   1. `[writable]` rule_set_pda
+///   2. `[optional]` system_program
 pub struct CreateRuleSetCpiBuilder<'a, 'b> {
     instruction: Box<CreateRuleSetCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -287,7 +287,7 @@ impl<'a, 'b> CreateRuleSetCpi<'a, 'b> {
 ///
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` rule_set_pda
-///   2. `[optional]` system_program
+///   2. `[]` system_program
 pub struct CreateRuleSetCpiBuilder<'a, 'b> {
     instruction: Box<CreateRuleSetCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -487,9 +487,9 @@ impl<'a, 'b> CreateV1Cpi<'a, 'b> {
 ///   3. `[signer]` mint_authority
 ///   4. `[writable, signer]` payer
 ///   5. `[]` update_authority
-///   6. `[optional]` system_program
-///   7. `[optional]` sysvar_instructions
-///   8. `[optional]` spl_token_program
+///   6. `[]` system_program
+///   7. `[]` sysvar_instructions
+///   8. `[]` spl_token_program
 pub struct CreateV1CpiBuilder<'a, 'b> {
     instruction: Box<CreateV1CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -123,7 +123,19 @@ pub struct CreateV1InstructionArgs {
     pub max_supply: Option<u64>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateV1`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, optional]` master_edition
+///   2. `[writable, signer]` mint
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[]` update_authority
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   8. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Default)]
 pub struct CreateV1Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -465,7 +477,19 @@ impl<'a, 'b> CreateV1Cpi<'a, 'b> {
     }
 }
 
-/// `create_v1` CPI instruction builder.
+/// Instruction builder for `CreateV1` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, optional]` master_edition
+///   2. `[writable, signer]` mint
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[]` update_authority
+///   6. `[optional]` system_program
+///   7. `[optional]` sysvar_instructions
+///   8. `[optional]` spl_token_program
 pub struct CreateV1CpiBuilder<'a, 'b> {
     instruction: Box<CreateV1CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -122,7 +122,19 @@ pub struct CreateV2InstructionArgs {
     pub max_supply: Option<u64>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `CreateV2`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, optional]` master_edition
+///   2. `[writable, signer]` mint
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[]` update_authority
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   8. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Default)]
 pub struct CreateV2Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -456,7 +468,19 @@ impl<'a, 'b> CreateV2Cpi<'a, 'b> {
     }
 }
 
-/// `create_v2` CPI instruction builder.
+/// Instruction builder for `CreateV2` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, optional]` master_edition
+///   2. `[writable, signer]` mint
+///   3. `[signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[]` update_authority
+///   6. `[optional]` system_program
+///   7. `[optional]` sysvar_instructions
+///   8. `[optional]` spl_token_program
 pub struct CreateV2CpiBuilder<'a, 'b> {
     instruction: Box<CreateV2CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -478,9 +478,9 @@ impl<'a, 'b> CreateV2Cpi<'a, 'b> {
 ///   3. `[signer]` mint_authority
 ///   4. `[writable, signer]` payer
 ///   5. `[]` update_authority
-///   6. `[optional]` system_program
-///   7. `[optional]` sysvar_instructions
-///   8. `[optional]` spl_token_program
+///   6. `[]` system_program
+///   7. `[]` sysvar_instructions
+///   8. `[]` spl_token_program
 pub struct CreateV2CpiBuilder<'a, 'b> {
     instruction: Box<CreateV2CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -165,7 +165,23 @@ pub struct DelegateInstructionArgs {
     pub delegate_args: DelegateArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Delegate`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` delegate_record
+///   1. `[]` delegate
+///   2. `[writable]` metadata
+///   3. `[optional]` master_edition
+///   4. `[]` mint
+///   5. `[writable, optional]` token
+///   6. `[signer]` authority
+///   7. `[writable, signer]` payer
+///   8. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   9. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   10. `[optional]` spl_token_program
+///   11. `[optional]` authorization_rules_program
+///   12. `[optional]` authorization_rules
 #[derive(Default)]
 pub struct DelegateBuilder {
     delegate_record: Option<solana_program::pubkey::Pubkey>,
@@ -608,7 +624,23 @@ impl<'a, 'b> DelegateCpi<'a, 'b> {
     }
 }
 
-/// `delegate` CPI instruction builder.
+/// Instruction builder for `Delegate` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` delegate_record
+///   1. `[]` delegate
+///   2. `[writable]` metadata
+///   3. `[optional]` master_edition
+///   4. `[]` mint
+///   5. `[writable, optional]` token
+///   6. `[signer]` authority
+///   7. `[writable, signer]` payer
+///   8. `[optional]` system_program
+///   9. `[optional]` sysvar_instructions
+///   10. `[optional]` spl_token_program
+///   11. `[optional]` authorization_rules_program
+///   12. `[optional]` authorization_rules
 pub struct DelegateCpiBuilder<'a, 'b> {
     instruction: Box<DelegateCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -636,8 +636,8 @@ impl<'a, 'b> DelegateCpi<'a, 'b> {
 ///   5. `[writable, optional]` token
 ///   6. `[signer]` authority
 ///   7. `[writable, signer]` payer
-///   8. `[optional]` system_program
-///   9. `[optional]` sysvar_instructions
+///   8. `[]` system_program
+///   9. `[]` sysvar_instructions
 ///   10. `[optional]` spl_token_program
 ///   11. `[optional]` authorization_rules_program
 ///   12. `[optional]` authorization_rules

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -134,7 +134,23 @@ pub struct DeprecatedCreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `DeprecatedCreateMasterEdition`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` edition
+///   1. `[writable]` mint
+///   2. `[writable]` printing_mint
+///   3. `[writable]` one_time_printing_authorization_mint
+///   4. `[signer]` update_authority
+///   5. `[signer]` printing_mint_authority
+///   6. `[signer]` mint_authority
+///   7. `[]` metadata
+///   8. `[signer]` payer
+///   9. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   10. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   11. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
+///   12. `[signer]` one_time_printing_authorization_mint_authority
 #[derive(Default)]
 pub struct DeprecatedCreateMasterEditionBuilder {
     edition: Option<solana_program::pubkey::Pubkey>,
@@ -540,7 +556,23 @@ impl<'a, 'b> DeprecatedCreateMasterEditionCpi<'a, 'b> {
     }
 }
 
-/// `deprecated_create_master_edition` CPI instruction builder.
+/// Instruction builder for `DeprecatedCreateMasterEdition` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` edition
+///   1. `[writable]` mint
+///   2. `[writable]` printing_mint
+///   3. `[writable]` one_time_printing_authorization_mint
+///   4. `[signer]` update_authority
+///   5. `[signer]` printing_mint_authority
+///   6. `[signer]` mint_authority
+///   7. `[]` metadata
+///   8. `[signer]` payer
+///   9. `[optional]` token_program
+///   10. `[optional]` system_program
+///   11. `[optional]` rent
+///   12. `[signer]` one_time_printing_authorization_mint_authority
 pub struct DeprecatedCreateMasterEditionCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedCreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -569,9 +569,9 @@ impl<'a, 'b> DeprecatedCreateMasterEditionCpi<'a, 'b> {
 ///   6. `[signer]` mint_authority
 ///   7. `[]` metadata
 ///   8. `[signer]` payer
-///   9. `[optional]` token_program
-///   10. `[optional]` system_program
-///   11. `[optional]` rent
+///   9. `[]` token_program
+///   10. `[]` system_program
+///   11. `[]` rent
 ///   12. `[signer]` one_time_printing_authorization_mint_authority
 pub struct DeprecatedCreateMasterEditionCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedCreateMasterEditionCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -624,9 +624,9 @@ impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b
 ///   9. `[signer]` payer
 ///   10. `[]` master_update_authority
 ///   11. `[]` master_metadata
-///   12. `[optional]` token_program
-///   13. `[optional]` system_program
-///   14. `[optional]` rent
+///   12. `[]` token_program
+///   13. `[]` system_program
+///   14. `[]` rent
 ///   15. `[writable, optional]` reservation_list
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
     instruction:

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -146,7 +146,26 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `DeprecatedMintNewEditionFromMasterEditionViaPrintingToken`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable]` edition
+///   2. `[writable]` master_edition
+///   3. `[writable]` mint
+///   4. `[signer]` mint_authority
+///   5. `[writable]` printing_mint
+///   6. `[writable]` master_token_account
+///   7. `[writable]` edition_marker
+///   8. `[signer]` burn_authority
+///   9. `[signer]` payer
+///   10. `[]` master_update_authority
+///   11. `[]` master_metadata
+///   12. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   13. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   14. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
+///   15. `[writable, optional]` reservation_list
 #[derive(Default)]
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -589,7 +608,26 @@ impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b
     }
 }
 
-/// `deprecated_mint_new_edition_from_master_edition_via_printing_token` CPI instruction builder.
+/// Instruction builder for `DeprecatedMintNewEditionFromMasterEditionViaPrintingToken` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable]` edition
+///   2. `[writable]` master_edition
+///   3. `[writable]` mint
+///   4. `[signer]` mint_authority
+///   5. `[writable]` printing_mint
+///   6. `[writable]` master_token_account
+///   7. `[writable]` edition_marker
+///   8. `[signer]` burn_authority
+///   9. `[signer]` payer
+///   10. `[]` master_update_authority
+///   11. `[]` master_metadata
+///   12. `[optional]` token_program
+///   13. `[optional]` system_program
+///   14. `[optional]` rent
+///   15. `[writable, optional]` reservation_list
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
     instruction:
         Box<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -395,8 +395,8 @@ impl<'a, 'b> DeprecatedMintPrintingTokensCpi<'a, 'b> {
 ///   2. `[signer]` update_authority
 ///   3. `[]` metadata
 ///   4. `[]` master_edition
-///   5. `[optional]` token_program
-///   6. `[optional]` rent
+///   5. `[]` token_program
+///   6. `[]` rent
 pub struct DeprecatedMintPrintingTokensCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedMintPrintingTokensCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -100,7 +100,17 @@ pub struct DeprecatedMintPrintingTokensInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `DeprecatedMintPrintingTokens`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` destination
+///   1. `[writable]` printing_mint
+///   2. `[signer]` update_authority
+///   3. `[]` metadata
+///   4. `[]` master_edition
+///   5. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   6. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Default)]
 pub struct DeprecatedMintPrintingTokensBuilder {
     destination: Option<solana_program::pubkey::Pubkey>,
@@ -376,7 +386,17 @@ impl<'a, 'b> DeprecatedMintPrintingTokensCpi<'a, 'b> {
     }
 }
 
-/// `deprecated_mint_printing_tokens` CPI instruction builder.
+/// Instruction builder for `DeprecatedMintPrintingTokens` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` destination
+///   1. `[writable]` printing_mint
+///   2. `[signer]` update_authority
+///   3. `[]` metadata
+///   4. `[]` master_edition
+///   5. `[optional]` token_program
+///   6. `[optional]` rent
 pub struct DeprecatedMintPrintingTokensCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedMintPrintingTokensCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -111,7 +111,19 @@ pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `DeprecatedMintPrintingTokensViaToken`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` destination
+///   1. `[writable]` token
+///   2. `[writable]` one_time_printing_authorization_mint
+///   3. `[writable]` printing_mint
+///   4. `[signer]` burn_authority
+///   5. `[]` metadata
+///   6. `[]` master_edition
+///   7. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 #[derive(Default)]
 pub struct DeprecatedMintPrintingTokensViaTokenBuilder {
     destination: Option<solana_program::pubkey::Pubkey>,
@@ -425,7 +437,19 @@ impl<'a, 'b> DeprecatedMintPrintingTokensViaTokenCpi<'a, 'b> {
     }
 }
 
-/// `deprecated_mint_printing_tokens_via_token` CPI instruction builder.
+/// Instruction builder for `DeprecatedMintPrintingTokensViaToken` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` destination
+///   1. `[writable]` token
+///   2. `[writable]` one_time_printing_authorization_mint
+///   3. `[writable]` printing_mint
+///   4. `[signer]` burn_authority
+///   5. `[]` metadata
+///   6. `[]` master_edition
+///   7. `[optional]` token_program
+///   8. `[optional]` rent
 pub struct DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -448,8 +448,8 @@ impl<'a, 'b> DeprecatedMintPrintingTokensViaTokenCpi<'a, 'b> {
 ///   4. `[signer]` burn_authority
 ///   5. `[]` metadata
 ///   6. `[]` master_edition
-///   7. `[optional]` token_program
-///   8. `[optional]` rent
+///   7. `[]` token_program
+///   8. `[]` rent
 pub struct DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -80,7 +80,13 @@ pub struct DeprecatedSetReservationListInstructionArgs {
     pub total_spot_offset: u64,
 }
 
-/// Instruction builder.
+/// Instruction builder for `DeprecatedSetReservationList`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` master_edition
+///   1. `[writable]` reservation_list
+///   2. `[signer]` resource
 #[derive(Default)]
 pub struct DeprecatedSetReservationListBuilder {
     master_edition: Option<solana_program::pubkey::Pubkey>,
@@ -297,7 +303,13 @@ impl<'a, 'b> DeprecatedSetReservationListCpi<'a, 'b> {
     }
 }
 
-/// `deprecated_set_reservation_list` CPI instruction builder.
+/// Instruction builder for `DeprecatedSetReservationList` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` master_edition
+///   1. `[writable]` reservation_list
+///   2. `[signer]` resource
 pub struct DeprecatedSetReservationListCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedSetReservationListCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -126,7 +126,20 @@ impl DummyInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `Dummy`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` edition
+///   1. `[writable, optional]` mint
+///   2. `[signer]` update_authority
+///   3. `[writable, signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[writable]` foo
+///   6. `[signer, optional]` bar
+///   7. `[signer, optional]` delegate
+///   8. `[writable, optional]` delegate_record
+///   9. `[]` token_or_ata_program
 #[derive(Default)]
 pub struct DummyBuilder {
     edition: Option<solana_program::pubkey::Pubkey>,
@@ -462,7 +475,20 @@ impl<'a, 'b> DummyCpi<'a, 'b> {
     }
 }
 
-/// `dummy` CPI instruction builder.
+/// Instruction builder for `Dummy` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` edition
+///   1. `[writable, optional]` mint
+///   2. `[signer]` update_authority
+///   3. `[writable, signer]` mint_authority
+///   4. `[writable, signer]` payer
+///   5. `[writable]` foo
+///   6. `[signer, optional]` bar
+///   7. `[signer, optional]` delegate
+///   8. `[writable, optional]` delegate_record
+///   9. `[]` token_or_ata_program
 pub struct DummyCpiBuilder<'a, 'b> {
     instruction: Box<DummyCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -75,7 +75,15 @@ impl FreezeDelegatedAccountInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `FreezeDelegatedAccount`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` delegate
+///   1. `[writable]` token_account
+///   2. `[]` edition
+///   3. `[]` mint
+///   4. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Default)]
 pub struct FreezeDelegatedAccountBuilder {
     delegate: Option<solana_program::pubkey::Pubkey>,
@@ -288,7 +296,15 @@ impl<'a, 'b> FreezeDelegatedAccountCpi<'a, 'b> {
     }
 }
 
-/// `freeze_delegated_account` CPI instruction builder.
+/// Instruction builder for `FreezeDelegatedAccount` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` delegate
+///   1. `[writable]` token_account
+///   2. `[]` edition
+///   3. `[]` mint
+///   4. `[optional]` token_program
 pub struct FreezeDelegatedAccountCpiBuilder<'a, 'b> {
     instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -304,7 +304,7 @@ impl<'a, 'b> FreezeDelegatedAccountCpi<'a, 'b> {
 ///   1. `[writable]` token_account
 ///   2. `[]` edition
 ///   3. `[]` mint
-///   4. `[optional]` token_program
+///   4. `[]` token_program
 pub struct FreezeDelegatedAccountCpiBuilder<'a, 'b> {
     instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -123,7 +123,21 @@ pub struct InitializeInstructionArgs {
     pub data: CandyMachineData,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Initialize`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[writable]` authority_pda
+///   2. `[]` authority
+///   3. `[signer]` payer
+///   4. `[]` collection_metadata
+///   5. `[]` collection_mint
+///   6. `[]` collection_master_edition
+///   7. `[writable, signer]` collection_update_authority
+///   8. `[writable]` collection_authority_record
+///   9. `[optional]` token_metadata_program (default to `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`)
+///   10. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Default)]
 pub struct InitializeBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -475,7 +489,21 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
     }
 }
 
-/// `initialize` CPI instruction builder.
+/// Instruction builder for `Initialize` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[writable]` authority_pda
+///   2. `[]` authority
+///   3. `[signer]` payer
+///   4. `[]` collection_metadata
+///   5. `[]` collection_mint
+///   6. `[]` collection_master_edition
+///   7. `[writable, signer]` collection_update_authority
+///   8. `[writable]` collection_authority_record
+///   9. `[optional]` token_metadata_program
+///   10. `[optional]` system_program
 pub struct InitializeCpiBuilder<'a, 'b> {
     instruction: Box<InitializeCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -502,8 +502,8 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
 ///   6. `[]` collection_master_edition
 ///   7. `[writable, signer]` collection_update_authority
 ///   8. `[writable]` collection_authority_record
-///   9. `[optional]` token_metadata_program
-///   10. `[optional]` system_program
+///   9. `[]` token_metadata_program
+///   10. `[]` system_program
 pub struct InitializeCpiBuilder<'a, 'b> {
     instruction: Box<InitializeCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -123,7 +123,20 @@ pub struct MigrateInstructionArgs {
     pub migrate_args: MigrateArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Migrate`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` master_edition
+///   2. `[writable]` token_account
+///   3. `[]` mint
+///   4. `[signer]` update_authority
+///   5. `[]` collection_metadata
+///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   8. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   9. `[optional]` authorization_rules
 #[derive(Default)]
 pub struct MigrateBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -469,7 +482,20 @@ impl<'a, 'b> MigrateCpi<'a, 'b> {
     }
 }
 
-/// `migrate` CPI instruction builder.
+/// Instruction builder for `Migrate` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[]` master_edition
+///   2. `[writable]` token_account
+///   3. `[]` mint
+///   4. `[signer]` update_authority
+///   5. `[]` collection_metadata
+///   6. `[optional]` token_program
+///   7. `[optional]` system_program
+///   8. `[optional]` sysvar_instructions
+///   9. `[optional]` authorization_rules
 pub struct MigrateCpiBuilder<'a, 'b> {
     instruction: Box<MigrateCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -492,9 +492,9 @@ impl<'a, 'b> MigrateCpi<'a, 'b> {
 ///   3. `[]` mint
 ///   4. `[signer]` update_authority
 ///   5. `[]` collection_metadata
-///   6. `[optional]` token_program
-///   7. `[optional]` system_program
-///   8. `[optional]` sysvar_instructions
+///   6. `[]` token_program
+///   7. `[]` system_program
+///   8. `[]` sysvar_instructions
 ///   9. `[optional]` authorization_rules
 pub struct MigrateCpiBuilder<'a, 'b> {
     instruction: Box<MigrateCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -581,10 +581,10 @@ impl<'a, 'b> MintCpi<'a, 'b> {
 ///   3. `[writable]` mint
 ///   4. `[writable, signer]` payer
 ///   5. `[signer]` authority
-///   6. `[optional]` system_program
-///   7. `[optional]` sysvar_instructions
-///   8. `[optional]` spl_token_program
-///   9. `[optional]` spl_ata_program
+///   6. `[]` system_program
+///   7. `[]` sysvar_instructions
+///   8. `[]` spl_token_program
+///   9. `[]` spl_ata_program
 ///   10. `[optional]` authorization_rules_program
 ///   11. `[optional]` authorization_rules
 pub struct MintCpiBuilder<'a, 'b> {

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -147,7 +147,22 @@ pub struct MintInstructionArgs {
     pub mint_args: MintArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Mint`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` token
+///   1. `[]` metadata
+///   2. `[optional]` master_edition
+///   3. `[writable]` mint
+///   4. `[writable, signer]` payer
+///   5. `[signer]` authority
+///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   8. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   9. `[optional]` spl_ata_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
+///   10. `[optional]` authorization_rules_program
+///   11. `[optional]` authorization_rules
 #[derive(Default)]
 pub struct MintBuilder {
     token: Option<solana_program::pubkey::Pubkey>,
@@ -556,7 +571,22 @@ impl<'a, 'b> MintCpi<'a, 'b> {
     }
 }
 
-/// `mint` CPI instruction builder.
+/// Instruction builder for `Mint` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` token
+///   1. `[]` metadata
+///   2. `[optional]` master_edition
+///   3. `[writable]` mint
+///   4. `[writable, signer]` payer
+///   5. `[signer]` authority
+///   6. `[optional]` system_program
+///   7. `[optional]` sysvar_instructions
+///   8. `[optional]` spl_token_program
+///   9. `[optional]` spl_ata_program
+///   10. `[optional]` authorization_rules_program
+///   11. `[optional]` authorization_rules
 pub struct MintCpiBuilder<'a, 'b> {
     instruction: Box<MintCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -644,9 +644,9 @@ impl<'a, 'b> MintFromCandyMachineCpi<'a, 'b> {
 ///   10. `[writable]` collection_metadata
 ///   11. `[]` collection_master_edition
 ///   12. `[]` collection_update_authority
-///   13. `[optional]` token_metadata_program
-///   14. `[optional]` token_program
-///   15. `[optional]` system_program
+///   13. `[]` token_metadata_program
+///   14. `[]` token_program
+///   15. `[]` system_program
 ///   16. `[]` recent_slothashes
 pub struct MintFromCandyMachineCpiBuilder<'a, 'b> {
     instruction: Box<MintFromCandyMachineCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -148,7 +148,27 @@ impl MintFromCandyMachineInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `MintFromCandyMachine`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[writable]` authority_pda
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[writable]` nft_mint
+///   5. `[signer]` nft_mint_authority
+///   6. `[writable]` nft_metadata
+///   7. `[writable]` nft_master_edition
+///   8. `[]` collection_authority_record
+///   9. `[]` collection_mint
+///   10. `[writable]` collection_metadata
+///   11. `[]` collection_master_edition
+///   12. `[]` collection_update_authority
+///   13. `[optional]` token_metadata_program (default to `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`)
+///   14. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   15. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   16. `[]` recent_slothashes
 #[derive(Default)]
 pub struct MintFromCandyMachineBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -607,7 +627,27 @@ impl<'a, 'b> MintFromCandyMachineCpi<'a, 'b> {
     }
 }
 
-/// `mint_from_candy_machine` CPI instruction builder.
+/// Instruction builder for `MintFromCandyMachine` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[writable]` authority_pda
+///   2. `[signer]` mint_authority
+///   3. `[writable, signer]` payer
+///   4. `[writable]` nft_mint
+///   5. `[signer]` nft_mint_authority
+///   6. `[writable]` nft_metadata
+///   7. `[writable]` nft_master_edition
+///   8. `[]` collection_authority_record
+///   9. `[]` collection_mint
+///   10. `[writable]` collection_metadata
+///   11. `[]` collection_master_edition
+///   12. `[]` collection_update_authority
+///   13. `[optional]` token_metadata_program
+///   14. `[optional]` token_program
+///   15. `[optional]` system_program
+///   16. `[]` recent_slothashes
 pub struct MintFromCandyMachineCpiBuilder<'a, 'b> {
     instruction: Box<MintFromCandyMachineCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -609,8 +609,8 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
 ///   8. `[]` token_account
 ///   9. `[]` new_metadata_update_authority
 ///   10. `[]` metadata
-///   11. `[optional]` token_program
-///   12. `[optional]` system_program
+///   11. `[]` token_program
+///   12. `[]` system_program
 ///   13. `[optional]` rent
 pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -149,7 +149,24 @@ pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
         MintNewEditionFromMasterEditionViaTokenArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `MintNewEditionFromMasterEditionViaToken`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` new_metadata
+///   1. `[writable]` new_edition
+///   2. `[writable]` master_edition
+///   3. `[writable]` new_mint
+///   4. `[writable]` edition_mark_pda
+///   5. `[signer]` new_mint_authority
+///   6. `[writable, signer]` payer
+///   7. `[signer]` token_account_owner
+///   8. `[]` token_account
+///   9. `[]` new_metadata_update_authority
+///   10. `[]` metadata
+///   11. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   12. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   13. `[optional]` rent
 #[derive(Default)]
 pub struct MintNewEditionFromMasterEditionViaTokenBuilder {
     new_metadata: Option<solana_program::pubkey::Pubkey>,
@@ -577,7 +594,24 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
     }
 }
 
-/// `mint_new_edition_from_master_edition_via_token` CPI instruction builder.
+/// Instruction builder for `MintNewEditionFromMasterEditionViaToken` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` new_metadata
+///   1. `[writable]` new_edition
+///   2. `[writable]` master_edition
+///   3. `[writable]` new_mint
+///   4. `[writable]` edition_mark_pda
+///   5. `[signer]` new_mint_authority
+///   6. `[writable, signer]` payer
+///   7. `[signer]` token_account_owner
+///   8. `[]` token_account
+///   9. `[]` new_metadata_update_authority
+///   10. `[]` metadata
+///   11. `[optional]` token_program
+///   12. `[optional]` system_program
+///   13. `[optional]` rent
 pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -166,7 +166,27 @@ pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
         MintNewEditionFromMasterEditionViaTokenArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `MintNewEditionFromMasterEditionViaVaultProxy`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` new_metadata
+///   1. `[writable]` new_edition
+///   2. `[writable]` master_edition
+///   3. `[writable]` new_mint
+///   4. `[writable]` edition_mark_pda
+///   5. `[signer]` new_mint_authority
+///   6. `[writable, signer]` payer
+///   7. `[signer]` vault_authority
+///   8. `[]` safety_deposit_store
+///   9. `[]` safety_deposit_box
+///   10. `[]` vault
+///   11. `[]` new_metadata_update_authority
+///   12. `[]` metadata
+///   13. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   14. `[]` token_vault_program
+///   15. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   16. `[optional]` rent
 #[derive(Default)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyBuilder {
     new_metadata: Option<solana_program::pubkey::Pubkey>,
@@ -661,7 +681,27 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
     }
 }
 
-/// `mint_new_edition_from_master_edition_via_vault_proxy` CPI instruction builder.
+/// Instruction builder for `MintNewEditionFromMasterEditionViaVaultProxy` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` new_metadata
+///   1. `[writable]` new_edition
+///   2. `[writable]` master_edition
+///   3. `[writable]` new_mint
+///   4. `[writable]` edition_mark_pda
+///   5. `[signer]` new_mint_authority
+///   6. `[writable, signer]` payer
+///   7. `[signer]` vault_authority
+///   8. `[]` safety_deposit_store
+///   9. `[]` safety_deposit_box
+///   10. `[]` vault
+///   11. `[]` new_metadata_update_authority
+///   12. `[]` metadata
+///   13. `[optional]` token_program
+///   14. `[]` token_vault_program
+///   15. `[optional]` system_program
+///   16. `[optional]` rent
 pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
     instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -698,9 +698,9 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
 ///   10. `[]` vault
 ///   11. `[]` new_metadata_update_authority
 ///   12. `[]` metadata
-///   13. `[optional]` token_program
+///   13. `[]` token_program
 ///   14. `[]` token_vault_program
-///   15. `[optional]` system_program
+///   15. `[]` system_program
 ///   16. `[optional]` rent
 pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
     instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -50,7 +50,11 @@ impl PuffMetadataInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `PuffMetadata`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
 #[derive(Default)]
 pub struct PuffMetadataBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -186,7 +190,11 @@ impl<'a, 'b> PuffMetadataCpi<'a, 'b> {
     }
 }
 
-/// `puff_metadata` CPI instruction builder.
+/// Instruction builder for `PuffMetadata` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
 pub struct PuffMetadataCpiBuilder<'a, 'b> {
     instruction: Box<PuffMetadataCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -58,7 +58,12 @@ impl RemoveCreatorVerificationInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `RemoveCreatorVerification`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` creator
 #[derive(Default)]
 pub struct RemoveCreatorVerificationBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -214,7 +219,12 @@ impl<'a, 'b> RemoveCreatorVerificationCpi<'a, 'b> {
     }
 }
 
-/// `remove_creator_verification` CPI instruction builder.
+/// Instruction builder for `RemoveCreatorVerification` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` creator
 pub struct RemoveCreatorVerificationCpiBuilder<'a, 'b> {
     instruction: Box<RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -165,7 +165,23 @@ pub struct RevokeInstructionArgs {
     pub revoke_args: RevokeArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Revoke`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` delegate_record
+///   1. `[]` delegate
+///   2. `[writable]` metadata
+///   3. `[optional]` master_edition
+///   4. `[]` mint
+///   5. `[writable, optional]` token
+///   6. `[signer]` authority
+///   7. `[writable, signer]` payer
+///   8. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   9. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   10. `[optional]` spl_token_program
+///   11. `[optional]` authorization_rules_program
+///   12. `[optional]` authorization_rules
 #[derive(Default)]
 pub struct RevokeBuilder {
     delegate_record: Option<solana_program::pubkey::Pubkey>,
@@ -605,7 +621,23 @@ impl<'a, 'b> RevokeCpi<'a, 'b> {
     }
 }
 
-/// `revoke` CPI instruction builder.
+/// Instruction builder for `Revoke` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` delegate_record
+///   1. `[]` delegate
+///   2. `[writable]` metadata
+///   3. `[optional]` master_edition
+///   4. `[]` mint
+///   5. `[writable, optional]` token
+///   6. `[signer]` authority
+///   7. `[writable, signer]` payer
+///   8. `[optional]` system_program
+///   9. `[optional]` sysvar_instructions
+///   10. `[optional]` spl_token_program
+///   11. `[optional]` authorization_rules_program
+///   12. `[optional]` authorization_rules
 pub struct RevokeCpiBuilder<'a, 'b> {
     instruction: Box<RevokeCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -633,8 +633,8 @@ impl<'a, 'b> RevokeCpi<'a, 'b> {
 ///   5. `[writable, optional]` token
 ///   6. `[signer]` authority
 ///   7. `[writable, signer]` payer
-///   8. `[optional]` system_program
-///   9. `[optional]` sysvar_instructions
+///   8. `[]` system_program
+///   9. `[]` sysvar_instructions
 ///   10. `[optional]` spl_token_program
 ///   11. `[optional]` authorization_rules_program
 ///   12. `[optional]` authorization_rules

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -75,7 +75,15 @@ impl RevokeCollectionAuthorityInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `RevokeCollectionAuthority`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_authority_record
+///   1. `[writable]` delegate_authority
+///   2. `[writable, signer]` revoke_authority
+///   3. `[]` metadata
+///   4. `[]` mint
 #[derive(Default)]
 pub struct RevokeCollectionAuthorityBuilder {
     collection_authority_record: Option<solana_program::pubkey::Pubkey>,
@@ -298,7 +306,15 @@ impl<'a, 'b> RevokeCollectionAuthorityCpi<'a, 'b> {
     }
 }
 
-/// `revoke_collection_authority` CPI instruction builder.
+/// Instruction builder for `RevokeCollectionAuthority` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_authority_record
+///   1. `[writable]` delegate_authority
+///   2. `[writable, signer]` revoke_authority
+///   3. `[]` metadata
+///   4. `[]` mint
 pub struct RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -103,7 +103,19 @@ impl RevokeUseAuthorityInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `RevokeUseAuthority`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` use_authority_record
+///   1. `[writable, signer]` owner
+///   2. `[]` user
+///   3. `[writable]` owner_token_account
+///   4. `[]` mint
+///   5. `[]` metadata
+///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   8. `[optional]` rent
 #[derive(Default)]
 pub struct RevokeUseAuthorityBuilder {
     use_authority_record: Option<solana_program::pubkey::Pubkey>,
@@ -410,7 +422,19 @@ impl<'a, 'b> RevokeUseAuthorityCpi<'a, 'b> {
     }
 }
 
-/// `revoke_use_authority` CPI instruction builder.
+/// Instruction builder for `RevokeUseAuthority` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` use_authority_record
+///   1. `[writable, signer]` owner
+///   2. `[]` user
+///   3. `[writable]` owner_token_account
+///   4. `[]` mint
+///   5. `[]` metadata
+///   6. `[optional]` token_program
+///   7. `[optional]` system_program
+///   8. `[optional]` rent
 pub struct RevokeUseAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -432,8 +432,8 @@ impl<'a, 'b> RevokeUseAuthorityCpi<'a, 'b> {
 ///   3. `[writable]` owner_token_account
 ///   4. `[]` mint
 ///   5. `[]` metadata
-///   6. `[optional]` token_program
-///   7. `[optional]` system_program
+///   6. `[]` token_program
+///   7. `[]` system_program
 ///   8. `[optional]` rent
 pub struct RevokeUseAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -100,7 +100,18 @@ impl SetAndVerifyCollectionInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetAndVerifyCollection`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` update_authority
+///   4. `[]` collection_mint
+///   5. `[]` collection
+///   6. `[]` collection_master_edition_account
+///   7. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct SetAndVerifyCollectionBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -393,7 +404,18 @@ impl<'a, 'b> SetAndVerifyCollectionCpi<'a, 'b> {
     }
 }
 
-/// `set_and_verify_collection` CPI instruction builder.
+/// Instruction builder for `SetAndVerifyCollection` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` update_authority
+///   4. `[]` collection_mint
+///   5. `[]` collection
+///   6. `[]` collection_master_edition_account
+///   7. `[optional]` collection_authority_record
 pub struct SetAndVerifyCollectionCpiBuilder<'a, 'b> {
     instruction: Box<SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -100,7 +100,18 @@ impl SetAndVerifySizedCollectionItemInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetAndVerifySizedCollectionItem`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` update_authority
+///   4. `[]` collection_mint
+///   5. `[writable]` collection
+///   6. `[writable]` collection_master_edition_account
+///   7. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct SetAndVerifySizedCollectionItemBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -393,7 +404,18 @@ impl<'a, 'b> SetAndVerifySizedCollectionItemCpi<'a, 'b> {
     }
 }
 
-/// `set_and_verify_sized_collection_item` CPI instruction builder.
+/// Instruction builder for `SetAndVerifySizedCollectionItem` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` update_authority
+///   4. `[]` collection_mint
+///   5. `[writable]` collection
+///   6. `[writable]` collection_master_edition_account
+///   7. `[optional]` collection_authority_record
 pub struct SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
     instruction: Box<SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -70,7 +70,12 @@ pub struct SetAuthorityInstructionArgs {
     pub new_authority: Pubkey,
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetAuthority`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
 #[derive(Default)]
 pub struct SetAuthorityBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -239,7 +244,12 @@ impl<'a, 'b> SetAuthorityCpi<'a, 'b> {
     }
 }
 
-/// `set_authority` CPI instruction builder.
+/// Instruction builder for `SetAuthority` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
 pub struct SetAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<SetAuthorityCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -564,8 +564,8 @@ impl<'a, 'b> SetCollectionCpi<'a, 'b> {
 ///   9. `[]` new_collection_mint
 ///   10. `[]` new_collection_master_edition
 ///   11. `[writable]` new_collection_authority_record
-///   12. `[optional]` token_metadata_program
-///   13. `[optional]` system_program
+///   12. `[]` token_metadata_program
+///   13. `[]` system_program
 pub struct SetCollectionCpiBuilder<'a, 'b> {
     instruction: Box<SetCollectionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -128,7 +128,24 @@ impl SetCollectionInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetCollection`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
+///   2. `[writable]` authority_pda
+///   3. `[signer]` payer
+///   4. `[]` collection_mint
+///   5. `[]` collection_metadata
+///   6. `[writable]` collection_authority_record
+///   7. `[writable, signer]` new_collection_update_authority
+///   8. `[]` new_collection_metadata
+///   9. `[]` new_collection_mint
+///   10. `[]` new_collection_master_edition
+///   11. `[writable]` new_collection_authority_record
+///   12. `[optional]` token_metadata_program (default to `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`)
+///   13. `[optional]` system_program (default to `11111111111111111111111111111111`)
 #[derive(Default)]
 pub struct SetCollectionBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -531,7 +548,24 @@ impl<'a, 'b> SetCollectionCpi<'a, 'b> {
     }
 }
 
-/// `set_collection` CPI instruction builder.
+/// Instruction builder for `SetCollection` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
+///   2. `[writable]` authority_pda
+///   3. `[signer]` payer
+///   4. `[]` collection_mint
+///   5. `[]` collection_metadata
+///   6. `[writable]` collection_authority_record
+///   7. `[writable, signer]` new_collection_update_authority
+///   8. `[]` new_collection_metadata
+///   9. `[]` new_collection_mint
+///   10. `[]` new_collection_master_edition
+///   11. `[writable]` new_collection_authority_record
+///   12. `[optional]` token_metadata_program
+///   13. `[optional]` system_program
 pub struct SetCollectionCpiBuilder<'a, 'b> {
     instruction: Box<SetCollectionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -90,7 +90,14 @@ pub struct SetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetCollectionSize`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[]` collection_mint
+///   3. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct SetCollectionSizeBuilder {
     collection_metadata: Option<solana_program::pubkey::Pubkey>,
@@ -329,7 +336,14 @@ impl<'a, 'b> SetCollectionSizeCpi<'a, 'b> {
     }
 }
 
-/// `set_collection_size` CPI instruction builder.
+/// Instruction builder for `SetCollectionSize` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` collection_metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[]` collection_mint
+///   3. `[optional]` collection_authority_record
 pub struct SetCollectionSizeCpiBuilder<'a, 'b> {
     instruction: Box<SetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -63,7 +63,13 @@ impl SetMintAuthorityInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetMintAuthority`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
+///   2. `[signer]` mint_authority
 #[derive(Default)]
 pub struct SetMintAuthorityBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -231,7 +237,13 @@ impl<'a, 'b> SetMintAuthorityCpi<'a, 'b> {
     }
 }
 
-/// `set_mint_authority` CPI instruction builder.
+/// Instruction builder for `SetMintAuthority` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
+///   2. `[signer]` mint_authority
 pub struct SetMintAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<SetMintAuthorityCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -73,7 +73,14 @@ impl SetTokenStandardInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `SetTokenStandard`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` update_authority
+///   2. `[]` mint
+///   3. `[optional]` edition
 #[derive(Default)]
 pub struct SetTokenStandardBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -276,7 +283,14 @@ impl<'a, 'b> SetTokenStandardCpi<'a, 'b> {
     }
 }
 
-/// `set_token_standard` CPI instruction builder.
+/// Instruction builder for `SetTokenStandard` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` update_authority
+///   2. `[]` mint
+///   3. `[optional]` edition
 pub struct SetTokenStandardCpiBuilder<'a, 'b> {
     instruction: Box<SetTokenStandardCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -56,7 +56,12 @@ impl SignMetadataInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `SignMetadata`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` creator
 #[derive(Default)]
 pub struct SignMetadataBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -210,7 +215,12 @@ impl<'a, 'b> SignMetadataCpi<'a, 'b> {
     }
 }
 
-/// `sign_metadata` CPI instruction builder.
+/// Instruction builder for `SignMetadata` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` creator
 pub struct SignMetadataCpiBuilder<'a, 'b> {
     instruction: Box<SignMetadataCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -75,7 +75,15 @@ impl ThawDelegatedAccountInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `ThawDelegatedAccount`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` delegate
+///   1. `[writable]` token_account
+///   2. `[]` edition
+///   3. `[]` mint
+///   4. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 #[derive(Default)]
 pub struct ThawDelegatedAccountBuilder {
     delegate: Option<solana_program::pubkey::Pubkey>,
@@ -288,7 +296,15 @@ impl<'a, 'b> ThawDelegatedAccountCpi<'a, 'b> {
     }
 }
 
-/// `thaw_delegated_account` CPI instruction builder.
+/// Instruction builder for `ThawDelegatedAccount` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` delegate
+///   1. `[writable]` token_account
+///   2. `[]` edition
+///   3. `[]` mint
+///   4. `[optional]` token_program
 pub struct ThawDelegatedAccountCpiBuilder<'a, 'b> {
     instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -304,7 +304,7 @@ impl<'a, 'b> ThawDelegatedAccountCpi<'a, 'b> {
 ///   1. `[writable]` token_account
 ///   2. `[]` edition
 ///   3. `[]` mint
-///   4. `[optional]` token_program
+///   4. `[]` token_program
 pub struct ThawDelegatedAccountCpiBuilder<'a, 'b> {
     instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -173,7 +173,25 @@ pub struct TransferInstructionArgs {
     pub transfer_args: TransferArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Transfer`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` authority
+///   1. `[writable, optional]` delegate_record
+///   2. `[writable]` token
+///   3. `[]` token_owner
+///   4. `[writable]` destination
+///   5. `[]` destination_owner
+///   6. `[]` mint
+///   7. `[writable]` metadata
+///   8. `[optional]` master_edition
+///   9. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   10. `[optional]` spl_ata_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
+///   11. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   12. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   13. `[optional]` authorization_rules_program
+///   14. `[optional]` authorization_rules
 #[derive(Default)]
 pub struct TransferBuilder {
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -657,7 +675,25 @@ impl<'a, 'b> TransferCpi<'a, 'b> {
     }
 }
 
-/// `transfer` CPI instruction builder.
+/// Instruction builder for `Transfer` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` authority
+///   1. `[writable, optional]` delegate_record
+///   2. `[writable]` token
+///   3. `[]` token_owner
+///   4. `[writable]` destination
+///   5. `[]` destination_owner
+///   6. `[]` mint
+///   7. `[writable]` metadata
+///   8. `[optional]` master_edition
+///   9. `[optional]` spl_token_program
+///   10. `[optional]` spl_ata_program
+///   11. `[optional]` system_program
+///   12. `[optional]` sysvar_instructions
+///   13. `[optional]` authorization_rules_program
+///   14. `[optional]` authorization_rules
 pub struct TransferCpiBuilder<'a, 'b> {
     instruction: Box<TransferCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -688,10 +688,10 @@ impl<'a, 'b> TransferCpi<'a, 'b> {
 ///   6. `[]` mint
 ///   7. `[writable]` metadata
 ///   8. `[optional]` master_edition
-///   9. `[optional]` spl_token_program
-///   10. `[optional]` spl_ata_program
-///   11. `[optional]` system_program
-///   12. `[optional]` sysvar_instructions
+///   9. `[]` spl_token_program
+///   10. `[]` spl_ata_program
+///   11. `[]` system_program
+///   12. `[]` sysvar_instructions
 ///   13. `[optional]` authorization_rules_program
 ///   14. `[optional]` authorization_rules
 pub struct TransferCpiBuilder<'a, 'b> {

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -141,7 +141,23 @@ pub struct TransferOutOfEscrowInstructionArgs {
     pub amount: u64,
 }
 
-/// Instruction builder.
+/// Instruction builder for `TransferOutOfEscrow`.
+///
+/// ### Accounts:
+///
+///   0. `[]` escrow
+///   1. `[writable]` metadata
+///   2. `[writable, signer]` payer
+///   3. `[]` attribute_mint
+///   4. `[writable]` attribute_src
+///   5. `[writable]` attribute_dst
+///   6. `[]` escrow_mint
+///   7. `[]` escrow_account
+///   8. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   9. `[optional]` ata_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
+///   10. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   11. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   12. `[signer, optional]` authority
 #[derive(Default)]
 pub struct TransferOutOfEscrowBuilder {
     escrow: Option<solana_program::pubkey::Pubkey>,
@@ -535,7 +551,23 @@ impl<'a, 'b> TransferOutOfEscrowCpi<'a, 'b> {
     }
 }
 
-/// `transfer_out_of_escrow` CPI instruction builder.
+/// Instruction builder for `TransferOutOfEscrow` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[]` escrow
+///   1. `[writable]` metadata
+///   2. `[writable, signer]` payer
+///   3. `[]` attribute_mint
+///   4. `[writable]` attribute_src
+///   5. `[writable]` attribute_dst
+///   6. `[]` escrow_mint
+///   7. `[]` escrow_account
+///   8. `[optional]` system_program
+///   9. `[optional]` ata_program
+///   10. `[optional]` token_program
+///   11. `[optional]` sysvar_instructions
+///   12. `[signer, optional]` authority
 pub struct TransferOutOfEscrowCpiBuilder<'a, 'b> {
     instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -563,10 +563,10 @@ impl<'a, 'b> TransferOutOfEscrowCpi<'a, 'b> {
 ///   5. `[writable]` attribute_dst
 ///   6. `[]` escrow_mint
 ///   7. `[]` escrow_account
-///   8. `[optional]` system_program
-///   9. `[optional]` ata_program
-///   10. `[optional]` token_program
-///   11. `[optional]` sysvar_instructions
+///   8. `[]` system_program
+///   9. `[]` ata_program
+///   10. `[]` token_program
+///   11. `[]` sysvar_instructions
 ///   12. `[signer, optional]` authority
 pub struct TransferOutOfEscrowCpiBuilder<'a, 'b> {
     instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a, 'b>>,

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -89,7 +89,16 @@ impl UnverifyCollectionInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `UnverifyCollection`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[]` collection_mint
+///   3. `[]` collection
+///   4. `[]` collection_master_edition_account
+///   5. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct UnverifyCollectionBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -343,7 +352,16 @@ impl<'a, 'b> UnverifyCollectionCpi<'a, 'b> {
     }
 }
 
-/// `unverify_collection` CPI instruction builder.
+/// Instruction builder for `UnverifyCollection` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[]` collection_mint
+///   3. `[]` collection
+///   4. `[]` collection_master_edition_account
+///   5. `[optional]` collection_authority_record
 pub struct UnverifyCollectionCpiBuilder<'a, 'b> {
     instruction: Box<UnverifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -94,7 +94,17 @@ impl UnverifySizedCollectionItemInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `UnverifySizedCollectionItem`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` collection_mint
+///   4. `[writable]` collection
+///   5. `[]` collection_master_edition_account
+///   6. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct UnverifySizedCollectionItemBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -366,7 +376,17 @@ impl<'a, 'b> UnverifySizedCollectionItemCpi<'a, 'b> {
     }
 }
 
-/// `unverify_sized_collection_item` CPI instruction builder.
+/// Instruction builder for `UnverifySizedCollectionItem` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` collection_mint
+///   4. `[writable]` collection
+///   5. `[]` collection_master_edition_account
+///   6. `[optional]` collection_authority_record
 pub struct UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
     instruction: Box<UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -72,7 +72,12 @@ pub struct UpdateCandyMachineInstructionArgs {
     pub data: CandyMachineData,
 }
 
-/// Instruction builder.
+/// Instruction builder for `UpdateCandyMachine`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
 #[derive(Default)]
 pub struct UpdateCandyMachineBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -240,7 +245,12 @@ impl<'a, 'b> UpdateCandyMachineCpi<'a, 'b> {
     }
 }
 
-/// `update_candy_machine` CPI instruction builder.
+/// Instruction builder for `UpdateCandyMachine` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[signer]` authority
 pub struct UpdateCandyMachineCpiBuilder<'a, 'b> {
     instruction: Box<UpdateCandyMachineCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -84,7 +84,12 @@ pub struct UpdateMetadataAccountInstructionDataData {
     pub creators: Option<Vec<Creator>>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `UpdateMetadataAccount`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` update_authority
 #[derive(Default)]
 pub struct UpdateMetadataAccountBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -275,7 +280,12 @@ impl<'a, 'b> UpdateMetadataAccountCpi<'a, 'b> {
     }
 }
 
-/// `update_metadata_account` CPI instruction builder.
+/// Instruction builder for `UpdateMetadataAccount` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` update_authority
 pub struct UpdateMetadataAccountCpiBuilder<'a, 'b> {
     instruction: Box<UpdateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -75,7 +75,12 @@ pub struct UpdateMetadataAccountV2InstructionArgs {
     pub is_mutable: Option<bool>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `UpdateMetadataAccountV2`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` update_authority
 #[derive(Default)]
 pub struct UpdateMetadataAccountV2Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -274,7 +279,12 @@ impl<'a, 'b> UpdateMetadataAccountV2Cpi<'a, 'b> {
     }
 }
 
-/// `update_metadata_account_v2` CPI instruction builder.
+/// Instruction builder for `UpdateMetadataAccountV2` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` update_authority
 pub struct UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
     instruction: Box<UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -62,7 +62,13 @@ impl UpdatePrimarySaleHappenedViaTokenInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `UpdatePrimarySaleHappenedViaToken`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` owner
+///   2. `[]` token
 #[derive(Default)]
 pub struct UpdatePrimarySaleHappenedViaTokenBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -236,7 +242,13 @@ impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpi<'a, 'b> {
     }
 }
 
-/// `update_primary_sale_happened_via_token` CPI instruction builder.
+/// Instruction builder for `UpdatePrimarySaleHappenedViaToken` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` owner
+///   2. `[]` token
 pub struct UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -184,7 +184,20 @@ pub struct UpdateV1InstructionDataData {
     pub creators: Option<Vec<Creator>>,
 }
 
-/// Instruction builder.
+/// Instruction builder for `UpdateV1`.
+///
+/// ### Accounts:
+///
+///   0. `[signer]` authority
+///   1. `[writable]` metadata
+///   2. `[writable, optional]` master_edition
+///   3. `[]` mint
+///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   5. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
+///   6. `[optional]` token
+///   7. `[optional]` delegate_record
+///   8. `[optional]` authorization_rules_program
+///   9. `[optional]` authorization_rules
 #[derive(Default)]
 pub struct UpdateV1Builder {
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -658,7 +671,20 @@ impl<'a, 'b> UpdateV1Cpi<'a, 'b> {
     }
 }
 
-/// `update_v1` CPI instruction builder.
+/// Instruction builder for `UpdateV1` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[signer]` authority
+///   1. `[writable]` metadata
+///   2. `[writable, optional]` master_edition
+///   3. `[]` mint
+///   4. `[optional]` system_program
+///   5. `[optional]` sysvar_instructions
+///   6. `[optional]` token
+///   7. `[optional]` delegate_record
+///   8. `[optional]` authorization_rules_program
+///   9. `[optional]` authorization_rules
 pub struct UpdateV1CpiBuilder<'a, 'b> {
     instruction: Box<UpdateV1CpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -679,8 +679,8 @@ impl<'a, 'b> UpdateV1Cpi<'a, 'b> {
 ///   1. `[writable]` metadata
 ///   2. `[writable, optional]` master_edition
 ///   3. `[]` mint
-///   4. `[optional]` system_program
-///   5. `[optional]` sysvar_instructions
+///   4. `[]` system_program
+///   5. `[]` sysvar_instructions
 ///   6. `[optional]` token
 ///   7. `[optional]` delegate_record
 ///   8. `[optional]` authorization_rules_program

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -142,7 +142,21 @@ pub struct UseAssetInstructionArgs {
     pub use_asset_args: UseAssetArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `UseAsset`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable]` token_account
+///   2. `[writable]` mint
+///   3. `[writable, signer]` use_authority
+///   4. `[]` owner
+///   5. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   6. `[optional]` ata_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
+///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   8. `[writable, optional]` use_authority_record
+///   9. `[optional]` authorization_rules
+///   10. `[optional]` authorization_rules_program
 #[derive(Default)]
 pub struct UseAssetBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -527,7 +541,21 @@ impl<'a, 'b> UseAssetCpi<'a, 'b> {
     }
 }
 
-/// `use_asset` CPI instruction builder.
+/// Instruction builder for `UseAsset` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable]` token_account
+///   2. `[writable]` mint
+///   3. `[writable, signer]` use_authority
+///   4. `[]` owner
+///   5. `[optional]` spl_token_program
+///   6. `[optional]` ata_program
+///   7. `[optional]` system_program
+///   8. `[writable, optional]` use_authority_record
+///   9. `[optional]` authorization_rules
+///   10. `[optional]` authorization_rules_program
 pub struct UseAssetCpiBuilder<'a, 'b> {
     instruction: Box<UseAssetCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -550,9 +550,9 @@ impl<'a, 'b> UseAssetCpi<'a, 'b> {
 ///   2. `[writable]` mint
 ///   3. `[writable, signer]` use_authority
 ///   4. `[]` owner
-///   5. `[optional]` spl_token_program
-///   6. `[optional]` ata_program
-///   7. `[optional]` system_program
+///   5. `[]` spl_token_program
+///   6. `[]` ata_program
+///   7. `[]` system_program
 ///   8. `[writable, optional]` use_authority_record
 ///   9. `[optional]` authorization_rules
 ///   10. `[optional]` authorization_rules_program

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -132,7 +132,21 @@ pub struct UtilizeInstructionArgs {
     pub number_of_uses: u64,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Utilize`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable]` token_account
+///   2. `[writable]` mint
+///   3. `[writable, signer]` use_authority
+///   4. `[]` owner
+///   5. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
+///   6. `[optional]` ata_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
+///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
+///   9. `[writable, optional]` use_authority_record
+///   10. `[optional]` burner
 #[derive(Default)]
 pub struct UtilizeBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -501,7 +515,21 @@ impl<'a, 'b> UtilizeCpi<'a, 'b> {
     }
 }
 
-/// `utilize` CPI instruction builder.
+/// Instruction builder for `Utilize` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable]` token_account
+///   2. `[writable]` mint
+///   3. `[writable, signer]` use_authority
+///   4. `[]` owner
+///   5. `[optional]` token_program
+///   6. `[optional]` ata_program
+///   7. `[optional]` system_program
+///   8. `[optional]` rent
+///   9. `[writable, optional]` use_authority_record
+///   10. `[optional]` burner
 pub struct UtilizeCpiBuilder<'a, 'b> {
     instruction: Box<UtilizeCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -524,10 +524,10 @@ impl<'a, 'b> UtilizeCpi<'a, 'b> {
 ///   2. `[writable]` mint
 ///   3. `[writable, signer]` use_authority
 ///   4. `[]` owner
-///   5. `[optional]` token_program
-///   6. `[optional]` ata_program
-///   7. `[optional]` system_program
-///   8. `[optional]` rent
+///   5. `[]` token_program
+///   6. `[]` ata_program
+///   7. `[]` system_program
+///   8. `[]` rent
 ///   9. `[writable, optional]` use_authority_record
 ///   10. `[optional]` burner
 pub struct UtilizeCpiBuilder<'a, 'b> {

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -650,7 +650,7 @@ impl<'a, 'b> ValidateCpi<'a, 'b> {
 ///
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` rule_set
-///   2. `[optional]` system_program
+///   2. `[]` system_program
 ///   3. `[signer, optional]` opt_rule_signer1
 ///   4. `[signer, optional]` opt_rule_signer2
 ///   5. `[signer, optional]` opt_rule_signer3

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -157,7 +157,23 @@ pub struct ValidateInstructionArgs {
     pub payload: Payload,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Validate`.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` payer
+///   1. `[writable]` rule_set
+///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
+///   3. `[signer, optional]` opt_rule_signer1
+///   4. `[signer, optional]` opt_rule_signer2
+///   5. `[signer, optional]` opt_rule_signer3
+///   6. `[signer, optional]` opt_rule_signer4
+///   7. `[signer, optional]` opt_rule_signer5
+///   8. `[optional]` opt_rule_nonsigner1
+///   9. `[optional]` opt_rule_nonsigner2
+///   10. `[optional]` opt_rule_nonsigner3
+///   11. `[optional]` opt_rule_nonsigner4
+///   12. `[optional]` opt_rule_nonsigner5
 #[derive(Default)]
 pub struct ValidateBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -628,7 +644,23 @@ impl<'a, 'b> ValidateCpi<'a, 'b> {
     }
 }
 
-/// `validate` CPI instruction builder.
+/// Instruction builder for `Validate` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable, signer]` payer
+///   1. `[writable]` rule_set
+///   2. `[optional]` system_program
+///   3. `[signer, optional]` opt_rule_signer1
+///   4. `[signer, optional]` opt_rule_signer2
+///   5. `[signer, optional]` opt_rule_signer3
+///   6. `[signer, optional]` opt_rule_signer4
+///   7. `[signer, optional]` opt_rule_signer5
+///   8. `[optional]` opt_rule_nonsigner1
+///   9. `[optional]` opt_rule_nonsigner2
+///   10. `[optional]` opt_rule_nonsigner3
+///   11. `[optional]` opt_rule_nonsigner4
+///   12. `[optional]` opt_rule_nonsigner5
 pub struct ValidateCpiBuilder<'a, 'b> {
     instruction: Box<ValidateCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -100,7 +100,15 @@ pub struct VerifyInstructionArgs {
     pub verify_args: VerifyArgs,
 }
 
-/// Instruction builder.
+/// Instruction builder for `Verify`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[optional]` authorization_rules
+///   4. `[optional]` authorization_rules_program
 #[derive(Default)]
 pub struct VerifyBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -354,7 +362,15 @@ impl<'a, 'b> VerifyCpi<'a, 'b> {
     }
 }
 
-/// `verify` CPI instruction builder.
+/// Instruction builder for `Verify` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[optional]` authorization_rules
+///   4. `[optional]` authorization_rules_program
 pub struct VerifyCpiBuilder<'a, 'b> {
     instruction: Box<VerifyCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -79,7 +79,16 @@ impl VerifyCollectionInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `VerifyCollection`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` collection_mint
+///   4. `[]` collection
+///   5. `[]` collection_master_edition_account
 #[derive(Default)]
 pub struct VerifyCollectionBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -318,7 +327,16 @@ impl<'a, 'b> VerifyCollectionCpi<'a, 'b> {
     }
 }
 
-/// `verify_collection` CPI instruction builder.
+/// Instruction builder for `VerifyCollection` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[writable, signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` collection_mint
+///   4. `[]` collection
+///   5. `[]` collection_master_edition_account
 pub struct VerifyCollectionCpiBuilder<'a, 'b> {
     instruction: Box<VerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -94,7 +94,17 @@ impl VerifySizedCollectionItemInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `VerifySizedCollectionItem`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` collection_mint
+///   4. `[writable]` collection
+///   5. `[]` collection_master_edition_account
+///   6. `[optional]` collection_authority_record
 #[derive(Default)]
 pub struct VerifySizedCollectionItemBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -366,7 +376,17 @@ impl<'a, 'b> VerifySizedCollectionItemCpi<'a, 'b> {
     }
 }
 
-/// `verify_sized_collection_item` CPI instruction builder.
+/// Instruction builder for `VerifySizedCollectionItem` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` metadata
+///   1. `[signer]` collection_authority
+///   2. `[writable, signer]` payer
+///   3. `[]` collection_mint
+///   4. `[writable]` collection
+///   5. `[]` collection_master_edition_account
+///   6. `[optional]` collection_authority_record
 pub struct VerifySizedCollectionItemCpiBuilder<'a, 'b> {
     instruction: Box<VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -57,7 +57,12 @@ impl WithdrawInstructionData {
     }
 }
 
-/// Instruction builder.
+/// Instruction builder for `Withdraw`.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[writable, signer]` authority
 #[derive(Default)]
 pub struct WithdrawBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
@@ -208,7 +213,12 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
     }
 }
 
-/// `withdraw` CPI instruction builder.
+/// Instruction builder for `Withdraw` via CPI.
+///
+/// ### Accounts:
+///
+///   0. `[writable]` candy_machine
+///   1. `[writable, signer]` authority
 pub struct WithdrawCpiBuilder<'a, 'b> {
     instruction: Box<WithdrawCpiBuilderInstruction<'a, 'b>>,
 }


### PR DESCRIPTION
This PR adds the account list to builders docs. This facilitates the discovery of the accounts that are required to be set.

For instruction builders, it also includes the default values:
```
/// Instruction builder for `UpdateV1`.
///
/// ### Accounts:
///
///   0. `[signer]` authority
///   1. `[writable]` metadata
///   2. `[writable, optional]` master_edition
///   3. `[]` mint
///   4. `[optional]` system_program (default to `11111111111111111111111111111111`)
///   5. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
///   6. `[optional]` token
///   7. `[optional]` delegate_record
///   8. `[optional]` authorization_rules_program
///   9. `[optional]` authorization_rules
```

CPI builders do not include default values, since the `AccountInfo` object is always required:
```
/// Instruction builder for `UpdateV1` via CPI.
///
/// ### Accounts:
///
///   0. `[signer]` authority
///   1. `[writable]` metadata
///   2. `[writable, optional]` master_edition
///   3. `[]` mint
///   4. `[]` system_program
///   5. `[]` sysvar_instructions
///   6. `[optional]` token
///   7. `[optional]` delegate_record
///   8. `[optional]` authorization_rules_program
///   9. `[optional]` authorization_rules
```