### PR TITLE
Add constant seeds

### DIFF
--- a/.changeset/sixty-falcons-beg.md
+++ b/.changeset/sixty-falcons-beg.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add constant seeds in Rust client

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, v0.16 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, v0.16 ]
 
 jobs:
   lint_fix:

--- a/src/renderers/rust/GetRustRenderMapVisitor.ts
+++ b/src/renderers/rust/GetRustRenderMapVisitor.ts
@@ -165,6 +165,9 @@ export class GetRustRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
     });
     const hasVariableSeeds =
       account.seeds.filter((seed) => seed.kind === 'variable').length > 0;
+    const constantSeeds = account.seeds.filter(
+      (seed) => seed.kind === 'constant'
+    ).length;
 
     const { imports } = typeManifest;
 
@@ -183,6 +186,7 @@ export class GetRustRenderMapVisitor extends BaseThrowVisitor<RenderMap> {
         typeManifest,
         seeds,
         hasVariableSeeds,
+        constantSeeds,
       })
     );
   }

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -16,6 +16,47 @@ impl {{ account.name | pascalCase }} {
   {% if account.size != null %}
     pub const LEN: usize = {{ account.size }};
   {% endif %}
+  {% if constantSeeds > 0 %}
+    {% set index = 0 %}
+    /// Prefix values used to generate a PDA for this account.
+    ///
+    /// Values are positional and appear in the following order:
+    ///
+    {% for seed in seeds %}
+      {% if seed.kind === 'programId' %}
+        ///   {{ loop.index0 }}. `crate::{{ program.name | snakeCase | upper }}_ID`
+      {% elif seed.kind === 'constant' %}
+        ///   {{ loop.index0 }}. `{{ account.name | pascalCase }}::PREFIX{{ '.' + index if constantSeeds > 1 }}`
+        {% set index = index + 1 %}
+      {% else %}
+        ///   {{ loop.index0 }}. {{ seed.name | snakeCase }} (`{{ seed.typeManifest.type }}`)
+      {% endif %}
+    {% endfor %}
+    {% if constantSeeds > 1 %}
+      pub const PREFIX: (
+      {% for seed in seeds %}
+        {% if seed.kind === 'constant' %}
+          &'static [u8],
+        {% endif %}
+      {% endfor %}
+      ) = (
+      {% for seed in seeds %}
+        {% if seed.kind === 'constant' %}
+          {{ seed.value.render }}.as_bytes(),
+        {% endif %}
+      {% endfor %}
+      );
+    {% endif %}
+    {% if constantSeeds === 1 %}
+      pub const PREFIX: &'static [u8] =
+      {% for seed in seeds %}
+        {% if seed.kind === 'constant' %}
+          {{ seed.value.render }}.as_bytes()
+        {% endif %}
+      {% endfor %}
+      ;
+    {% endif %}
+  {% endif %}
 
   {% if seeds.length > 0 %}
     pub fn create_pda(

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -20,6 +20,14 @@ pub struct DelegateRecord {
 
 impl DelegateRecord {
     pub const LEN: usize = 282;
+    /// Prefix values used to generate a PDA for this account.
+    ///
+    /// Values are positional and appear in the following order:
+    ///
+    ///   0. `DelegateRecord::PREFIX`
+    ///   1. `crate::MPL_TOKEN_METADATA_ID`
+    ///   2. role (`DelegateRole`)
+    pub const PREFIX: &'static [u8] = "delegate_record".as_bytes();
 
     pub fn create_pda(
         role: DelegateRole,

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -13,7 +13,7 @@ use borsh::BorshSerialize;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EditionMarker {
     pub key: TmKey,
-    #[cfg_attr(feature = "serde", serde_with::serde_as(as = "serde_with::Bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]
     pub ledger: [u8; 200],
 }
 

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -21,6 +21,13 @@ pub struct FrequencyAccount {
 
 impl FrequencyAccount {
     pub const LEN: usize = 24;
+    /// Prefix values used to generate a PDA for this account.
+    ///
+    /// Values are positional and appear in the following order:
+    ///
+    ///   0. `FrequencyAccount::PREFIX`
+    ///   1. `crate::MPL_TOKEN_AUTH_RULES_ID`
+    pub const PREFIX: &'static [u8] = "frequency_pda".as_bytes();
 
     pub fn create_pda(
         bump: u8,

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -30,6 +30,15 @@ pub struct MasterEditionV1 {
 }
 
 impl MasterEditionV1 {
+    /// Prefix values used to generate a PDA for this account.
+    ///
+    /// Values are positional and appear in the following order:
+    ///
+    ///   0. `MasterEditionV1::PREFIX`
+    ///   1. `crate::MPL_TOKEN_METADATA_ID`
+    ///   2. delegate_role (`DelegateRole`)
+    pub const PREFIX: &'static [u8] = "metadata".as_bytes();
+
     pub fn create_pda(
         delegate_role: DelegateRole,
         bump: u8,

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -20,6 +20,16 @@ pub struct MasterEditionV2 {
 
 impl MasterEditionV2 {
     pub const LEN: usize = 282;
+    /// Prefix values used to generate a PDA for this account.
+    ///
+    /// Values are positional and appear in the following order:
+    ///
+    ///   0. `MasterEditionV2::PREFIX.0`
+    ///   1. `crate::MPL_TOKEN_METADATA_ID`
+    ///   2. mint (`Pubkey`)
+    ///   3. `MasterEditionV2::PREFIX.1`
+    pub const PREFIX: (&'static [u8], &'static [u8]) =
+        ("metadata".as_bytes(), "edition".as_bytes());
 
     pub fn create_pda(
         mint: Pubkey,

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -49,6 +49,14 @@ pub struct Metadata {
 
 impl Metadata {
     pub const LEN: usize = 679;
+    /// Prefix values used to generate a PDA for this account.
+    ///
+    /// Values are positional and appear in the following order:
+    ///
+    ///   0. `Metadata::PREFIX`
+    ///   1. `crate::MPL_TOKEN_METADATA_ID`
+    ///   2. mint (`Pubkey`)
+    pub const PREFIX: &'static [u8] = "metadata".as_bytes();
 
     pub fn create_pda(
         mint: Pubkey,

--- a/test/packages/rust/src/generated/types/hidden_settings.rs
+++ b/test/packages/rust/src/generated/types/hidden_settings.rs
@@ -17,6 +17,6 @@ pub struct HiddenSettings {
     /// Shared URI
     pub uri: String,
     /// Hash of the hidden settings file
-    #[cfg_attr(feature = "serde", serde_with::serde_as(as = "serde_with::Bytes"))]
+    #[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]
     pub hash: [u8; 64],
 }


### PR DESCRIPTION
This PR exposes the constant seeds used in PDA generation as a `PREFIX` field on account structs.