### PR TITLE
Fix byte seeds

### DIFF
--- a/.changeset/four-pots-heal.md
+++ b/.changeset/four-pots-heal.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Fix byte array as seeds on Rust client

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -68,6 +68,8 @@ impl {{ account.name | pascalCase }} {
               {{ seed.value.render }}.as_bytes(),
             {% elif seed.kind == 'variablePdaSeedNode' and seed.type.kind == 'publicKeyTypeNode' %}
               {{ seed.name | snakeCase }}.as_ref(),
+            {% elif seed.kind == 'variablePdaSeedNode' and seed.type.kind == 'bytesTypeNode' %}
+              &{{ seed.name | snakeCase }},
             {% else %}
               {{ seed.name | snakeCase }}.to_string().as_ref(),
             {% endif %}
@@ -98,6 +100,8 @@ impl {{ account.name | pascalCase }} {
               {{ seed.value.render }}.as_bytes(),
             {% elif seed.kind == 'variablePdaSeedNode' and seed.type.kind == 'publicKeyTypeNode' %}
               {{ seed.name | snakeCase }}.as_ref(),
+            {% elif seed.kind == 'variablePdaSeedNode' and seed.type.kind == 'bytesTypeNode' %}
+              &{{ seed.name | snakeCase }},
             {% else %}
               {{ seed.name | snakeCase }}.to_string().as_ref(),
             {% endif %}

--- a/test/renderers/rust/_setup.ts
+++ b/test/renderers/rust/_setup.ts
@@ -1,0 +1,18 @@
+import type { ExecutionContext } from 'ava';
+
+export function codeContains(
+  t: ExecutionContext,
+  actual: string,
+  expected: string[] | string | RegExp[] | RegExp
+) {
+  const expectedArray = Array.isArray(expected) ? expected : [expected];
+  expectedArray.forEach((e) => {
+    t.true(
+      typeof e === 'string' ? actual.includes(e) : e.test(actual),
+      `The following expected code is missing from the actual content:\n` +
+        `${e}\n\n` +
+        `Actual content:\n` +
+        `${actual}`
+    );
+  });
+}

--- a/test/renderers/rust/accountsPage.test.ts
+++ b/test/renderers/rust/accountsPage.test.ts
@@ -1,0 +1,44 @@
+import test from 'ava';
+import {
+  accountNode,
+  bytesTypeNode,
+  fixedSizeNode,
+  pdaLinkNode,
+  pdaNode,
+  programNode,
+  variablePdaSeedNode,
+  visit,
+} from '../../../src';
+import { getRenderMapVisitor } from '../../../src/renderers/rust/getRenderMapVisitor';
+import { codeContains } from './_setup';
+
+test('it renders a byte array seed used on an account', (t) => {
+  // Given the following program with 1 account and 1 pda with a byte array as seeds.
+  const node = programNode({
+    name: 'splToken',
+    publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    accounts: [
+      accountNode({
+        name: 'testAccount',
+        discriminators: [],
+        pda: pdaLinkNode('testPda'),
+      }),
+    ],
+    pdas: [
+      // Byte array seeds.
+      pdaNode('testPda', [
+        variablePdaSeedNode('byteArraySeed', bytesTypeNode(fixedSizeNode(32))),
+      ]),
+    ],
+  });
+
+  // When we render it.
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Then we expect the following identifier and reference to the byte array
+  // as a parameters to be rendered.
+  codeContains(t, renderMap.get('accounts/test_account.rs'), [
+    `byte_array_seed: [u8; 32],`,
+    `&byte_array_seed,`,
+  ]);
+});


### PR DESCRIPTION
This PR fixes the seeds generation for PDA helpers when byte arrays are used on the Rust client.