### PR TITLE
Generate CPI accounts only when needed

### DIFF
--- a/.changeset/twelve-cougars-smash.md
+++ b/.changeset/twelve-cougars-smash.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Does not generate lifetime for empty account struct in Rust client

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -1,23 +1,25 @@
-/// `{{ instruction.name | snakeCase }}` CPI accounts.
-pub struct {{ instruction.name | pascalCase }}CpiAccounts{{ '<\'a, \'b>' if instruction.accounts.length > 0 }} {
-  {% for account in instruction.accounts %}
-    {% if account.docs.length > 0 %}
-      {{ macros.docblock(account.docs) }}
-    {% endif %}
+{% if instruction.accounts.length > 0 %}
+  /// `{{ instruction.name | snakeCase }}` CPI accounts.
+  pub struct {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b> {
+    {% for account in instruction.accounts %}
+      {% if account.docs.length > 0 %}
+        {{ macros.docblock(account.docs) }}
+      {% endif %}
 
-    {% if account.isSigner === 'either' %}
-      {% set type = '(&\'b solana_program::account_info::AccountInfo<\'a>, bool)' %}
-    {% else %}
-      {% set type = '&\'b solana_program::account_info::AccountInfo<\'a>' %}
-    {% endif %}
+      {% if account.isSigner === 'either' %}
+        {% set type = '(&\'b solana_program::account_info::AccountInfo<\'a>, bool)' %}
+      {% else %}
+        {% set type = '&\'b solana_program::account_info::AccountInfo<\'a>' %}
+      {% endif %}
 
-    {% if account.isOptional %}
-      pub {{ account.name | snakeCase }}: Option<{{ type }}>,
-    {% else %}
-      pub {{ account.name | snakeCase }}: {{ type }},
-    {% endif %}
-  {% endfor %}
-}
+      {% if account.isOptional %}
+        pub {{ account.name | snakeCase }}: Option<{{ type }}>,
+      {% else %}
+        pub {{ account.name | snakeCase }}: {{ type }},
+      {% endif %}
+    {% endfor %}
+  }
+{% endif %}
 
 /// `{{ instruction.name | snakeCase }}` CPI instruction.
 pub struct {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
@@ -49,7 +51,9 @@ pub struct {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
 impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
   pub fn new(
     program: &'b solana_program::account_info::AccountInfo<'a>,
-    accounts: {{ instruction.name | pascalCase }}CpiAccounts{{ '<\'a, \'b>' if instruction.accounts.length > 0 }},
+    {% if instruction.accounts.length > 0 %}
+      accounts: {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b>,
+    {% endif %}
     {% if hasArgs %}
       args: {{ instruction.name | pascalCase }}InstructionArgs,
     {% endif %}

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -49,7 +49,7 @@ pub struct {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
 impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
   pub fn new(
     program: &'b solana_program::account_info::AccountInfo<'a>,
-    accounts: {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b>,
+    accounts: {{ instruction.name | pascalCase }}CpiAccounts{{ '<\'a, \'b>' if instruction.accounts.length > 0 }},
     {% if hasArgs %}
       args: {{ instruction.name | pascalCase }}InstructionArgs,
     {% endif %}

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -1,5 +1,5 @@
 /// `{{ instruction.name | snakeCase }}` CPI accounts.
-pub struct {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b> {
+pub struct {{ instruction.name | pascalCase }}CpiAccounts{{ '<\'a, \'b>' if instruction.accounts.length > 0 }} {
   {% for account in instruction.accounts %}
     {% if account.docs.length > 0 %}
       {{ macros.docblock(account.docs) }}


### PR DESCRIPTION
This PR changes the Rust renderer to only generate the CPI accounts when the instruction expects accounts – i.e., the CPI account struct is not generated for instructions that to not take accounts.