### PR TITLE
Update web3.js and use new codec type inferrences

### DIFF
--- a/.changeset/funny-chicken-look.md
+++ b/.changeset/funny-chicken-look.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Update web3.js and use new codec type inferrences

--- a/src/renderers/js-experimental/fragments/typeDecoder.njk
+++ b/src/renderers/js-experimental/fragments/typeDecoder.njk
@@ -1,6 +1,6 @@
 {% import "templates/macros.njk" as macros %}
 
 {{ macros.docblock(docs) }}
-export function {{ decoderFunction }}() {
-  return {{ manifest.decoder.render }} satisfies Decoder<{{ strictName }}>;
+export function {{ decoderFunction }}(): Decoder<{{ strictName }}> {
+  return {{ manifest.decoder.render }};
 }

--- a/src/renderers/js-experimental/fragments/typeEncoder.njk
+++ b/src/renderers/js-experimental/fragments/typeEncoder.njk
@@ -1,6 +1,6 @@
 {% import "templates/macros.njk" as macros %}
 
 {{ macros.docblock(docs) }}
-export function {{ encoderFunction }}() {
-  return {{ manifest.encoder.render }} satisfies Encoder<{{ looseName }}>;
+export function {{ encoderFunction }}(): Encoder<{{ looseName }}> {
+  return {{ manifest.encoder.render }};
 }

--- a/test/packages/js-experimental/package.json
+++ b/test/packages/js-experimental/package.json
@@ -11,20 +11,20 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@solana/accounts": "2.0.0-experimental.5e737f9",
-    "@solana/addresses": "2.0.0-experimental.5e737f9",
-    "@solana/codecs-core": "2.0.0-experimental.5e737f9",
-    "@solana/codecs-data-structures": "2.0.0-experimental.5e737f9",
-    "@solana/codecs-numbers": "2.0.0-experimental.5e737f9",
-    "@solana/codecs-strings": "2.0.0-experimental.5e737f9",
-    "@solana/instructions": "2.0.0-experimental.5e737f9",
-    "@solana/keys": "2.0.0-experimental.5e737f9",
-    "@solana/programs": "2.0.0-experimental.5e737f9",
-    "@solana/options": "2.0.0-experimental.5e737f9",
-    "@solana/signers": "2.0.0-experimental.5e737f9",
-    "@solana/transactions": "2.0.0-experimental.5e737f9"
+    "@solana/accounts": "2.0.0-experimental.a7a613a",
+    "@solana/addresses": "2.0.0-experimental.a7a613a",
+    "@solana/codecs-core": "2.0.0-experimental.a7a613a",
+    "@solana/codecs-data-structures": "2.0.0-experimental.a7a613a",
+    "@solana/codecs-numbers": "2.0.0-experimental.a7a613a",
+    "@solana/codecs-strings": "2.0.0-experimental.a7a613a",
+    "@solana/instructions": "2.0.0-experimental.a7a613a",
+    "@solana/keys": "2.0.0-experimental.a7a613a",
+    "@solana/programs": "2.0.0-experimental.a7a613a",
+    "@solana/options": "2.0.0-experimental.a7a613a",
+    "@solana/signers": "2.0.0-experimental.a7a613a",
+    "@solana/transactions": "2.0.0-experimental.a7a613a"
   },
   "devDependencies": {
-    "typescript": "^4.9.4"
+    "typescript": "^5.3.3"
   }
 }

--- a/test/packages/js-experimental/pnpm-lock.yaml
+++ b/test/packages/js-experimental/pnpm-lock.yaml
@@ -6,193 +6,202 @@ settings:
 
 dependencies:
   '@solana/accounts':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.15.0)
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/addresses':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/codecs-core':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a
   '@solana/codecs-data-structures':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a
   '@solana/codecs-numbers':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a
   '@solana/codecs-strings':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/instructions':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a
   '@solana/keys':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/options':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a
   '@solana/programs':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a
   '@solana/signers':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/transactions':
-    specifier: 2.0.0-experimental.5e737f9
-    version: 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+    specifier: 2.0.0-experimental.a7a613a
+    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
 
 devDependencies:
   typescript:
-    specifier: ^4.9.4
-    version: 4.9.5
+    specifier: ^5.3.3
+    version: 5.3.3
 
 packages:
 
-  /@solana/accounts@2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.15.0):
-    resolution: {integrity: sha512-Pgi2LD7R+zj6TCHCRbqMR9sK4YKfDi1OAzrDuOAxmztw6nvplN2Kn1uwrDcFx5KV7YoS034G3WXo1bQTuPM1Nw==}
+  /@solana/accounts@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-fifvhOC49UmCqooNI5inAnkkVfLc2diQ/R3WDQSocJ8u9E3chDFg+SPmwXRNNk3Prp1MnbJhsNpRPbO+7A/ypA==}
     dependencies:
-      '@solana/addresses': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-strings': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/rpc-core': 2.0.0-experimental.5e737f9
-      '@solana/rpc-transport': 2.0.0-experimental.5e737f9(ws@8.15.0)
-      '@solana/rpc-types': 2.0.0-experimental.5e737f9
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-    dev: false
-
-  /@solana/addresses@2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-mb/CfAiU/IuTcr5zwQl9tUck6mO3vsd6KmTszuL7rKuVI1pC3m5/zNeyclaGvNfR0XGFLUCds/7Ro6S86ACZ1w==}
-    dependencies:
-      '@solana/assertions': 2.0.0-experimental.5e737f9
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-strings': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/addresses': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-strings': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/rpc-spec': 2.0.0-experimental.a7a613a
+      '@solana/rpc-types': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/assertions@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-zxtGw+CSbgMVyKZwbgfX/ZuHGEkxpQGT/MKe2dUO/PXAsKihLm+KdfbWXWjfxm7GMi/Onn4L1oGgIkPHg+v3Pw==}
-    dev: false
-
-  /@solana/codecs-core@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-rAkgDNVhz85u9JBpzfSWNemogK/wv0wACyN9gvjkkxiiZOdAwEMJJJN1ktBfktbgKrIUPBdT+yJxuDxMmi6Xkw==}
-    dev: false
-
-  /@solana/codecs-data-structures@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-IWgZNNYVDiYGVtuIA7Du+ynUGqeMETUkvzwn/w0JqTkkcYtHj96LeBlM7Wcouw6uq0fLlmCs2eEtTBIfA7JXDA==}
+  /@solana/addresses@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-W5lc7y9CQYwooshmZ6qr2T6Ymj6aVVEM0hlaQA6GVZ20PYCJOGSXg0mloNalG0Fp50J2ouE3Xhy5OoFjoYQgvQ==}
     dependencies:
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-numbers': 2.0.0-experimental.5e737f9
+      '@solana/assertions': 2.0.0-experimental.a7a613a
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-strings': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/codecs-numbers@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-CKwmZDQuu0qpeM7VrB9RKQkmEMPoy8YtWgqKsUVJXarVZyCrYL58OIden+5gJusGEEctN5xuQQzx6yCPTjRJIA==}
+  /@solana/assertions@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-V3/Q4hkdRkaSiJE3FG7ELhgFnKC1WfnrkIm+6gUfhrzh5Vihg494HXV+x7xEOJFw5m3EYmTDiYEevIr9d5qvMg==}
+    dev: false
+
+  /@solana/codecs-core@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-4C0GCWoIP8zvUd4kIs4QQnNupjh+GEXcoO+RAYRJ8nDlDW4DdEhb/W4weC+hoFaEjr0STEhCeH4yMWaKF3L6WQ==}
+    dev: false
+
+  /@solana/codecs-data-structures@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-K22h6+YA8hVZ5Nq+49nFUIUJgOMxYP9zEt69oQxh/OnETZF538uIOrsCFU7MzLCLCwUnoJynkBY4Oycm+4m7OQ==}
     dependencies:
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-numbers': 2.0.0-experimental.a7a613a
     dev: false
 
-  /@solana/codecs-strings@2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-ufs/JCAhykDZL+KrsPVW33MVRVxmMOhf6dg21d6WNq6RojC2fMcgQHd/6FzUvqvEjA5l84CI+zNZ8mWxet+GGw==}
+  /@solana/codecs-numbers@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-B1aNhPkoSRqMskHcgB/u0/tnAWfrp6dYHf9o36q+ppAoOZdbS9xz4rwzkt2FMUHaoSWPPa6/tHFQ0Vbge3VMRA==}
+    dependencies:
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+    dev: false
+
+  /@solana/codecs-strings@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-Tw9fqT8UzScpuP4bsDCiKb7DGXQ9BmsqvLJY7b1sjga9Vr0M3mA8BGHemz4WusHXb9AXJEN1Pc1NVYxd4rsH0w==}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
     dependencies:
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-numbers': 2.0.0-experimental.5e737f9
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-numbers': 2.0.0-experimental.a7a613a
       fastestsmallesttextencoderdecoder: 1.0.22
     dev: false
 
-  /@solana/functional@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-riNvo1ri86wiH5kmc1dSpbe1fnZIaiot5Lxb2LwB03yc8w8+6/YK4oKXWcfnSqDgQpp7OQ4R61iahT5i6Zuc5w==}
-    dev: false
-
-  /@solana/instructions@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-AZMIsGGfJf2GqCOY3THexTXyl+tWd4NtO0hQvY2nivVFCT5uqQiWmZK+vU13fGt2UYdRveHNMI3Rystttk6m4g==}
-    dev: false
-
-  /@solana/keys@2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-wN1Rrq+uU6r6HFEY8fMxq5da9F5O+IbxOfLVuyyEELa3TpCVAR8QjVwpWyqb/GyIE3/DQQw/3tSi+NQ/Fd2yMg==}
+  /@solana/errors@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-B7rkUWtAqXgsQwgOAH2qRyy/SOZ1T/3ThC4YezmWwbjxNHqx7+kekoCRhyshkw5AdhV7U4kQJSACQq/j3Cy1WA==}
+    hasBin: true
     dependencies:
-      '@solana/assertions': 2.0.0-experimental.5e737f9
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-strings': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+      chalk: 5.3.0
+      commander: 11.1.0
+    dev: false
+
+  /@solana/functional@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-OkaYVw6O5vNzOjEut0E44mxF1yS6BMXCnUcZuKy9nvuHNeUFZ6BjFJhMQXOGhhs5qNzI9m+JHnrb7z3J0ZPrBw==}
+    dev: false
+
+  /@solana/instructions@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-UJSlElg/w+pTYySxmane6RNP5Ghe52SJDy0gsEC40SkusdGtJbwlusNfGVZVFFGf14n+urWKyR+2gcdaj11qJw==}
+    dev: false
+
+  /@solana/keys@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-A2Hf4IL7EH85yaadZMwu8dVMDzKLVRpIug8QjgKKiJRhu9FIezzbUDMT8l4ILBOpsRdcwgcK3/YFVRdVoMcWmA==}
+    dependencies:
+      '@solana/assertions': 2.0.0-experimental.a7a613a
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-strings': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/errors': 2.0.0-experimental.a7a613a
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/options@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-kVZIyrul8y+bpDp2jm+r9Osvzm0EFgUlB2BxyMk82N9zPGPNxutVAgZ8YkhZKiCKBYtd8UHdtk/CIqNjHy1Zlg==}
+  /@solana/options@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-gUV7uSOfHrOBLt3+Wv3LJDYkVQN1PTmNu511/zkkKdE3AwUMUfG7x+jMg85h3Tiw7xPs+HOgHBEyGdiYHk0W1g==}
     dependencies:
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-numbers': 2.0.0-experimental.5e737f9
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-numbers': 2.0.0-experimental.a7a613a
     dev: false
 
-  /@solana/programs@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-Pk1KYPgJm7LYAGFuUC8NOQ12vSpMTr6yLi9PYcZDM0Y2FQaMxRJeEyXFY0qgqBwvBVmPS8p82jQ/nyvy6xODuQ==}
+  /@solana/programs@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-1A6iwvlKmuJKZrL4+bTZUV1fh4aIHDqtCuQofRdenK46TJ0QqyTewEG3i6G1UuDQx2F6eKoFL3kC0QDK+7HUyw==}
     dev: false
 
-  /@solana/rpc-core@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-19lljbJTBWDVltVTyUdNewS1IAXpCI4QemeP0Aea01tL26KwCGDmm2rN/FLkr67yOqOjnEN5IfNQaBeYPjUD+g==}
+  /@solana/rpc-spec-types@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-lyZmEHac9WEL0Uf02X6sM7/vqGW6NAGV1fW3JRaLI9KOjMtN5OmRMiJiPhDKFHM/mBHGs0ddDwABBR0M1rNbzw==}
     dev: false
 
-  /@solana/rpc-transport@2.0.0-experimental.5e737f9(ws@8.15.0):
-    resolution: {integrity: sha512-lF6qPJUvjI+HP469qjUSKVflL2rkdwQvHCnAv3HzInONTT6NAAEhLdZBN0/GvkChpn13q/j2f9PsWUWSbi6NAg==}
-    peerDependencies:
-      ws: ^8.14.0
+  /@solana/rpc-spec@2.0.0-experimental.a7a613a:
+    resolution: {integrity: sha512-YfCbUxtSP/uVD+EPnM709JFF/LDBAUiLcosXLQZF62qSEDGWc15MelfXDHHqcSdUaPbxy6cCCqbVUhWaZt4ifQ==}
     dependencies:
-      ws: 8.15.0
+      '@solana/rpc-spec-types': 2.0.0-experimental.a7a613a
     dev: false
 
-  /@solana/rpc-types@2.0.0-experimental.5e737f9:
-    resolution: {integrity: sha512-IdfD8j2uQOAeCCjiyRT5/rc1U01jdZ0BWsM4Hyeyl1utURKzU9aRTxF3YfmX4En/v/cYzd31k7qQMSMrOondcA==}
-    dev: false
-
-  /@solana/signers@2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-+/4nnt7Hd2nW+A1EuoFbS16pLwjgp5M29Ms3aSQSqB+8MF50RPIADsyWf9u+mADKpsyvyD8cybbr4Zz8+NkFXg==}
+  /@solana/rpc-types@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-oICRh5Q4/5N/QRxea+xnUxLGFEp7jgRmJHqsR1eDhCUoSntwBL9ME3bdvsQh65gZ9DjKMUIU6FAPUzgmz/upWg==}
     dependencies:
-      '@solana/addresses': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/instructions': 2.0.0-experimental.5e737f9
-      '@solana/keys': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/transactions': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/addresses': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/codecs-strings': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
     dev: false
 
-  /@solana/transactions@2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22):
-    resolution: {integrity: sha512-PA7P1YVSr9AXjnD7ERgQVF4DR+/bTDrr/mAm3T7tCjSJu6gxNJ4PDYCSqrL3sbDMIQJ4s7UMhPDk4WCbFh8v0Q==}
+  /@solana/signers@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-2gnsMbDDnzcj63YiqkuNfcRIcWJEbuW2gwYfuypbby86g4etMhnYlsYwbRptb2BBd79ho0vBQfJco22D2UiCKw==}
     dependencies:
-      '@solana/addresses': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/codecs-core': 2.0.0-experimental.5e737f9
-      '@solana/codecs-data-structures': 2.0.0-experimental.5e737f9
-      '@solana/codecs-numbers': 2.0.0-experimental.5e737f9
-      '@solana/codecs-strings': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/functional': 2.0.0-experimental.5e737f9
-      '@solana/keys': 2.0.0-experimental.5e737f9(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/addresses': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/errors': 2.0.0-experimental.a7a613a
+      '@solana/instructions': 2.0.0-experimental.a7a613a
+      '@solana/keys': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/transactions': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+    dev: false
+
+  /@solana/transactions@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-DxxMzGEPGw0s3+AQGaqJqqFkcGWFJFuMB/z3U3cYMA5AmDZ3y51lGRsUonvdYw/ksQOGXawS6hrTeQ5VPu1yig==}
+    dependencies:
+      '@solana/addresses': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-data-structures': 2.0.0-experimental.a7a613a
+      '@solana/codecs-numbers': 2.0.0-experimental.a7a613a
+      '@solana/codecs-strings': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/errors': 2.0.0-experimental.a7a613a
+      '@solana/functional': 2.0.0-experimental.a7a613a
+      '@solana/keys': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+    dev: false
+
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
+  /commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
     dev: false
 
   /fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
     dev: false
 
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
-
-  /ws@8.15.0:
-    resolution: {integrity: sha512-H/Z3H55mrcrgjFwI+5jKavgXvwQLtfPCUEp6pi35VhoB0pfcHnSoyuTzkBEZpzq49g1193CUEwIvmsjcotenYw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false

--- a/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
+++ b/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
@@ -93,21 +93,7 @@ export type CandyMachineAccountDataArgs = {
 
 export function getCandyMachineAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: Array<number>;
-      /** Features versioning flags. */
-      features: number | bigint;
-      /** Authority address. */
-      authority: Address;
-      /** Authority address allowed to mint from the candy machine. */
-      mintAuthority: Address;
-      /** The collection mint for the candy machine. */
-      collectionMint: Address;
-      /** Number of assets redeemed. */
-      itemsRedeemed: number | bigint;
-      /** Candy machine configuration data. */
-      data: CandyMachineDataArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
       ['features', getU64Encoder()],
       ['authority', getAddressEncoder()],
@@ -124,7 +110,7 @@ export function getCandyMachineAccountDataEncoder() {
 }
 
 export function getCandyMachineAccountDataDecoder() {
-  return getStructDecoder<CandyMachineAccountData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['features', getU64Decoder()],
     ['authority', getAddressDecoder()],

--- a/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
+++ b/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
@@ -91,7 +91,7 @@ export type CandyMachineAccountDataArgs = {
   data: CandyMachineDataArgs;
 };
 
-export function getCandyMachineAccountDataEncoder() {
+export function getCandyMachineAccountDataEncoder(): Encoder<CandyMachineAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -106,10 +106,10 @@ export function getCandyMachineAccountDataEncoder() {
       ...value,
       discriminator: [51, 173, 177, 113, 25, 241, 109, 189],
     })
-  ) satisfies Encoder<CandyMachineAccountDataArgs>;
+  );
 }
 
-export function getCandyMachineAccountDataDecoder() {
+export function getCandyMachineAccountDataDecoder(): Decoder<CandyMachineAccountData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['features', getU64Decoder()],
@@ -118,7 +118,7 @@ export function getCandyMachineAccountDataDecoder() {
     ['collectionMint', getAddressDecoder()],
     ['itemsRedeemed', getU64Decoder()],
     ['data', getCandyMachineDataDecoder()],
-  ]) satisfies Decoder<CandyMachineAccountData>;
+  ]);
 }
 
 export function getCandyMachineAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
@@ -61,7 +61,7 @@ export type CollectionAuthorityRecordAccountDataArgs = {
   updateAuthority: OptionOrNullable<Address>;
 };
 
-export function getCollectionAuthorityRecordAccountDataEncoder() {
+export function getCollectionAuthorityRecordAccountDataEncoder(): Encoder<CollectionAuthorityRecordAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -69,15 +69,15 @@ export function getCollectionAuthorityRecordAccountDataEncoder() {
       ['updateAuthority', getOptionEncoder(getAddressEncoder())],
     ]),
     (value) => ({ ...value, key: TmKey.CollectionAuthorityRecord })
-  ) satisfies Encoder<CollectionAuthorityRecordAccountDataArgs>;
+  );
 }
 
-export function getCollectionAuthorityRecordAccountDataDecoder() {
+export function getCollectionAuthorityRecordAccountDataDecoder(): Decoder<CollectionAuthorityRecordAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['bump', getU8Decoder()],
     ['updateAuthority', getOptionDecoder(getAddressDecoder())],
-  ]) satisfies Decoder<CollectionAuthorityRecordAccountData>;
+  ]);
 }
 
 export function getCollectionAuthorityRecordAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
@@ -42,7 +42,7 @@ import {
   getOptionDecoder,
   getOptionEncoder,
 } from '@solana/options';
-import { TmKey, TmKeyArgs, getTmKeyDecoder, getTmKeyEncoder } from '../types';
+import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type CollectionAuthorityRecord<TAddress extends string = string> =
   Account<CollectionAuthorityRecordAccountData, TAddress>;
@@ -63,11 +63,7 @@ export type CollectionAuthorityRecordAccountDataArgs = {
 
 export function getCollectionAuthorityRecordAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      bump: number;
-      updateAuthority: OptionOrNullable<Address>;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['bump', getU8Encoder()],
       ['updateAuthority', getOptionEncoder(getAddressEncoder())],
@@ -77,7 +73,7 @@ export function getCollectionAuthorityRecordAccountDataEncoder() {
 }
 
 export function getCollectionAuthorityRecordAccountDataDecoder() {
-  return getStructDecoder<CollectionAuthorityRecordAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['bump', getU8Decoder()],
     ['updateAuthority', getOptionDecoder(getAddressDecoder())],

--- a/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
@@ -37,7 +37,6 @@ import {
   DelegateRole,
   DelegateRoleArgs,
   TmKey,
-  TmKeyArgs,
   getDelegateRoleDecoder,
   getDelegateRoleEncoder,
   getTmKeyDecoder,
@@ -65,7 +64,7 @@ export type DelegateRecordAccountDataArgs = {
 
 export function getDelegateRecordAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ key: TmKeyArgs; role: DelegateRoleArgs; bump: number }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['role', getDelegateRoleEncoder()],
       ['bump', getU8Encoder()],
@@ -75,7 +74,7 @@ export function getDelegateRecordAccountDataEncoder() {
 }
 
 export function getDelegateRecordAccountDataDecoder() {
-  return getStructDecoder<DelegateRecordAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['role', getDelegateRoleDecoder()],
     ['bump', getU8Decoder()],

--- a/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
@@ -62,7 +62,7 @@ export type DelegateRecordAccountDataArgs = {
   bump: number;
 };
 
-export function getDelegateRecordAccountDataEncoder() {
+export function getDelegateRecordAccountDataEncoder(): Encoder<DelegateRecordAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -70,15 +70,15 @@ export function getDelegateRecordAccountDataEncoder() {
       ['bump', getU8Encoder()],
     ]),
     (value) => ({ ...value, key: TmKey.Delegate })
-  ) satisfies Encoder<DelegateRecordAccountDataArgs>;
+  );
 }
 
-export function getDelegateRecordAccountDataDecoder() {
+export function getDelegateRecordAccountDataDecoder(): Decoder<DelegateRecordAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['role', getDelegateRoleDecoder()],
     ['bump', getU8Decoder()],
-  ]) satisfies Decoder<DelegateRecordAccountData>;
+  ]);
 }
 
 export function getDelegateRecordAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/edition.ts
+++ b/test/packages/js-experimental/src/generated/accounts/edition.ts
@@ -36,7 +36,7 @@ import {
   getStructEncoder,
 } from '@solana/codecs-data-structures';
 import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import { TmKey, TmKeyArgs, getTmKeyDecoder, getTmKeyEncoder } from '../types';
+import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type Edition<TAddress extends string = string> = Account<
   EditionAccountData,
@@ -61,11 +61,7 @@ export type EditionAccountDataArgs = {
 
 export function getEditionAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      parent: Address;
-      edition: number | bigint;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['parent', getAddressEncoder()],
       ['edition', getU64Encoder()],
@@ -75,7 +71,7 @@ export function getEditionAccountDataEncoder() {
 }
 
 export function getEditionAccountDataDecoder() {
-  return getStructDecoder<EditionAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['parent', getAddressDecoder()],
     ['edition', getU64Decoder()],

--- a/test/packages/js-experimental/src/generated/accounts/edition.ts
+++ b/test/packages/js-experimental/src/generated/accounts/edition.ts
@@ -59,7 +59,7 @@ export type EditionAccountDataArgs = {
   edition: number | bigint;
 };
 
-export function getEditionAccountDataEncoder() {
+export function getEditionAccountDataEncoder(): Encoder<EditionAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -67,15 +67,15 @@ export function getEditionAccountDataEncoder() {
       ['edition', getU64Encoder()],
     ]),
     (value) => ({ ...value, key: TmKey.EditionV1 })
-  ) satisfies Encoder<EditionAccountDataArgs>;
+  );
 }
 
-export function getEditionAccountDataDecoder() {
+export function getEditionAccountDataDecoder(): Decoder<EditionAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['parent', getAddressDecoder()],
     ['edition', getU64Decoder()],
-  ]) satisfies Decoder<EditionAccountData>;
+  ]);
 }
 
 export function getEditionAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
+++ b/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
@@ -34,7 +34,7 @@ import {
   getStructEncoder,
 } from '@solana/codecs-data-structures';
 import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
-import { TmKey, TmKeyArgs, getTmKeyDecoder, getTmKeyEncoder } from '../types';
+import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type EditionMarker<TAddress extends string = string> = Account<
   EditionMarkerAccountData,
@@ -52,7 +52,7 @@ export type EditionMarkerAccountDataArgs = { ledger: Array<number> };
 
 export function getEditionMarkerAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ key: TmKeyArgs; ledger: Array<number> }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['ledger', getArrayEncoder(getU8Encoder(), { size: 200 })],
     ]),
@@ -61,7 +61,7 @@ export function getEditionMarkerAccountDataEncoder() {
 }
 
 export function getEditionMarkerAccountDataDecoder() {
-  return getStructDecoder<EditionMarkerAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['ledger', getArrayDecoder(getU8Decoder(), { size: 200 })],
   ]) satisfies Decoder<EditionMarkerAccountData>;

--- a/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
+++ b/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
@@ -50,21 +50,21 @@ export type EditionMarkerAccountData = { key: TmKey; ledger: Array<number> };
 
 export type EditionMarkerAccountDataArgs = { ledger: Array<number> };
 
-export function getEditionMarkerAccountDataEncoder() {
+export function getEditionMarkerAccountDataEncoder(): Encoder<EditionMarkerAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['ledger', getArrayEncoder(getU8Encoder(), { size: 200 })],
     ]),
     (value) => ({ ...value, key: TmKey.EditionMarker })
-  ) satisfies Encoder<EditionMarkerAccountDataArgs>;
+  );
 }
 
-export function getEditionMarkerAccountDataDecoder() {
+export function getEditionMarkerAccountDataDecoder(): Decoder<EditionMarkerAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['ledger', getArrayDecoder(getU8Decoder(), { size: 200 })],
-  ]) satisfies Decoder<EditionMarkerAccountData>;
+  ]);
 }
 
 export function getEditionMarkerAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
+++ b/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
@@ -68,7 +68,7 @@ export type FrequencyAccountAccountDataArgs = {
   period: number | bigint;
 };
 
-export function getFrequencyAccountAccountDataEncoder() {
+export function getFrequencyAccountAccountDataEncoder(): Encoder<FrequencyAccountAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getU64Encoder()],
@@ -76,15 +76,15 @@ export function getFrequencyAccountAccountDataEncoder() {
       ['period', getI64Encoder()],
     ]),
     (value) => ({ ...value, key: TaKey.Frequency })
-  ) satisfies Encoder<FrequencyAccountAccountDataArgs>;
+  );
 }
 
-export function getFrequencyAccountAccountDataDecoder() {
+export function getFrequencyAccountAccountDataDecoder(): Decoder<FrequencyAccountAccountData> {
   return getStructDecoder([
     ['key', getU64Decoder()],
     ['lastUpdate', getI64Decoder()],
     ['period', getI64Decoder()],
-  ]) satisfies Decoder<FrequencyAccountAccountData>;
+  ]);
 }
 
 export function getFrequencyAccountAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
+++ b/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
@@ -70,16 +70,7 @@ export type FrequencyAccountAccountDataArgs = {
 
 export function getFrequencyAccountAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      /** Test with only one line. */
-      key: number | bigint;
-      /**
-       * Test with multiple lines
-       * and this is the second line.
-       */
-      lastUpdate: number | bigint;
-      period: number | bigint;
-    }>([
+    getStructEncoder([
       ['key', getU64Encoder()],
       ['lastUpdate', getI64Encoder()],
       ['period', getI64Encoder()],
@@ -89,7 +80,7 @@ export function getFrequencyAccountAccountDataEncoder() {
 }
 
 export function getFrequencyAccountAccountDataDecoder() {
-  return getStructDecoder<FrequencyAccountAccountData>([
+  return getStructDecoder([
     ['key', getU64Decoder()],
     ['lastUpdate', getI64Decoder()],
     ['period', getI64Decoder()],

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
@@ -43,7 +43,7 @@ import {
   getOptionEncoder,
 } from '@solana/options';
 import { MasterEditionV1Seeds, findMasterEditionV1Pda } from '../pdas';
-import { TmKey, TmKeyArgs, getTmKeyDecoder, getTmKeyEncoder } from '../types';
+import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type MasterEditionV1<TAddress extends string = string> = Account<
   MasterEditionV1AccountData,
@@ -70,13 +70,7 @@ export type MasterEditionV1AccountDataArgs = {
 
 export function getMasterEditionV1AccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      supply: number | bigint;
-      maxSupply: OptionOrNullable<number | bigint>;
-      printingMint: Address;
-      oneTimePrintingAuthorizationMint: Address;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['supply', getU64Encoder()],
       ['maxSupply', getOptionEncoder(getU64Encoder())],
@@ -88,7 +82,7 @@ export function getMasterEditionV1AccountDataEncoder() {
 }
 
 export function getMasterEditionV1AccountDataDecoder() {
-  return getStructDecoder<MasterEditionV1AccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['supply', getU64Decoder()],
     ['maxSupply', getOptionDecoder(getU64Decoder())],

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
@@ -68,7 +68,7 @@ export type MasterEditionV1AccountDataArgs = {
   oneTimePrintingAuthorizationMint: Address;
 };
 
-export function getMasterEditionV1AccountDataEncoder() {
+export function getMasterEditionV1AccountDataEncoder(): Encoder<MasterEditionV1AccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -78,17 +78,17 @@ export function getMasterEditionV1AccountDataEncoder() {
       ['oneTimePrintingAuthorizationMint', getAddressEncoder()],
     ]),
     (value) => ({ ...value, key: TmKey.MasterEditionV1 })
-  ) satisfies Encoder<MasterEditionV1AccountDataArgs>;
+  );
 }
 
-export function getMasterEditionV1AccountDataDecoder() {
+export function getMasterEditionV1AccountDataDecoder(): Decoder<MasterEditionV1AccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['supply', getU64Decoder()],
     ['maxSupply', getOptionDecoder(getU64Decoder())],
     ['printingMint', getAddressDecoder()],
     ['oneTimePrintingAuthorizationMint', getAddressDecoder()],
-  ]) satisfies Decoder<MasterEditionV1AccountData>;
+  ]);
 }
 
 export function getMasterEditionV1AccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
@@ -39,7 +39,7 @@ import {
   getOptionEncoder,
 } from '@solana/options';
 import { MasterEditionV2Seeds, findMasterEditionV2Pda } from '../pdas';
-import { TmKey, TmKeyArgs, getTmKeyDecoder, getTmKeyEncoder } from '../types';
+import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type MasterEditionV2<TAddress extends string = string> = Account<
   MasterEditionV2AccountData,
@@ -62,11 +62,7 @@ export type MasterEditionV2AccountDataArgs = {
 
 export function getMasterEditionV2AccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      supply: number | bigint;
-      maxSupply: OptionOrNullable<number | bigint>;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['supply', getU64Encoder()],
       ['maxSupply', getOptionEncoder(getU64Encoder())],
@@ -76,7 +72,7 @@ export function getMasterEditionV2AccountDataEncoder() {
 }
 
 export function getMasterEditionV2AccountDataDecoder() {
-  return getStructDecoder<MasterEditionV2AccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['supply', getU64Decoder()],
     ['maxSupply', getOptionDecoder(getU64Decoder())],

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
@@ -60,7 +60,7 @@ export type MasterEditionV2AccountDataArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-export function getMasterEditionV2AccountDataEncoder() {
+export function getMasterEditionV2AccountDataEncoder(): Encoder<MasterEditionV2AccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -68,15 +68,15 @@ export function getMasterEditionV2AccountDataEncoder() {
       ['maxSupply', getOptionEncoder(getU64Encoder())],
     ]),
     (value) => ({ ...value, key: TmKey.MasterEditionV2 })
-  ) satisfies Encoder<MasterEditionV2AccountDataArgs>;
+  );
 }
 
-export function getMasterEditionV2AccountDataDecoder() {
+export function getMasterEditionV2AccountDataDecoder(): Decoder<MasterEditionV2AccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['supply', getU64Decoder()],
     ['maxSupply', getOptionDecoder(getU64Decoder())],
-  ]) satisfies Decoder<MasterEditionV2AccountData>;
+  ]);
 }
 
 export function getMasterEditionV2AccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/metadata.ts
+++ b/test/packages/js-experimental/src/generated/accounts/metadata.ts
@@ -136,7 +136,7 @@ export type MetadataAccountDataArgs = {
   delegateState: OptionOrNullable<DelegateStateArgs>;
 };
 
-export function getMetadataAccountDataEncoder() {
+export function getMetadataAccountDataEncoder(): Encoder<MetadataAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -158,10 +158,10 @@ export function getMetadataAccountDataEncoder() {
       ['delegateState', getOptionEncoder(getDelegateStateEncoder())],
     ]),
     (value) => ({ ...value, key: TmKey.MetadataV1 })
-  ) satisfies Encoder<MetadataAccountDataArgs>;
+  );
 }
 
-export function getMetadataAccountDataDecoder() {
+export function getMetadataAccountDataDecoder(): Decoder<MetadataAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['updateAuthority', getAddressDecoder()],
@@ -180,7 +180,7 @@ export function getMetadataAccountDataDecoder() {
     ['collectionDetails', getOptionDecoder(getCollectionDetailsDecoder())],
     ['programmableConfig', getOptionDecoder(getProgrammableConfigDecoder())],
     ['delegateState', getOptionDecoder(getDelegateStateDecoder())],
-  ]) satisfies Decoder<MetadataAccountData>;
+  ]);
 }
 
 export function getMetadataAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/metadata.ts
+++ b/test/packages/js-experimental/src/generated/accounts/metadata.ts
@@ -65,7 +65,6 @@ import {
   ProgrammableConfig,
   ProgrammableConfigArgs,
   TmKey,
-  TmKeyArgs,
   TokenStandard,
   TokenStandardArgs,
   Uses,
@@ -139,25 +138,7 @@ export type MetadataAccountDataArgs = {
 
 export function getMetadataAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      updateAuthority: Address;
-      mint: Address;
-      name: string;
-      symbol: string;
-      uri: string;
-      sellerFeeBasisPoints: number;
-      creators: OptionOrNullable<Array<CreatorArgs>>;
-      primarySaleHappened: boolean;
-      isMutable: boolean;
-      editionNonce: OptionOrNullable<number>;
-      tokenStandard: OptionOrNullable<TokenStandardArgs>;
-      collection: OptionOrNullable<CollectionArgs>;
-      uses: OptionOrNullable<UsesArgs>;
-      collectionDetails: OptionOrNullable<CollectionDetailsArgs>;
-      programmableConfig: OptionOrNullable<ProgrammableConfigArgs>;
-      delegateState: OptionOrNullable<DelegateStateArgs>;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['updateAuthority', getAddressEncoder()],
       ['mint', getAddressEncoder()],
@@ -181,7 +162,7 @@ export function getMetadataAccountDataEncoder() {
 }
 
 export function getMetadataAccountDataDecoder() {
-  return getStructDecoder<MetadataAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['updateAuthority', getAddressDecoder()],
     ['mint', getAddressDecoder()],

--- a/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
@@ -48,7 +48,6 @@ import {
   Reservation,
   ReservationArgs,
   TmKey,
-  TmKeyArgs,
   getReservationDecoder,
   getReservationEncoder,
   getTmKeyDecoder,
@@ -82,14 +81,7 @@ export type ReservationListV2AccountDataArgs = {
 
 export function getReservationListV2AccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      masterEdition: Address;
-      supplySnapshot: OptionOrNullable<number | bigint>;
-      reservations: Array<ReservationArgs>;
-      totalReservationSpots: number | bigint;
-      currentReservationSpots: number | bigint;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['masterEdition', getAddressEncoder()],
       ['supplySnapshot', getOptionEncoder(getU64Encoder())],
@@ -102,7 +94,7 @@ export function getReservationListV2AccountDataEncoder() {
 }
 
 export function getReservationListV2AccountDataDecoder() {
-  return getStructDecoder<ReservationListV2AccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['masterEdition', getAddressDecoder()],
     ['supplySnapshot', getOptionDecoder(getU64Decoder())],

--- a/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
@@ -79,7 +79,7 @@ export type ReservationListV2AccountDataArgs = {
   currentReservationSpots: number | bigint;
 };
 
-export function getReservationListV2AccountDataEncoder() {
+export function getReservationListV2AccountDataEncoder(): Encoder<ReservationListV2AccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -90,10 +90,10 @@ export function getReservationListV2AccountDataEncoder() {
       ['currentReservationSpots', getU64Encoder()],
     ]),
     (value) => ({ ...value, key: TmKey.ReservationListV2 })
-  ) satisfies Encoder<ReservationListV2AccountDataArgs>;
+  );
 }
 
-export function getReservationListV2AccountDataDecoder() {
+export function getReservationListV2AccountDataDecoder(): Decoder<ReservationListV2AccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['masterEdition', getAddressDecoder()],
@@ -101,7 +101,7 @@ export function getReservationListV2AccountDataDecoder() {
     ['reservations', getArrayDecoder(getReservationDecoder())],
     ['totalReservationSpots', getU64Decoder()],
     ['currentReservationSpots', getU64Decoder()],
-  ]) satisfies Decoder<ReservationListV2AccountData>;
+  ]);
 }
 
 export function getReservationListV2AccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
+++ b/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
@@ -40,7 +40,6 @@ import {
   EscrowAuthority,
   EscrowAuthorityArgs,
   TmKey,
-  TmKeyArgs,
   getEscrowAuthorityDecoder,
   getEscrowAuthorityEncoder,
   getTmKeyDecoder,
@@ -70,12 +69,7 @@ export type TokenOwnedEscrowAccountDataArgs = {
 
 export function getTokenOwnedEscrowAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      baseToken: Address;
-      authority: EscrowAuthorityArgs;
-      bump: number;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['baseToken', getAddressEncoder()],
       ['authority', getEscrowAuthorityEncoder()],
@@ -86,7 +80,7 @@ export function getTokenOwnedEscrowAccountDataEncoder() {
 }
 
 export function getTokenOwnedEscrowAccountDataDecoder() {
-  return getStructDecoder<TokenOwnedEscrowAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['baseToken', getAddressDecoder()],
     ['authority', getEscrowAuthorityDecoder()],

--- a/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
+++ b/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
@@ -67,7 +67,7 @@ export type TokenOwnedEscrowAccountDataArgs = {
   bump: number;
 };
 
-export function getTokenOwnedEscrowAccountDataEncoder() {
+export function getTokenOwnedEscrowAccountDataEncoder(): Encoder<TokenOwnedEscrowAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -76,16 +76,16 @@ export function getTokenOwnedEscrowAccountDataEncoder() {
       ['bump', getU8Encoder()],
     ]),
     (value) => ({ ...value, key: TmKey.TokenOwnedEscrow })
-  ) satisfies Encoder<TokenOwnedEscrowAccountDataArgs>;
+  );
 }
 
-export function getTokenOwnedEscrowAccountDataDecoder() {
+export function getTokenOwnedEscrowAccountDataDecoder(): Decoder<TokenOwnedEscrowAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['baseToken', getAddressDecoder()],
     ['authority', getEscrowAuthorityDecoder()],
     ['bump', getU8Decoder()],
-  ]) satisfies Decoder<TokenOwnedEscrowAccountData>;
+  ]);
 }
 
 export function getTokenOwnedEscrowAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
@@ -58,7 +58,7 @@ export type UseAuthorityRecordAccountDataArgs = {
   bump: number;
 };
 
-export function getUseAuthorityRecordAccountDataEncoder() {
+export function getUseAuthorityRecordAccountDataEncoder(): Encoder<UseAuthorityRecordAccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -66,15 +66,15 @@ export function getUseAuthorityRecordAccountDataEncoder() {
       ['bump', getU8Encoder()],
     ]),
     (value) => ({ ...value, key: TmKey.UseAuthorityRecord })
-  ) satisfies Encoder<UseAuthorityRecordAccountDataArgs>;
+  );
 }
 
-export function getUseAuthorityRecordAccountDataDecoder() {
+export function getUseAuthorityRecordAccountDataDecoder(): Decoder<UseAuthorityRecordAccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['allowedUses', getU64Decoder()],
     ['bump', getU8Decoder()],
-  ]) satisfies Decoder<UseAuthorityRecordAccountData>;
+  ]);
 }
 
 export function getUseAuthorityRecordAccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
@@ -37,7 +37,7 @@ import {
   getU8Decoder,
   getU8Encoder,
 } from '@solana/codecs-numbers';
-import { TmKey, TmKeyArgs, getTmKeyDecoder, getTmKeyEncoder } from '../types';
+import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type UseAuthorityRecord<TAddress extends string = string> = Account<
   UseAuthorityRecordAccountData,
@@ -60,11 +60,7 @@ export type UseAuthorityRecordAccountDataArgs = {
 
 export function getUseAuthorityRecordAccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      allowedUses: number | bigint;
-      bump: number;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['allowedUses', getU64Encoder()],
       ['bump', getU8Encoder()],
@@ -74,7 +70,7 @@ export function getUseAuthorityRecordAccountDataEncoder() {
 }
 
 export function getUseAuthorityRecordAccountDataDecoder() {
-  return getStructDecoder<UseAuthorityRecordAccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['allowedUses', getU64Decoder()],
     ['bump', getU8Decoder()],

--- a/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
+++ b/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
@@ -106,13 +106,7 @@ export type AddConfigLinesInstructionDataArgs = {
 
 export function getAddConfigLinesInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: Array<number>;
-      index: number;
-      configLines: Array<ConfigLineArgs>;
-      /** More dummy lines. */
-      moreLines: Array<ConfigLineArgs>;
-    }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
       ['index', getU32Encoder()],
       ['configLines', getArrayEncoder(getConfigLineEncoder())],
@@ -129,7 +123,7 @@ export function getAddConfigLinesInstructionDataEncoder() {
 }
 
 export function getAddConfigLinesInstructionDataDecoder() {
-  return getStructDecoder<AddConfigLinesInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['index', getU32Decoder()],
     ['configLines', getArrayDecoder(getConfigLineDecoder())],

--- a/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
+++ b/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
@@ -104,7 +104,7 @@ export type AddConfigLinesInstructionDataArgs = {
   moreLines: Array<ConfigLineArgs>;
 };
 
-export function getAddConfigLinesInstructionDataEncoder() {
+export function getAddConfigLinesInstructionDataEncoder(): Encoder<AddConfigLinesInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -119,10 +119,10 @@ export function getAddConfigLinesInstructionDataEncoder() {
       ...value,
       discriminator: [223, 50, 224, 227, 151, 8, 115, 106],
     })
-  ) satisfies Encoder<AddConfigLinesInstructionDataArgs>;
+  );
 }
 
-export function getAddConfigLinesInstructionDataDecoder() {
+export function getAddConfigLinesInstructionDataDecoder(): Decoder<AddConfigLinesInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['index', getU32Decoder()],
@@ -131,7 +131,7 @@ export function getAddConfigLinesInstructionDataDecoder() {
       'moreLines',
       getArrayDecoder(getConfigLineDecoder(), { size: getU64Decoder() }),
     ],
-  ]) satisfies Decoder<AddConfigLinesInstructionData>;
+  ]);
 }
 
 export function getAddConfigLinesInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
@@ -138,17 +138,15 @@ export type ApproveCollectionAuthorityInstructionData = {
 
 export type ApproveCollectionAuthorityInstructionDataArgs = {};
 
-export function getApproveCollectionAuthorityInstructionDataEncoder() {
+export function getApproveCollectionAuthorityInstructionDataEncoder(): Encoder<ApproveCollectionAuthorityInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 23 })
-  ) satisfies Encoder<ApproveCollectionAuthorityInstructionDataArgs>;
+  );
 }
 
-export function getApproveCollectionAuthorityInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<ApproveCollectionAuthorityInstructionData>;
+export function getApproveCollectionAuthorityInstructionDataDecoder(): Decoder<ApproveCollectionAuthorityInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getApproveCollectionAuthorityInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
@@ -140,15 +140,13 @@ export type ApproveCollectionAuthorityInstructionDataArgs = {};
 
 export function getApproveCollectionAuthorityInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 23 })
   ) satisfies Encoder<ApproveCollectionAuthorityInstructionDataArgs>;
 }
 
 export function getApproveCollectionAuthorityInstructionDataDecoder() {
-  return getStructDecoder<ApproveCollectionAuthorityInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<ApproveCollectionAuthorityInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
@@ -172,7 +172,7 @@ export type ApproveUseAuthorityInstructionDataArgs = {
 
 export function getApproveUseAuthorityInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; numberOfUses: number | bigint }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['numberOfUses', getU64Encoder()],
     ]),
@@ -181,7 +181,7 @@ export function getApproveUseAuthorityInstructionDataEncoder() {
 }
 
 export function getApproveUseAuthorityInstructionDataDecoder() {
-  return getStructDecoder<ApproveUseAuthorityInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['numberOfUses', getU64Decoder()],
   ]) satisfies Decoder<ApproveUseAuthorityInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
@@ -170,21 +170,21 @@ export type ApproveUseAuthorityInstructionDataArgs = {
   numberOfUses: number | bigint;
 };
 
-export function getApproveUseAuthorityInstructionDataEncoder() {
+export function getApproveUseAuthorityInstructionDataEncoder(): Encoder<ApproveUseAuthorityInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['numberOfUses', getU64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 20 })
-  ) satisfies Encoder<ApproveUseAuthorityInstructionDataArgs>;
+  );
 }
 
-export function getApproveUseAuthorityInstructionDataDecoder() {
+export function getApproveUseAuthorityInstructionDataDecoder(): Decoder<ApproveUseAuthorityInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['numberOfUses', getU64Decoder()],
-  ]) satisfies Decoder<ApproveUseAuthorityInstructionData>;
+  ]);
 }
 
 export function getApproveUseAuthorityInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -120,21 +120,21 @@ export type BubblegumSetCollectionSizeInstructionDataArgs = {
   setCollectionSizeArgs: SetCollectionSizeArgsArgs;
 };
 
-export function getBubblegumSetCollectionSizeInstructionDataEncoder() {
+export function getBubblegumSetCollectionSizeInstructionDataEncoder(): Encoder<BubblegumSetCollectionSizeInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['setCollectionSizeArgs', getSetCollectionSizeArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 36 })
-  ) satisfies Encoder<BubblegumSetCollectionSizeInstructionDataArgs>;
+  );
 }
 
-export function getBubblegumSetCollectionSizeInstructionDataDecoder() {
+export function getBubblegumSetCollectionSizeInstructionDataDecoder(): Decoder<BubblegumSetCollectionSizeInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['setCollectionSizeArgs', getSetCollectionSizeArgsDecoder()],
-  ]) satisfies Decoder<BubblegumSetCollectionSizeInstructionData>;
+  ]);
 }
 
 export function getBubblegumSetCollectionSizeInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -122,10 +122,7 @@ export type BubblegumSetCollectionSizeInstructionDataArgs = {
 
 export function getBubblegumSetCollectionSizeInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      setCollectionSizeArgs: SetCollectionSizeArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['setCollectionSizeArgs', getSetCollectionSizeArgsEncoder()],
     ]),
@@ -134,7 +131,7 @@ export function getBubblegumSetCollectionSizeInstructionDataEncoder() {
 }
 
 export function getBubblegumSetCollectionSizeInstructionDataDecoder() {
-  return getStructDecoder<BubblegumSetCollectionSizeInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['setCollectionSizeArgs', getSetCollectionSizeArgsDecoder()],
   ]) satisfies Decoder<BubblegumSetCollectionSizeInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/burn.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burn.ts
@@ -151,7 +151,7 @@ export type BurnInstructionDataArgs = { burnArgs: BurnArgsArgs };
 
 export function getBurnInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; burnArgs: BurnArgsArgs }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['burnArgs', getBurnArgsEncoder()],
     ]),
@@ -160,7 +160,7 @@ export function getBurnInstructionDataEncoder() {
 }
 
 export function getBurnInstructionDataDecoder() {
-  return getStructDecoder<BurnInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['burnArgs', getBurnArgsDecoder()],
   ]) satisfies Decoder<BurnInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/burn.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burn.ts
@@ -149,21 +149,21 @@ export type BurnInstructionData = { discriminator: number; burnArgs: BurnArgs };
 
 export type BurnInstructionDataArgs = { burnArgs: BurnArgsArgs };
 
-export function getBurnInstructionDataEncoder() {
+export function getBurnInstructionDataEncoder(): Encoder<BurnInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['burnArgs', getBurnArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 44 })
-  ) satisfies Encoder<BurnInstructionDataArgs>;
+  );
 }
 
-export function getBurnInstructionDataDecoder() {
+export function getBurnInstructionDataDecoder(): Decoder<BurnInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['burnArgs', getBurnArgsDecoder()],
-  ]) satisfies Decoder<BurnInstructionData>;
+  ]);
 }
 
 export function getBurnInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
@@ -157,15 +157,13 @@ export type BurnEditionNftInstructionDataArgs = {};
 
 export function getBurnEditionNftInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 37 })
   ) satisfies Encoder<BurnEditionNftInstructionDataArgs>;
 }
 
 export function getBurnEditionNftInstructionDataDecoder() {
-  return getStructDecoder<BurnEditionNftInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<BurnEditionNftInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
@@ -155,17 +155,15 @@ export type BurnEditionNftInstructionData = { discriminator: number };
 
 export type BurnEditionNftInstructionDataArgs = {};
 
-export function getBurnEditionNftInstructionDataEncoder() {
+export function getBurnEditionNftInstructionDataEncoder(): Encoder<BurnEditionNftInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 37 })
-  ) satisfies Encoder<BurnEditionNftInstructionDataArgs>;
+  );
 }
 
-export function getBurnEditionNftInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<BurnEditionNftInstructionData>;
+export function getBurnEditionNftInstructionDataDecoder(): Decoder<BurnEditionNftInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getBurnEditionNftInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/burnNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnNft.ts
@@ -123,17 +123,15 @@ export type BurnNftInstructionData = { discriminator: number };
 
 export type BurnNftInstructionDataArgs = {};
 
-export function getBurnNftInstructionDataEncoder() {
+export function getBurnNftInstructionDataEncoder(): Encoder<BurnNftInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 29 })
-  ) satisfies Encoder<BurnNftInstructionDataArgs>;
+  );
 }
 
-export function getBurnNftInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<BurnNftInstructionData>;
+export function getBurnNftInstructionDataDecoder(): Decoder<BurnNftInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getBurnNftInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/burnNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnNft.ts
@@ -125,15 +125,13 @@ export type BurnNftInstructionDataArgs = {};
 
 export function getBurnNftInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 29 })
   ) satisfies Encoder<BurnNftInstructionDataArgs>;
 }
 
 export function getBurnNftInstructionDataDecoder() {
-  return getStructDecoder<BurnNftInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<BurnNftInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
@@ -137,15 +137,13 @@ export type CloseEscrowAccountInstructionDataArgs = {};
 
 export function getCloseEscrowAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 39 })
   ) satisfies Encoder<CloseEscrowAccountInstructionDataArgs>;
 }
 
 export function getCloseEscrowAccountInstructionDataDecoder() {
-  return getStructDecoder<CloseEscrowAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<CloseEscrowAccountInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
@@ -135,17 +135,15 @@ export type CloseEscrowAccountInstructionData = { discriminator: number };
 
 export type CloseEscrowAccountInstructionDataArgs = {};
 
-export function getCloseEscrowAccountInstructionDataEncoder() {
+export function getCloseEscrowAccountInstructionDataEncoder(): Encoder<CloseEscrowAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 39 })
-  ) satisfies Encoder<CloseEscrowAccountInstructionDataArgs>;
+  );
 }
 
-export function getCloseEscrowAccountInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<CloseEscrowAccountInstructionData>;
+export function getCloseEscrowAccountInstructionDataDecoder(): Decoder<CloseEscrowAccountInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getCloseEscrowAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -87,15 +87,13 @@ export type ConvertMasterEditionV1ToV2InstructionDataArgs = {};
 
 export function getConvertMasterEditionV1ToV2InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 12 })
   ) satisfies Encoder<ConvertMasterEditionV1ToV2InstructionDataArgs>;
 }
 
 export function getConvertMasterEditionV1ToV2InstructionDataDecoder() {
-  return getStructDecoder<ConvertMasterEditionV1ToV2InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<ConvertMasterEditionV1ToV2InstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -85,17 +85,15 @@ export type ConvertMasterEditionV1ToV2InstructionData = {
 
 export type ConvertMasterEditionV1ToV2InstructionDataArgs = {};
 
-export function getConvertMasterEditionV1ToV2InstructionDataEncoder() {
+export function getConvertMasterEditionV1ToV2InstructionDataEncoder(): Encoder<ConvertMasterEditionV1ToV2InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 12 })
-  ) satisfies Encoder<ConvertMasterEditionV1ToV2InstructionDataArgs>;
+  );
 }
 
-export function getConvertMasterEditionV1ToV2InstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<ConvertMasterEditionV1ToV2InstructionData>;
+export function getConvertMasterEditionV1ToV2InstructionDataDecoder(): Decoder<ConvertMasterEditionV1ToV2InstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getConvertMasterEditionV1ToV2InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createAccount.ts
@@ -96,7 +96,7 @@ export type CreateAccountInstructionDataArgs = {
   programId: Address;
 };
 
-export function getCreateAccountInstructionDataEncoder() {
+export function getCreateAccountInstructionDataEncoder(): Encoder<CreateAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU32Encoder()],
@@ -105,16 +105,16 @@ export function getCreateAccountInstructionDataEncoder() {
       ['programId', getAddressEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 0 })
-  ) satisfies Encoder<CreateAccountInstructionDataArgs>;
+  );
 }
 
-export function getCreateAccountInstructionDataDecoder() {
+export function getCreateAccountInstructionDataDecoder(): Decoder<CreateAccountInstructionData> {
   return getStructDecoder([
     ['discriminator', getU32Decoder()],
     ['lamports', getU64Decoder()],
     ['space', getU64Decoder()],
     ['programId', getAddressDecoder()],
-  ]) satisfies Decoder<CreateAccountInstructionData>;
+  ]);
 }
 
 export function getCreateAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createAccount.ts
@@ -98,12 +98,7 @@ export type CreateAccountInstructionDataArgs = {
 
 export function getCreateAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      lamports: number | bigint;
-      space: number | bigint;
-      programId: Address;
-    }>([
+    getStructEncoder([
       ['discriminator', getU32Encoder()],
       ['lamports', getU64Encoder()],
       ['space', getU64Encoder()],
@@ -114,7 +109,7 @@ export function getCreateAccountInstructionDataEncoder() {
 }
 
 export function getCreateAccountInstructionDataDecoder() {
-  return getStructDecoder<CreateAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU32Decoder()],
     ['lamports', getU64Decoder()],
     ['space', getU64Decoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
@@ -145,17 +145,15 @@ export type CreateEscrowAccountInstructionData = { discriminator: number };
 
 export type CreateEscrowAccountInstructionDataArgs = {};
 
-export function getCreateEscrowAccountInstructionDataEncoder() {
+export function getCreateEscrowAccountInstructionDataEncoder(): Encoder<CreateEscrowAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 38 })
-  ) satisfies Encoder<CreateEscrowAccountInstructionDataArgs>;
+  );
 }
 
-export function getCreateEscrowAccountInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<CreateEscrowAccountInstructionData>;
+export function getCreateEscrowAccountInstructionDataDecoder(): Decoder<CreateEscrowAccountInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getCreateEscrowAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
@@ -147,15 +147,13 @@ export type CreateEscrowAccountInstructionDataArgs = {};
 
 export function getCreateEscrowAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 38 })
   ) satisfies Encoder<CreateEscrowAccountInstructionDataArgs>;
 }
 
 export function getCreateEscrowAccountInstructionDataDecoder() {
-  return getStructDecoder<CreateEscrowAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<CreateEscrowAccountInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
@@ -110,13 +110,7 @@ export type CreateFrequencyRuleInstructionDataArgs = {
 
 export function getCreateFrequencyRuleInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      ruleSetName: string;
-      freqRuleName: string;
-      lastUpdate: number | bigint;
-      period: number | bigint;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['ruleSetName', getStringEncoder()],
       ['freqRuleName', getStringEncoder()],
@@ -128,7 +122,7 @@ export function getCreateFrequencyRuleInstructionDataEncoder() {
 }
 
 export function getCreateFrequencyRuleInstructionDataDecoder() {
-  return getStructDecoder<CreateFrequencyRuleInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['ruleSetName', getStringDecoder()],
     ['freqRuleName', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
@@ -108,7 +108,7 @@ export type CreateFrequencyRuleInstructionDataArgs = {
   period: number | bigint;
 };
 
-export function getCreateFrequencyRuleInstructionDataEncoder() {
+export function getCreateFrequencyRuleInstructionDataEncoder(): Encoder<CreateFrequencyRuleInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -118,17 +118,17 @@ export function getCreateFrequencyRuleInstructionDataEncoder() {
       ['period', getI64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 2 })
-  ) satisfies Encoder<CreateFrequencyRuleInstructionDataArgs>;
+  );
 }
 
-export function getCreateFrequencyRuleInstructionDataDecoder() {
+export function getCreateFrequencyRuleInstructionDataDecoder(): Decoder<CreateFrequencyRuleInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['ruleSetName', getStringDecoder()],
     ['freqRuleName', getStringDecoder()],
     ['lastUpdate', getI64Decoder()],
     ['period', getI64Decoder()],
-  ]) satisfies Decoder<CreateFrequencyRuleInstructionData>;
+  ]);
 }
 
 export function getCreateFrequencyRuleInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
@@ -161,21 +161,21 @@ export type CreateMasterEditionInstructionDataArgs = {
   createMasterEditionArgs: CreateMasterEditionArgsArgs;
 };
 
-export function getCreateMasterEditionInstructionDataEncoder() {
+export function getCreateMasterEditionInstructionDataEncoder(): Encoder<CreateMasterEditionInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createMasterEditionArgs', getCreateMasterEditionArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 10 })
-  ) satisfies Encoder<CreateMasterEditionInstructionDataArgs>;
+  );
 }
 
-export function getCreateMasterEditionInstructionDataDecoder() {
+export function getCreateMasterEditionInstructionDataDecoder(): Decoder<CreateMasterEditionInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createMasterEditionArgs', getCreateMasterEditionArgsDecoder()],
-  ]) satisfies Decoder<CreateMasterEditionInstructionData>;
+  ]);
 }
 
 export function getCreateMasterEditionInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
@@ -163,10 +163,7 @@ export type CreateMasterEditionInstructionDataArgs = {
 
 export function getCreateMasterEditionInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      createMasterEditionArgs: CreateMasterEditionArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createMasterEditionArgs', getCreateMasterEditionArgsEncoder()],
     ]),
@@ -175,7 +172,7 @@ export function getCreateMasterEditionInstructionDataEncoder() {
 }
 
 export function getCreateMasterEditionInstructionDataDecoder() {
-  return getStructDecoder<CreateMasterEditionInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createMasterEditionArgs', getCreateMasterEditionArgsDecoder()],
   ]) satisfies Decoder<CreateMasterEditionInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
@@ -160,21 +160,21 @@ export type CreateMasterEditionV3InstructionDataArgs = {
   createMasterEditionArgs: CreateMasterEditionArgsArgs;
 };
 
-export function getCreateMasterEditionV3InstructionDataEncoder() {
+export function getCreateMasterEditionV3InstructionDataEncoder(): Encoder<CreateMasterEditionV3InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createMasterEditionArgs', getCreateMasterEditionArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 17 })
-  ) satisfies Encoder<CreateMasterEditionV3InstructionDataArgs>;
+  );
 }
 
-export function getCreateMasterEditionV3InstructionDataDecoder() {
+export function getCreateMasterEditionV3InstructionDataDecoder(): Decoder<CreateMasterEditionV3InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createMasterEditionArgs', getCreateMasterEditionArgsDecoder()],
-  ]) satisfies Decoder<CreateMasterEditionV3InstructionData>;
+  ]);
 }
 
 export function getCreateMasterEditionV3InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
@@ -162,10 +162,7 @@ export type CreateMasterEditionV3InstructionDataArgs = {
 
 export function getCreateMasterEditionV3InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      createMasterEditionArgs: CreateMasterEditionArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createMasterEditionArgs', getCreateMasterEditionArgsEncoder()],
     ]),
@@ -174,7 +171,7 @@ export function getCreateMasterEditionV3InstructionDataEncoder() {
 }
 
 export function getCreateMasterEditionV3InstructionDataDecoder() {
-  return getStructDecoder<CreateMasterEditionV3InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createMasterEditionArgs', getCreateMasterEditionArgsDecoder()],
   ]) satisfies Decoder<CreateMasterEditionV3InstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
@@ -178,7 +178,7 @@ export type CreateMetadataAccountInstructionDataArgs = {
   metadataBump: number;
 };
 
-export function getCreateMetadataAccountInstructionDataEncoder() {
+export function getCreateMetadataAccountInstructionDataEncoder(): Encoder<CreateMetadataAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -196,10 +196,10 @@ export function getCreateMetadataAccountInstructionDataEncoder() {
       ['metadataBump', getU8Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 0 })
-  ) satisfies Encoder<CreateMetadataAccountInstructionDataArgs>;
+  );
 }
 
-export function getCreateMetadataAccountInstructionDataDecoder() {
+export function getCreateMetadataAccountInstructionDataDecoder(): Decoder<CreateMetadataAccountInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
@@ -214,7 +214,7 @@ export function getCreateMetadataAccountInstructionDataDecoder() {
     ],
     ['isMutable', getBooleanDecoder()],
     ['metadataBump', getU8Decoder()],
-  ]) satisfies Decoder<CreateMetadataAccountInstructionData>;
+  ]);
 }
 
 export function getCreateMetadataAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
@@ -180,28 +180,11 @@ export type CreateMetadataAccountInstructionDataArgs = {
 
 export function getCreateMetadataAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      data: {
-        name: string;
-        symbol: string;
-        uri: string;
-        sellerFeeBasisPoints: number;
-        creators: OptionOrNullable<Array<CreatorArgs>>;
-      };
-      isMutable: boolean;
-      metadataBump: number;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       [
         'data',
-        getStructEncoder<{
-          name: string;
-          symbol: string;
-          uri: string;
-          sellerFeeBasisPoints: number;
-          creators: OptionOrNullable<Array<CreatorArgs>>;
-        }>([
+        getStructEncoder([
           ['name', getStringEncoder()],
           ['symbol', getStringEncoder()],
           ['uri', getStringEncoder()],
@@ -217,17 +200,11 @@ export function getCreateMetadataAccountInstructionDataEncoder() {
 }
 
 export function getCreateMetadataAccountInstructionDataDecoder() {
-  return getStructDecoder<CreateMetadataAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'data',
-      getStructDecoder<{
-        name: string;
-        symbol: string;
-        uri: string;
-        sellerFeeBasisPoints: number;
-        creators: Option<Array<Creator>>;
-      }>([
+      getStructDecoder([
         ['name', getStringDecoder()],
         ['symbol', getStringDecoder()],
         ['uri', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
@@ -142,11 +142,7 @@ export type CreateMetadataAccountV2InstructionDataArgs = {
 
 export function getCreateMetadataAccountV2InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      data: DataV2Args;
-      isMutable: boolean;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['data', getDataV2Encoder()],
       ['isMutable', getBooleanEncoder()],
@@ -156,7 +152,7 @@ export function getCreateMetadataAccountV2InstructionDataEncoder() {
 }
 
 export function getCreateMetadataAccountV2InstructionDataDecoder() {
-  return getStructDecoder<CreateMetadataAccountV2InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['data', getDataV2Decoder()],
     ['isMutable', getBooleanDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
@@ -140,7 +140,7 @@ export type CreateMetadataAccountV2InstructionDataArgs = {
   isMutable: boolean;
 };
 
-export function getCreateMetadataAccountV2InstructionDataEncoder() {
+export function getCreateMetadataAccountV2InstructionDataEncoder(): Encoder<CreateMetadataAccountV2InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -148,15 +148,15 @@ export function getCreateMetadataAccountV2InstructionDataEncoder() {
       ['isMutable', getBooleanEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 16 })
-  ) satisfies Encoder<CreateMetadataAccountV2InstructionDataArgs>;
+  );
 }
 
-export function getCreateMetadataAccountV2InstructionDataDecoder() {
+export function getCreateMetadataAccountV2InstructionDataDecoder(): Decoder<CreateMetadataAccountV2InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['data', getDataV2Decoder()],
     ['isMutable', getBooleanDecoder()],
-  ]) satisfies Decoder<CreateMetadataAccountV2InstructionData>;
+  ]);
 }
 
 export function getCreateMetadataAccountV2InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
@@ -154,7 +154,7 @@ export type CreateMetadataAccountV3InstructionDataArgs = {
   collectionDetails: OptionOrNullable<CollectionDetailsArgs>;
 };
 
-export function getCreateMetadataAccountV3InstructionDataEncoder() {
+export function getCreateMetadataAccountV3InstructionDataEncoder(): Encoder<CreateMetadataAccountV3InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -163,16 +163,16 @@ export function getCreateMetadataAccountV3InstructionDataEncoder() {
       ['collectionDetails', getOptionEncoder(getCollectionDetailsEncoder())],
     ]),
     (value) => ({ ...value, discriminator: 33 })
-  ) satisfies Encoder<CreateMetadataAccountV3InstructionDataArgs>;
+  );
 }
 
-export function getCreateMetadataAccountV3InstructionDataDecoder() {
+export function getCreateMetadataAccountV3InstructionDataDecoder(): Decoder<CreateMetadataAccountV3InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['data', getDataV2Decoder()],
     ['isMutable', getBooleanDecoder()],
     ['collectionDetails', getOptionDecoder(getCollectionDetailsDecoder())],
-  ]) satisfies Decoder<CreateMetadataAccountV3InstructionData>;
+  ]);
 }
 
 export function getCreateMetadataAccountV3InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
@@ -156,12 +156,7 @@ export type CreateMetadataAccountV3InstructionDataArgs = {
 
 export function getCreateMetadataAccountV3InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      data: DataV2Args;
-      isMutable: boolean;
-      collectionDetails: OptionOrNullable<CollectionDetailsArgs>;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['data', getDataV2Encoder()],
       ['isMutable', getBooleanEncoder()],
@@ -172,7 +167,7 @@ export function getCreateMetadataAccountV3InstructionDataEncoder() {
 }
 
 export function getCreateMetadataAccountV3InstructionDataDecoder() {
-  return getStructDecoder<CreateMetadataAccountV3InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['data', getDataV2Decoder()],
     ['isMutable', getBooleanDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
@@ -107,11 +107,7 @@ export type CreateRuleSetInstructionDataArgs = {
 
 export function getCreateRuleSetInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      createArgs: TaCreateArgsArgs;
-      ruleSetBump: number;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createArgs', getTaCreateArgsEncoder()],
       ['ruleSetBump', getU8Encoder()],
@@ -121,7 +117,7 @@ export function getCreateRuleSetInstructionDataEncoder() {
 }
 
 export function getCreateRuleSetInstructionDataDecoder() {
-  return getStructDecoder<CreateRuleSetInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createArgs', getTaCreateArgsDecoder()],
     ['ruleSetBump', getU8Decoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
@@ -105,7 +105,7 @@ export type CreateRuleSetInstructionDataArgs = {
   ruleSetBump: number;
 };
 
-export function getCreateRuleSetInstructionDataEncoder() {
+export function getCreateRuleSetInstructionDataEncoder(): Encoder<CreateRuleSetInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -113,15 +113,15 @@ export function getCreateRuleSetInstructionDataEncoder() {
       ['ruleSetBump', getU8Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 0 })
-  ) satisfies Encoder<CreateRuleSetInstructionDataArgs>;
+  );
 }
 
-export function getCreateRuleSetInstructionDataDecoder() {
+export function getCreateRuleSetInstructionDataDecoder(): Decoder<CreateRuleSetInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createArgs', getTaCreateArgsDecoder()],
     ['ruleSetBump', getU8Decoder()],
-  ]) satisfies Decoder<CreateRuleSetInstructionData>;
+  ]);
 }
 
 export function getCreateRuleSetInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV1.ts
@@ -176,7 +176,7 @@ export type CreateV1InstructionDataArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-export function getCreateV1InstructionDataEncoder() {
+export function getCreateV1InstructionDataEncoder(): Encoder<CreateV1InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -186,17 +186,17 @@ export function getCreateV1InstructionDataEncoder() {
       ['maxSupply', getOptionEncoder(getU64Encoder())],
     ]),
     (value) => ({ ...value, discriminator: 41, createV1Discriminator: 0 })
-  ) satisfies Encoder<CreateV1InstructionDataArgs>;
+  );
 }
 
-export function getCreateV1InstructionDataDecoder() {
+export function getCreateV1InstructionDataDecoder(): Decoder<CreateV1InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createV1Discriminator', getU8Decoder()],
     ['assetData', getAssetDataDecoder()],
     ['decimals', getOptionDecoder(getU8Decoder())],
     ['maxSupply', getOptionDecoder(getU64Decoder())],
-  ]) satisfies Decoder<CreateV1InstructionData>;
+  ]);
 }
 
 export function getCreateV1InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/createV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV1.ts
@@ -178,13 +178,7 @@ export type CreateV1InstructionDataArgs = {
 
 export function getCreateV1InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      createV1Discriminator: number;
-      assetData: AssetDataArgs;
-      decimals: OptionOrNullable<number>;
-      maxSupply: OptionOrNullable<number | bigint>;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createV1Discriminator', getU8Encoder()],
       ['assetData', getAssetDataEncoder()],
@@ -196,7 +190,7 @@ export function getCreateV1InstructionDataEncoder() {
 }
 
 export function getCreateV1InstructionDataDecoder() {
-  return getStructDecoder<CreateV1InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createV1Discriminator', getU8Decoder()],
     ['assetData', getAssetDataDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV2.ts
@@ -176,12 +176,7 @@ export type CreateV2InstructionDataArgs = {
 
 export function getCreateV2InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      createV2Discriminator: number;
-      assetData: AssetDataArgs;
-      maxSupply: OptionOrNullable<number | bigint>;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createV2Discriminator', getU8Encoder()],
       ['assetData', getAssetDataEncoder()],
@@ -192,7 +187,7 @@ export function getCreateV2InstructionDataEncoder() {
 }
 
 export function getCreateV2InstructionDataDecoder() {
-  return getStructDecoder<CreateV2InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createV2Discriminator', getU8Decoder()],
     ['assetData', getAssetDataDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/createV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV2.ts
@@ -174,7 +174,7 @@ export type CreateV2InstructionDataArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-export function getCreateV2InstructionDataEncoder() {
+export function getCreateV2InstructionDataEncoder(): Encoder<CreateV2InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -183,16 +183,16 @@ export function getCreateV2InstructionDataEncoder() {
       ['maxSupply', getOptionEncoder(getU64Encoder())],
     ]),
     (value) => ({ ...value, discriminator: 41, createV2Discriminator: 1 })
-  ) satisfies Encoder<CreateV2InstructionDataArgs>;
+  );
 }
 
-export function getCreateV2InstructionDataDecoder() {
+export function getCreateV2InstructionDataDecoder(): Decoder<CreateV2InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createV2Discriminator', getU8Decoder()],
     ['assetData', getAssetDataDecoder()],
     ['maxSupply', getOptionDecoder(getU64Decoder())],
-  ]) satisfies Decoder<CreateV2InstructionData>;
+  ]);
 }
 
 export function getCreateV2InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/delegate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/delegate.ts
@@ -192,18 +192,16 @@ export type DelegateInstructionDataArgs = { delegateArgs: DelegateArgsArgs };
 
 export function getDelegateInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; delegateArgs: DelegateArgsArgs }>(
-      [
-        ['discriminator', getU8Encoder()],
-        ['delegateArgs', getDelegateArgsEncoder()],
-      ]
-    ),
+    getStructEncoder([
+      ['discriminator', getU8Encoder()],
+      ['delegateArgs', getDelegateArgsEncoder()],
+    ]),
     (value) => ({ ...value, discriminator: 48 })
   ) satisfies Encoder<DelegateInstructionDataArgs>;
 }
 
 export function getDelegateInstructionDataDecoder() {
-  return getStructDecoder<DelegateInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['delegateArgs', getDelegateArgsDecoder()],
   ]) satisfies Decoder<DelegateInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/delegate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/delegate.ts
@@ -190,21 +190,21 @@ export type DelegateInstructionData = {
 
 export type DelegateInstructionDataArgs = { delegateArgs: DelegateArgsArgs };
 
-export function getDelegateInstructionDataEncoder() {
+export function getDelegateInstructionDataEncoder(): Encoder<DelegateInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['delegateArgs', getDelegateArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 48 })
-  ) satisfies Encoder<DelegateInstructionDataArgs>;
+  );
 }
 
-export function getDelegateInstructionDataDecoder() {
+export function getDelegateInstructionDataDecoder(): Decoder<DelegateInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['delegateArgs', getDelegateArgsDecoder()],
-  ]) satisfies Decoder<DelegateInstructionData>;
+  ]);
 }
 
 export function getDelegateInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
@@ -204,10 +204,7 @@ export type DeprecatedCreateMasterEditionInstructionDataArgs = {
 
 export function getDeprecatedCreateMasterEditionInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      createMasterEditionArgs: CreateMasterEditionArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createMasterEditionArgs', getCreateMasterEditionArgsEncoder()],
     ]),
@@ -216,7 +213,7 @@ export function getDeprecatedCreateMasterEditionInstructionDataEncoder() {
 }
 
 export function getDeprecatedCreateMasterEditionInstructionDataDecoder() {
-  return getStructDecoder<DeprecatedCreateMasterEditionInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createMasterEditionArgs', getCreateMasterEditionArgsDecoder()],
   ]) satisfies Decoder<DeprecatedCreateMasterEditionInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
@@ -202,21 +202,21 @@ export type DeprecatedCreateMasterEditionInstructionDataArgs = {
   createMasterEditionArgs: CreateMasterEditionArgsArgs;
 };
 
-export function getDeprecatedCreateMasterEditionInstructionDataEncoder() {
+export function getDeprecatedCreateMasterEditionInstructionDataEncoder(): Encoder<DeprecatedCreateMasterEditionInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['createMasterEditionArgs', getCreateMasterEditionArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 2 })
-  ) satisfies Encoder<DeprecatedCreateMasterEditionInstructionDataArgs>;
+  );
 }
 
-export function getDeprecatedCreateMasterEditionInstructionDataDecoder() {
+export function getDeprecatedCreateMasterEditionInstructionDataDecoder(): Decoder<DeprecatedCreateMasterEditionInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['createMasterEditionArgs', getCreateMasterEditionArgsDecoder()],
-  ]) satisfies Decoder<DeprecatedCreateMasterEditionInstructionData>;
+  ]);
 }
 
 export function getDeprecatedCreateMasterEditionInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -207,17 +207,15 @@ export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction
 export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs =
   {};
 
-export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataEncoder() {
+export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataEncoder(): Encoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 3 })
-  ) satisfies Encoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs>;
+  );
 }
 
-export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData>;
+export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataDecoder(): Decoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -209,17 +209,15 @@ export type DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction
 
 export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 3 })
   ) satisfies Encoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataArgs>;
 }
 
 export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataDecoder() {
-  return getStructDecoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData>(
-    [['discriminator', getU8Decoder()]]
-  ) satisfies Decoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData>;
+  return getStructDecoder([
+    ['discriminator', getU8Decoder()],
+  ]) satisfies Decoder<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData>;
 }
 
 export function getDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
@@ -138,7 +138,7 @@ export type DeprecatedMintPrintingTokensInstructionDataArgs = {
   mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgsArgs;
 };
 
-export function getDeprecatedMintPrintingTokensInstructionDataEncoder() {
+export function getDeprecatedMintPrintingTokensInstructionDataEncoder(): Encoder<DeprecatedMintPrintingTokensInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -148,17 +148,17 @@ export function getDeprecatedMintPrintingTokensInstructionDataEncoder() {
       ],
     ]),
     (value) => ({ ...value, discriminator: 9 })
-  ) satisfies Encoder<DeprecatedMintPrintingTokensInstructionDataArgs>;
+  );
 }
 
-export function getDeprecatedMintPrintingTokensInstructionDataDecoder() {
+export function getDeprecatedMintPrintingTokensInstructionDataDecoder(): Decoder<DeprecatedMintPrintingTokensInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'mintPrintingTokensViaTokenArgs',
       getMintPrintingTokensViaTokenArgsDecoder(),
     ],
-  ]) satisfies Decoder<DeprecatedMintPrintingTokensInstructionData>;
+  ]);
 }
 
 export function getDeprecatedMintPrintingTokensInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
@@ -140,10 +140,7 @@ export type DeprecatedMintPrintingTokensInstructionDataArgs = {
 
 export function getDeprecatedMintPrintingTokensInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       [
         'mintPrintingTokensViaTokenArgs',
@@ -155,7 +152,7 @@ export function getDeprecatedMintPrintingTokensInstructionDataEncoder() {
 }
 
 export function getDeprecatedMintPrintingTokensInstructionDataDecoder() {
-  return getStructDecoder<DeprecatedMintPrintingTokensInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'mintPrintingTokensViaTokenArgs',

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
@@ -160,10 +160,7 @@ export type DeprecatedMintPrintingTokensViaTokenInstructionDataArgs = {
 
 export function getDeprecatedMintPrintingTokensViaTokenInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       [
         'mintPrintingTokensViaTokenArgs',
@@ -175,7 +172,7 @@ export function getDeprecatedMintPrintingTokensViaTokenInstructionDataEncoder() 
 }
 
 export function getDeprecatedMintPrintingTokensViaTokenInstructionDataDecoder() {
-  return getStructDecoder<DeprecatedMintPrintingTokensViaTokenInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'mintPrintingTokensViaTokenArgs',

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
@@ -158,7 +158,7 @@ export type DeprecatedMintPrintingTokensViaTokenInstructionDataArgs = {
   mintPrintingTokensViaTokenArgs: MintPrintingTokensViaTokenArgsArgs;
 };
 
-export function getDeprecatedMintPrintingTokensViaTokenInstructionDataEncoder() {
+export function getDeprecatedMintPrintingTokensViaTokenInstructionDataEncoder(): Encoder<DeprecatedMintPrintingTokensViaTokenInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -168,17 +168,17 @@ export function getDeprecatedMintPrintingTokensViaTokenInstructionDataEncoder() 
       ],
     ]),
     (value) => ({ ...value, discriminator: 8 })
-  ) satisfies Encoder<DeprecatedMintPrintingTokensViaTokenInstructionDataArgs>;
+  );
 }
 
-export function getDeprecatedMintPrintingTokensViaTokenInstructionDataDecoder() {
+export function getDeprecatedMintPrintingTokensViaTokenInstructionDataDecoder(): Decoder<DeprecatedMintPrintingTokensViaTokenInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'mintPrintingTokensViaTokenArgs',
       getMintPrintingTokensViaTokenArgsDecoder(),
     ],
-  ]) satisfies Decoder<DeprecatedMintPrintingTokensViaTokenInstructionData>;
+  ]);
 }
 
 export function getDeprecatedMintPrintingTokensViaTokenInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
@@ -116,7 +116,7 @@ export type DeprecatedSetReservationListInstructionDataArgs = {
   totalSpotOffset: number | bigint;
 };
 
-export function getDeprecatedSetReservationListInstructionDataEncoder() {
+export function getDeprecatedSetReservationListInstructionDataEncoder(): Encoder<DeprecatedSetReservationListInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -126,17 +126,17 @@ export function getDeprecatedSetReservationListInstructionDataEncoder() {
       ['totalSpotOffset', getU64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 5 })
-  ) satisfies Encoder<DeprecatedSetReservationListInstructionDataArgs>;
+  );
 }
 
-export function getDeprecatedSetReservationListInstructionDataDecoder() {
+export function getDeprecatedSetReservationListInstructionDataDecoder(): Decoder<DeprecatedSetReservationListInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['reservations', getArrayDecoder(getReservationDecoder())],
     ['totalReservationSpots', getOptionDecoder(getU64Decoder())],
     ['offset', getU64Decoder()],
     ['totalSpotOffset', getU64Decoder()],
-  ]) satisfies Decoder<DeprecatedSetReservationListInstructionData>;
+  ]);
 }
 
 export function getDeprecatedSetReservationListInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
@@ -118,13 +118,7 @@ export type DeprecatedSetReservationListInstructionDataArgs = {
 
 export function getDeprecatedSetReservationListInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      reservations: Array<ReservationArgs>;
-      totalReservationSpots: OptionOrNullable<number | bigint>;
-      offset: number | bigint;
-      totalSpotOffset: number | bigint;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['reservations', getArrayEncoder(getReservationEncoder())],
       ['totalReservationSpots', getOptionEncoder(getU64Encoder())],
@@ -136,7 +130,7 @@ export function getDeprecatedSetReservationListInstructionDataEncoder() {
 }
 
 export function getDeprecatedSetReservationListInstructionDataDecoder() {
-  return getStructDecoder<DeprecatedSetReservationListInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['reservations', getArrayDecoder(getReservationDecoder())],
     ['totalReservationSpots', getOptionDecoder(getU64Decoder())],

--- a/test/packages/js-experimental/src/generated/instructions/dummy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/dummy.ts
@@ -157,7 +157,7 @@ export type DummyInstructionDataArgs = {};
 
 export function getDummyInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: Array<number> }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
     ]),
     (value) => ({
@@ -168,7 +168,7 @@ export function getDummyInstructionDataEncoder() {
 }
 
 export function getDummyInstructionDataDecoder() {
-  return getStructDecoder<DummyInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
   ]) satisfies Decoder<DummyInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/dummy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/dummy.ts
@@ -155,7 +155,7 @@ export type DummyInstructionData = { discriminator: Array<number> };
 
 export type DummyInstructionDataArgs = {};
 
-export function getDummyInstructionDataEncoder() {
+export function getDummyInstructionDataEncoder(): Encoder<DummyInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -164,13 +164,13 @@ export function getDummyInstructionDataEncoder() {
       ...value,
       discriminator: [167, 117, 211, 79, 251, 254, 47, 135],
     })
-  ) satisfies Encoder<DummyInstructionDataArgs>;
+  );
 }
 
-export function getDummyInstructionDataDecoder() {
+export function getDummyInstructionDataDecoder(): Decoder<DummyInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
-  ]) satisfies Decoder<DummyInstructionData>;
+  ]);
 }
 
 export function getDummyInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
@@ -109,15 +109,13 @@ export type FreezeDelegatedAccountInstructionDataArgs = {};
 
 export function getFreezeDelegatedAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 26 })
   ) satisfies Encoder<FreezeDelegatedAccountInstructionDataArgs>;
 }
 
 export function getFreezeDelegatedAccountInstructionDataDecoder() {
-  return getStructDecoder<FreezeDelegatedAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<FreezeDelegatedAccountInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
@@ -107,17 +107,15 @@ export type FreezeDelegatedAccountInstructionData = { discriminator: number };
 
 export type FreezeDelegatedAccountInstructionDataArgs = {};
 
-export function getFreezeDelegatedAccountInstructionDataEncoder() {
+export function getFreezeDelegatedAccountInstructionDataEncoder(): Encoder<FreezeDelegatedAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 26 })
-  ) satisfies Encoder<FreezeDelegatedAccountInstructionDataArgs>;
+  );
 }
 
-export function getFreezeDelegatedAccountInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<FreezeDelegatedAccountInstructionData>;
+export function getFreezeDelegatedAccountInstructionDataDecoder(): Decoder<FreezeDelegatedAccountInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getFreezeDelegatedAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/initialize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/initialize.ts
@@ -186,10 +186,7 @@ export type InitializeInstructionDataArgs = { data: CandyMachineDataArgs };
 
 export function getInitializeInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: Array<number>;
-      data: CandyMachineDataArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
       ['data', getCandyMachineDataEncoder()],
     ]),
@@ -201,7 +198,7 @@ export function getInitializeInstructionDataEncoder() {
 }
 
 export function getInitializeInstructionDataDecoder() {
-  return getStructDecoder<InitializeInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['data', getCandyMachineDataDecoder()],
   ]) satisfies Decoder<InitializeInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/initialize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/initialize.ts
@@ -184,7 +184,7 @@ export type InitializeInstructionData = {
 
 export type InitializeInstructionDataArgs = { data: CandyMachineDataArgs };
 
-export function getInitializeInstructionDataEncoder() {
+export function getInitializeInstructionDataEncoder(): Encoder<InitializeInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -194,14 +194,14 @@ export function getInitializeInstructionDataEncoder() {
       ...value,
       discriminator: [175, 175, 109, 31, 13, 152, 155, 237],
     })
-  ) satisfies Encoder<InitializeInstructionDataArgs>;
+  );
 }
 
-export function getInitializeInstructionDataDecoder() {
+export function getInitializeInstructionDataDecoder(): Decoder<InitializeInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['data', getCandyMachineDataDecoder()],
-  ]) satisfies Decoder<InitializeInstructionData>;
+  ]);
 }
 
 export function getInitializeInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/migrate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/migrate.ts
@@ -166,7 +166,7 @@ export type MigrateInstructionDataArgs = { migrateArgs: MigrateArgsArgs };
 
 export function getMigrateInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; migrateArgs: MigrateArgsArgs }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['migrateArgs', getMigrateArgsEncoder()],
     ]),
@@ -175,7 +175,7 @@ export function getMigrateInstructionDataEncoder() {
 }
 
 export function getMigrateInstructionDataDecoder() {
-  return getStructDecoder<MigrateInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['migrateArgs', getMigrateArgsDecoder()],
   ]) satisfies Decoder<MigrateInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/migrate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/migrate.ts
@@ -164,21 +164,21 @@ export type MigrateInstructionData = {
 
 export type MigrateInstructionDataArgs = { migrateArgs: MigrateArgsArgs };
 
-export function getMigrateInstructionDataEncoder() {
+export function getMigrateInstructionDataEncoder(): Encoder<MigrateInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['migrateArgs', getMigrateArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 50 })
-  ) satisfies Encoder<MigrateInstructionDataArgs>;
+  );
 }
 
-export function getMigrateInstructionDataDecoder() {
+export function getMigrateInstructionDataDecoder(): Decoder<MigrateInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['migrateArgs', getMigrateArgsDecoder()],
-  ]) satisfies Decoder<MigrateInstructionData>;
+  ]);
 }
 
 export function getMigrateInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/mint.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mint.ts
@@ -187,21 +187,21 @@ export type MintInstructionData = { discriminator: number; mintArgs: MintArgs };
 
 export type MintInstructionDataArgs = { mintArgs: MintArgsArgs };
 
-export function getMintInstructionDataEncoder() {
+export function getMintInstructionDataEncoder(): Encoder<MintInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['mintArgs', getMintArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 42 })
-  ) satisfies Encoder<MintInstructionDataArgs>;
+  );
 }
 
-export function getMintInstructionDataDecoder() {
+export function getMintInstructionDataDecoder(): Decoder<MintInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['mintArgs', getMintArgsDecoder()],
-  ]) satisfies Decoder<MintInstructionData>;
+  ]);
 }
 
 export function getMintInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/mint.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mint.ts
@@ -189,7 +189,7 @@ export type MintInstructionDataArgs = { mintArgs: MintArgsArgs };
 
 export function getMintInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; mintArgs: MintArgsArgs }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['mintArgs', getMintArgsEncoder()],
     ]),
@@ -198,7 +198,7 @@ export function getMintInstructionDataEncoder() {
 }
 
 export function getMintInstructionDataDecoder() {
-  return getStructDecoder<MintInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['mintArgs', getMintArgsDecoder()],
   ]) satisfies Decoder<MintInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
@@ -232,7 +232,7 @@ export type MintFromCandyMachineInstructionDataArgs = {};
 
 export function getMintFromCandyMachineInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: Array<number> }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
     ]),
     (value) => ({
@@ -243,7 +243,7 @@ export function getMintFromCandyMachineInstructionDataEncoder() {
 }
 
 export function getMintFromCandyMachineInstructionDataDecoder() {
-  return getStructDecoder<MintFromCandyMachineInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
   ]) satisfies Decoder<MintFromCandyMachineInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
@@ -230,7 +230,7 @@ export type MintFromCandyMachineInstructionData = {
 
 export type MintFromCandyMachineInstructionDataArgs = {};
 
-export function getMintFromCandyMachineInstructionDataEncoder() {
+export function getMintFromCandyMachineInstructionDataEncoder(): Encoder<MintFromCandyMachineInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -239,13 +239,13 @@ export function getMintFromCandyMachineInstructionDataEncoder() {
       ...value,
       discriminator: [51, 57, 225, 47, 182, 146, 137, 166],
     })
-  ) satisfies Encoder<MintFromCandyMachineInstructionDataArgs>;
+  );
 }
 
-export function getMintFromCandyMachineInstructionDataDecoder() {
+export function getMintFromCandyMachineInstructionDataDecoder(): Decoder<MintFromCandyMachineInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
-  ]) satisfies Decoder<MintFromCandyMachineInstructionData>;
+  ]);
 }
 
 export function getMintFromCandyMachineInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
@@ -201,7 +201,7 @@ export type MintNewEditionFromMasterEditionViaTokenInstructionDataArgs = {
   mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgsArgs;
 };
 
-export function getMintNewEditionFromMasterEditionViaTokenInstructionDataEncoder() {
+export function getMintNewEditionFromMasterEditionViaTokenInstructionDataEncoder(): Encoder<MintNewEditionFromMasterEditionViaTokenInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -211,17 +211,17 @@ export function getMintNewEditionFromMasterEditionViaTokenInstructionDataEncoder
       ],
     ]),
     (value) => ({ ...value, discriminator: 11 })
-  ) satisfies Encoder<MintNewEditionFromMasterEditionViaTokenInstructionDataArgs>;
+  );
 }
 
-export function getMintNewEditionFromMasterEditionViaTokenInstructionDataDecoder() {
+export function getMintNewEditionFromMasterEditionViaTokenInstructionDataDecoder(): Decoder<MintNewEditionFromMasterEditionViaTokenInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'mintNewEditionFromMasterEditionViaTokenArgs',
       getMintNewEditionFromMasterEditionViaTokenArgsDecoder(),
     ],
-  ]) satisfies Decoder<MintNewEditionFromMasterEditionViaTokenInstructionData>;
+  ]);
 }
 
 export function getMintNewEditionFromMasterEditionViaTokenInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
@@ -203,10 +203,7 @@ export type MintNewEditionFromMasterEditionViaTokenInstructionDataArgs = {
 
 export function getMintNewEditionFromMasterEditionViaTokenInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       [
         'mintNewEditionFromMasterEditionViaTokenArgs',
@@ -218,15 +215,13 @@ export function getMintNewEditionFromMasterEditionViaTokenInstructionDataEncoder
 }
 
 export function getMintNewEditionFromMasterEditionViaTokenInstructionDataDecoder() {
-  return getStructDecoder<MintNewEditionFromMasterEditionViaTokenInstructionData>(
+  return getStructDecoder([
+    ['discriminator', getU8Decoder()],
     [
-      ['discriminator', getU8Decoder()],
-      [
-        'mintNewEditionFromMasterEditionViaTokenArgs',
-        getMintNewEditionFromMasterEditionViaTokenArgsDecoder(),
-      ],
-    ]
-  ) satisfies Decoder<MintNewEditionFromMasterEditionViaTokenInstructionData>;
+      'mintNewEditionFromMasterEditionViaTokenArgs',
+      getMintNewEditionFromMasterEditionViaTokenArgsDecoder(),
+    ],
+  ]) satisfies Decoder<MintNewEditionFromMasterEditionViaTokenInstructionData>;
 }
 
 export function getMintNewEditionFromMasterEditionViaTokenInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -227,10 +227,7 @@ export type MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs = {
 
 export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       [
         'mintNewEditionFromMasterEditionViaTokenArgs',
@@ -242,15 +239,13 @@ export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataEn
 }
 
 export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataDecoder() {
-  return getStructDecoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionData>(
+  return getStructDecoder([
+    ['discriminator', getU8Decoder()],
     [
-      ['discriminator', getU8Decoder()],
-      [
-        'mintNewEditionFromMasterEditionViaTokenArgs',
-        getMintNewEditionFromMasterEditionViaTokenArgsDecoder(),
-      ],
-    ]
-  ) satisfies Decoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionData>;
+      'mintNewEditionFromMasterEditionViaTokenArgs',
+      getMintNewEditionFromMasterEditionViaTokenArgsDecoder(),
+    ],
+  ]) satisfies Decoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionData>;
 }
 
 export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -225,7 +225,7 @@ export type MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs = {
   mintNewEditionFromMasterEditionViaTokenArgs: MintNewEditionFromMasterEditionViaTokenArgsArgs;
 };
 
-export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataEncoder() {
+export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataEncoder(): Encoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -235,17 +235,17 @@ export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataEn
       ],
     ]),
     (value) => ({ ...value, discriminator: 13 })
-  ) satisfies Encoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionDataArgs>;
+  );
 }
 
-export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataDecoder() {
+export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataDecoder(): Decoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'mintNewEditionFromMasterEditionViaTokenArgs',
       getMintNewEditionFromMasterEditionViaTokenArgsDecoder(),
     ],
-  ]) satisfies Decoder<MintNewEditionFromMasterEditionViaVaultProxyInstructionData>;
+  ]);
 }
 
 export function getMintNewEditionFromMasterEditionViaVaultProxyInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
@@ -67,17 +67,15 @@ export type PuffMetadataInstructionData = { discriminator: number };
 
 export type PuffMetadataInstructionDataArgs = {};
 
-export function getPuffMetadataInstructionDataEncoder() {
+export function getPuffMetadataInstructionDataEncoder(): Encoder<PuffMetadataInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 14 })
-  ) satisfies Encoder<PuffMetadataInstructionDataArgs>;
+  );
 }
 
-export function getPuffMetadataInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<PuffMetadataInstructionData>;
+export function getPuffMetadataInstructionDataDecoder(): Decoder<PuffMetadataInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getPuffMetadataInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
@@ -69,15 +69,13 @@ export type PuffMetadataInstructionDataArgs = {};
 
 export function getPuffMetadataInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 14 })
   ) satisfies Encoder<PuffMetadataInstructionDataArgs>;
 }
 
 export function getPuffMetadataInstructionDataDecoder() {
-  return getStructDecoder<PuffMetadataInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<PuffMetadataInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
+++ b/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
@@ -80,17 +80,15 @@ export type RemoveCreatorVerificationInstructionData = {
 
 export type RemoveCreatorVerificationInstructionDataArgs = {};
 
-export function getRemoveCreatorVerificationInstructionDataEncoder() {
+export function getRemoveCreatorVerificationInstructionDataEncoder(): Encoder<RemoveCreatorVerificationInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 28 })
-  ) satisfies Encoder<RemoveCreatorVerificationInstructionDataArgs>;
+  );
 }
 
-export function getRemoveCreatorVerificationInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<RemoveCreatorVerificationInstructionData>;
+export function getRemoveCreatorVerificationInstructionDataDecoder(): Decoder<RemoveCreatorVerificationInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getRemoveCreatorVerificationInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
+++ b/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
@@ -82,15 +82,13 @@ export type RemoveCreatorVerificationInstructionDataArgs = {};
 
 export function getRemoveCreatorVerificationInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 28 })
   ) satisfies Encoder<RemoveCreatorVerificationInstructionDataArgs>;
 }
 
 export function getRemoveCreatorVerificationInstructionDataDecoder() {
-  return getStructDecoder<RemoveCreatorVerificationInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<RemoveCreatorVerificationInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/revoke.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revoke.ts
@@ -192,7 +192,7 @@ export type RevokeInstructionDataArgs = { revokeArgs: RevokeArgsArgs };
 
 export function getRevokeInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; revokeArgs: RevokeArgsArgs }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['revokeArgs', getRevokeArgsEncoder()],
     ]),
@@ -201,7 +201,7 @@ export function getRevokeInstructionDataEncoder() {
 }
 
 export function getRevokeInstructionDataDecoder() {
-  return getStructDecoder<RevokeInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['revokeArgs', getRevokeArgsDecoder()],
   ]) satisfies Decoder<RevokeInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/revoke.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revoke.ts
@@ -190,21 +190,21 @@ export type RevokeInstructionData = {
 
 export type RevokeInstructionDataArgs = { revokeArgs: RevokeArgsArgs };
 
-export function getRevokeInstructionDataEncoder() {
+export function getRevokeInstructionDataEncoder(): Encoder<RevokeInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['revokeArgs', getRevokeArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 49 })
-  ) satisfies Encoder<RevokeInstructionDataArgs>;
+  );
 }
 
-export function getRevokeInstructionDataDecoder() {
+export function getRevokeInstructionDataDecoder(): Decoder<RevokeInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['revokeArgs', getRevokeArgsDecoder()],
-  ]) satisfies Decoder<RevokeInstructionData>;
+  ]);
 }
 
 export function getRevokeInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
@@ -111,15 +111,13 @@ export type RevokeCollectionAuthorityInstructionDataArgs = {};
 
 export function getRevokeCollectionAuthorityInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 24 })
   ) satisfies Encoder<RevokeCollectionAuthorityInstructionDataArgs>;
 }
 
 export function getRevokeCollectionAuthorityInstructionDataDecoder() {
-  return getStructDecoder<RevokeCollectionAuthorityInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<RevokeCollectionAuthorityInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
@@ -109,17 +109,15 @@ export type RevokeCollectionAuthorityInstructionData = {
 
 export type RevokeCollectionAuthorityInstructionDataArgs = {};
 
-export function getRevokeCollectionAuthorityInstructionDataEncoder() {
+export function getRevokeCollectionAuthorityInstructionDataEncoder(): Encoder<RevokeCollectionAuthorityInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 24 })
-  ) satisfies Encoder<RevokeCollectionAuthorityInstructionDataArgs>;
+  );
 }
 
-export function getRevokeCollectionAuthorityInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<RevokeCollectionAuthorityInstructionData>;
+export function getRevokeCollectionAuthorityInstructionDataDecoder(): Decoder<RevokeCollectionAuthorityInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getRevokeCollectionAuthorityInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
@@ -145,15 +145,13 @@ export type RevokeUseAuthorityInstructionDataArgs = {};
 
 export function getRevokeUseAuthorityInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 21 })
   ) satisfies Encoder<RevokeUseAuthorityInstructionDataArgs>;
 }
 
 export function getRevokeUseAuthorityInstructionDataDecoder() {
-  return getStructDecoder<RevokeUseAuthorityInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<RevokeUseAuthorityInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
@@ -143,17 +143,15 @@ export type RevokeUseAuthorityInstructionData = { discriminator: number };
 
 export type RevokeUseAuthorityInstructionDataArgs = {};
 
-export function getRevokeUseAuthorityInstructionDataEncoder() {
+export function getRevokeUseAuthorityInstructionDataEncoder(): Encoder<RevokeUseAuthorityInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 21 })
-  ) satisfies Encoder<RevokeUseAuthorityInstructionDataArgs>;
+  );
 }
 
-export function getRevokeUseAuthorityInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<RevokeUseAuthorityInstructionData>;
+export function getRevokeUseAuthorityInstructionDataDecoder(): Decoder<RevokeUseAuthorityInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getRevokeUseAuthorityInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
@@ -138,15 +138,13 @@ export type SetAndVerifyCollectionInstructionDataArgs = {};
 
 export function getSetAndVerifyCollectionInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 25 })
   ) satisfies Encoder<SetAndVerifyCollectionInstructionDataArgs>;
 }
 
 export function getSetAndVerifyCollectionInstructionDataDecoder() {
-  return getStructDecoder<SetAndVerifyCollectionInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<SetAndVerifyCollectionInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
@@ -136,17 +136,15 @@ export type SetAndVerifyCollectionInstructionData = { discriminator: number };
 
 export type SetAndVerifyCollectionInstructionDataArgs = {};
 
-export function getSetAndVerifyCollectionInstructionDataEncoder() {
+export function getSetAndVerifyCollectionInstructionDataEncoder(): Encoder<SetAndVerifyCollectionInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 25 })
-  ) satisfies Encoder<SetAndVerifyCollectionInstructionDataArgs>;
+  );
 }
 
-export function getSetAndVerifyCollectionInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<SetAndVerifyCollectionInstructionData>;
+export function getSetAndVerifyCollectionInstructionDataDecoder(): Decoder<SetAndVerifyCollectionInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getSetAndVerifyCollectionInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -139,17 +139,15 @@ export type SetAndVerifySizedCollectionItemInstructionData = {
 
 export type SetAndVerifySizedCollectionItemInstructionDataArgs = {};
 
-export function getSetAndVerifySizedCollectionItemInstructionDataEncoder() {
+export function getSetAndVerifySizedCollectionItemInstructionDataEncoder(): Encoder<SetAndVerifySizedCollectionItemInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 32 })
-  ) satisfies Encoder<SetAndVerifySizedCollectionItemInstructionDataArgs>;
+  );
 }
 
-export function getSetAndVerifySizedCollectionItemInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<SetAndVerifySizedCollectionItemInstructionData>;
+export function getSetAndVerifySizedCollectionItemInstructionDataDecoder(): Decoder<SetAndVerifySizedCollectionItemInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getSetAndVerifySizedCollectionItemInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -141,15 +141,13 @@ export type SetAndVerifySizedCollectionItemInstructionDataArgs = {};
 
 export function getSetAndVerifySizedCollectionItemInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 32 })
   ) satisfies Encoder<SetAndVerifySizedCollectionItemInstructionDataArgs>;
 }
 
 export function getSetAndVerifySizedCollectionItemInstructionDataDecoder() {
-  return getStructDecoder<SetAndVerifySizedCollectionItemInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<SetAndVerifySizedCollectionItemInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
@@ -89,7 +89,7 @@ export type SetAuthorityInstructionDataArgs = { newAuthority: Address };
 
 export function getSetAuthorityInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: Array<number>; newAuthority: Address }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
       ['newAuthority', getAddressEncoder()],
     ]),
@@ -101,7 +101,7 @@ export function getSetAuthorityInstructionDataEncoder() {
 }
 
 export function getSetAuthorityInstructionDataDecoder() {
-  return getStructDecoder<SetAuthorityInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['newAuthority', getAddressDecoder()],
   ]) satisfies Decoder<SetAuthorityInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
@@ -87,7 +87,7 @@ export type SetAuthorityInstructionData = {
 
 export type SetAuthorityInstructionDataArgs = { newAuthority: Address };
 
-export function getSetAuthorityInstructionDataEncoder() {
+export function getSetAuthorityInstructionDataEncoder(): Encoder<SetAuthorityInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -97,14 +97,14 @@ export function getSetAuthorityInstructionDataEncoder() {
       ...value,
       discriminator: [133, 250, 37, 21, 110, 163, 26, 121],
     })
-  ) satisfies Encoder<SetAuthorityInstructionDataArgs>;
+  );
 }
 
-export function getSetAuthorityInstructionDataDecoder() {
+export function getSetAuthorityInstructionDataDecoder(): Decoder<SetAuthorityInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['newAuthority', getAddressDecoder()],
-  ]) satisfies Decoder<SetAuthorityInstructionData>;
+  ]);
 }
 
 export function getSetAuthorityInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollection.ts
@@ -206,7 +206,7 @@ export type SetCollectionInstructionDataArgs = {};
 
 export function getSetCollectionInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: Array<number> }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
     ]),
     (value) => ({
@@ -217,7 +217,7 @@ export function getSetCollectionInstructionDataEncoder() {
 }
 
 export function getSetCollectionInstructionDataDecoder() {
-  return getStructDecoder<SetCollectionInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
   ]) satisfies Decoder<SetCollectionInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/setCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollection.ts
@@ -204,7 +204,7 @@ export type SetCollectionInstructionData = { discriminator: Array<number> };
 
 export type SetCollectionInstructionDataArgs = {};
 
-export function getSetCollectionInstructionDataEncoder() {
+export function getSetCollectionInstructionDataEncoder(): Encoder<SetCollectionInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -213,13 +213,13 @@ export function getSetCollectionInstructionDataEncoder() {
       ...value,
       discriminator: [192, 254, 206, 76, 168, 182, 59, 223],
     })
-  ) satisfies Encoder<SetCollectionInstructionDataArgs>;
+  );
 }
 
-export function getSetCollectionInstructionDataDecoder() {
+export function getSetCollectionInstructionDataDecoder(): Decoder<SetCollectionInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
-  ]) satisfies Decoder<SetCollectionInstructionData>;
+  ]);
 }
 
 export function getSetCollectionInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
@@ -110,21 +110,21 @@ export type SetCollectionSizeInstructionDataArgs = {
   setCollectionSizeArgs: SetCollectionSizeArgsArgs;
 };
 
-export function getSetCollectionSizeInstructionDataEncoder() {
+export function getSetCollectionSizeInstructionDataEncoder(): Encoder<SetCollectionSizeInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['setCollectionSizeArgs', getSetCollectionSizeArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 34 })
-  ) satisfies Encoder<SetCollectionSizeInstructionDataArgs>;
+  );
 }
 
-export function getSetCollectionSizeInstructionDataDecoder() {
+export function getSetCollectionSizeInstructionDataDecoder(): Decoder<SetCollectionSizeInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['setCollectionSizeArgs', getSetCollectionSizeArgsDecoder()],
-  ]) satisfies Decoder<SetCollectionSizeInstructionData>;
+  ]);
 }
 
 export function getSetCollectionSizeInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
@@ -112,10 +112,7 @@ export type SetCollectionSizeInstructionDataArgs = {
 
 export function getSetCollectionSizeInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      setCollectionSizeArgs: SetCollectionSizeArgsArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['setCollectionSizeArgs', getSetCollectionSizeArgsEncoder()],
     ]),
@@ -124,7 +121,7 @@ export function getSetCollectionSizeInstructionDataEncoder() {
 }
 
 export function getSetCollectionSizeInstructionDataDecoder() {
-  return getStructDecoder<SetCollectionSizeInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['setCollectionSizeArgs', getSetCollectionSizeArgsDecoder()],
   ]) satisfies Decoder<SetCollectionSizeInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
@@ -91,7 +91,7 @@ export type SetMintAuthorityInstructionDataArgs = {};
 
 export function getSetMintAuthorityInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: Array<number> }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
     ]),
     (value) => ({
@@ -102,7 +102,7 @@ export function getSetMintAuthorityInstructionDataEncoder() {
 }
 
 export function getSetMintAuthorityInstructionDataDecoder() {
-  return getStructDecoder<SetMintAuthorityInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
   ]) satisfies Decoder<SetMintAuthorityInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
@@ -89,7 +89,7 @@ export type SetMintAuthorityInstructionData = { discriminator: Array<number> };
 
 export type SetMintAuthorityInstructionDataArgs = {};
 
-export function getSetMintAuthorityInstructionDataEncoder() {
+export function getSetMintAuthorityInstructionDataEncoder(): Encoder<SetMintAuthorityInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -98,13 +98,13 @@ export function getSetMintAuthorityInstructionDataEncoder() {
       ...value,
       discriminator: [67, 127, 155, 187, 100, 174, 103, 121],
     })
-  ) satisfies Encoder<SetMintAuthorityInstructionDataArgs>;
+  );
 }
 
-export function getSetMintAuthorityInstructionDataDecoder() {
+export function getSetMintAuthorityInstructionDataDecoder(): Decoder<SetMintAuthorityInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
-  ]) satisfies Decoder<SetMintAuthorityInstructionData>;
+  ]);
 }
 
 export function getSetMintAuthorityInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
@@ -95,17 +95,15 @@ export type SetTokenStandardInstructionData = { discriminator: number };
 
 export type SetTokenStandardInstructionDataArgs = {};
 
-export function getSetTokenStandardInstructionDataEncoder() {
+export function getSetTokenStandardInstructionDataEncoder(): Encoder<SetTokenStandardInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 35 })
-  ) satisfies Encoder<SetTokenStandardInstructionDataArgs>;
+  );
 }
 
-export function getSetTokenStandardInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<SetTokenStandardInstructionData>;
+export function getSetTokenStandardInstructionDataDecoder(): Decoder<SetTokenStandardInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getSetTokenStandardInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
@@ -97,15 +97,13 @@ export type SetTokenStandardInstructionDataArgs = {};
 
 export function getSetTokenStandardInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 35 })
   ) satisfies Encoder<SetTokenStandardInstructionDataArgs>;
 }
 
 export function getSetTokenStandardInstructionDataDecoder() {
-  return getStructDecoder<SetTokenStandardInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<SetTokenStandardInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
@@ -80,15 +80,13 @@ export type SignMetadataInstructionDataArgs = {};
 
 export function getSignMetadataInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 7 })
   ) satisfies Encoder<SignMetadataInstructionDataArgs>;
 }
 
 export function getSignMetadataInstructionDataDecoder() {
-  return getStructDecoder<SignMetadataInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<SignMetadataInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
@@ -78,17 +78,15 @@ export type SignMetadataInstructionData = { discriminator: number };
 
 export type SignMetadataInstructionDataArgs = {};
 
-export function getSignMetadataInstructionDataEncoder() {
+export function getSignMetadataInstructionDataEncoder(): Encoder<SignMetadataInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 7 })
-  ) satisfies Encoder<SignMetadataInstructionDataArgs>;
+  );
 }
 
-export function getSignMetadataInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<SignMetadataInstructionData>;
+export function getSignMetadataInstructionDataDecoder(): Decoder<SignMetadataInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getSignMetadataInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
@@ -109,15 +109,13 @@ export type ThawDelegatedAccountInstructionDataArgs = {};
 
 export function getThawDelegatedAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 27 })
   ) satisfies Encoder<ThawDelegatedAccountInstructionDataArgs>;
 }
 
 export function getThawDelegatedAccountInstructionDataDecoder() {
-  return getStructDecoder<ThawDelegatedAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<ThawDelegatedAccountInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
@@ -107,17 +107,15 @@ export type ThawDelegatedAccountInstructionData = { discriminator: number };
 
 export type ThawDelegatedAccountInstructionDataArgs = {};
 
-export function getThawDelegatedAccountInstructionDataEncoder() {
+export function getThawDelegatedAccountInstructionDataEncoder(): Encoder<ThawDelegatedAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 27 })
-  ) satisfies Encoder<ThawDelegatedAccountInstructionDataArgs>;
+  );
 }
 
-export function getThawDelegatedAccountInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<ThawDelegatedAccountInstructionData>;
+export function getThawDelegatedAccountInstructionDataDecoder(): Decoder<ThawDelegatedAccountInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getThawDelegatedAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/transfer.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transfer.ts
@@ -215,21 +215,21 @@ export type TransferInstructionData = {
 
 export type TransferInstructionDataArgs = { transferArgs: TransferArgsArgs };
 
-export function getTransferInstructionDataEncoder() {
+export function getTransferInstructionDataEncoder(): Encoder<TransferInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['transferArgs', getTransferArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 46 })
-  ) satisfies Encoder<TransferInstructionDataArgs>;
+  );
 }
 
-export function getTransferInstructionDataDecoder() {
+export function getTransferInstructionDataDecoder(): Decoder<TransferInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['transferArgs', getTransferArgsDecoder()],
-  ]) satisfies Decoder<TransferInstructionData>;
+  ]);
 }
 
 export function getTransferInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/transfer.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transfer.ts
@@ -217,18 +217,16 @@ export type TransferInstructionDataArgs = { transferArgs: TransferArgsArgs };
 
 export function getTransferInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; transferArgs: TransferArgsArgs }>(
-      [
-        ['discriminator', getU8Encoder()],
-        ['transferArgs', getTransferArgsEncoder()],
-      ]
-    ),
+    getStructEncoder([
+      ['discriminator', getU8Encoder()],
+      ['transferArgs', getTransferArgsEncoder()],
+    ]),
     (value) => ({ ...value, discriminator: 46 })
   ) satisfies Encoder<TransferInstructionDataArgs>;
 }
 
 export function getTransferInstructionDataDecoder() {
-  return getStructDecoder<TransferInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['transferArgs', getTransferArgsDecoder()],
   ]) satisfies Decoder<TransferInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
@@ -197,7 +197,7 @@ export type TransferOutOfEscrowInstructionDataArgs = {
 
 export function getTransferOutOfEscrowInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; amount: number | bigint }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
@@ -206,7 +206,7 @@ export function getTransferOutOfEscrowInstructionDataEncoder() {
 }
 
 export function getTransferOutOfEscrowInstructionDataDecoder() {
-  return getStructDecoder<TransferOutOfEscrowInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['amount', getU64Decoder()],
   ]) satisfies Decoder<TransferOutOfEscrowInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
@@ -195,21 +195,21 @@ export type TransferOutOfEscrowInstructionDataArgs = {
   amount: number | bigint;
 };
 
-export function getTransferOutOfEscrowInstructionDataEncoder() {
+export function getTransferOutOfEscrowInstructionDataEncoder(): Encoder<TransferOutOfEscrowInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['amount', getU64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 40 })
-  ) satisfies Encoder<TransferOutOfEscrowInstructionDataArgs>;
+  );
 }
 
-export function getTransferOutOfEscrowInstructionDataDecoder() {
+export function getTransferOutOfEscrowInstructionDataDecoder(): Decoder<TransferOutOfEscrowInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['amount', getU64Decoder()],
-  ]) satisfies Decoder<TransferOutOfEscrowInstructionData>;
+  ]);
 }
 
 export function getTransferOutOfEscrowInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/transferSol.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferSol.ts
@@ -86,21 +86,21 @@ export type TransferSolInstructionData = {
 
 export type TransferSolInstructionDataArgs = { amount: number | bigint };
 
-export function getTransferSolInstructionDataEncoder() {
+export function getTransferSolInstructionDataEncoder(): Encoder<TransferSolInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU32Encoder()],
       ['amount', getU64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 2 })
-  ) satisfies Encoder<TransferSolInstructionDataArgs>;
+  );
 }
 
-export function getTransferSolInstructionDataDecoder() {
+export function getTransferSolInstructionDataDecoder(): Decoder<TransferSolInstructionData> {
   return getStructDecoder([
     ['discriminator', getU32Decoder()],
     ['amount', getU64Decoder()],
-  ]) satisfies Decoder<TransferSolInstructionData>;
+  ]);
 }
 
 export function getTransferSolInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/transferSol.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferSol.ts
@@ -88,7 +88,7 @@ export type TransferSolInstructionDataArgs = { amount: number | bigint };
 
 export function getTransferSolInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; amount: number | bigint }>([
+    getStructEncoder([
       ['discriminator', getU32Encoder()],
       ['amount', getU64Encoder()],
     ]),
@@ -97,7 +97,7 @@ export function getTransferSolInstructionDataEncoder() {
 }
 
 export function getTransferSolInstructionDataDecoder() {
-  return getStructDecoder<TransferSolInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU32Decoder()],
     ['amount', getU64Decoder()],
   ]) satisfies Decoder<TransferSolInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
@@ -119,17 +119,15 @@ export type UnverifyCollectionInstructionData = { discriminator: number };
 
 export type UnverifyCollectionInstructionDataArgs = {};
 
-export function getUnverifyCollectionInstructionDataEncoder() {
+export function getUnverifyCollectionInstructionDataEncoder(): Encoder<UnverifyCollectionInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 22 })
-  ) satisfies Encoder<UnverifyCollectionInstructionDataArgs>;
+  );
 }
 
-export function getUnverifyCollectionInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<UnverifyCollectionInstructionData>;
+export function getUnverifyCollectionInstructionDataDecoder(): Decoder<UnverifyCollectionInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getUnverifyCollectionInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
@@ -121,15 +121,13 @@ export type UnverifyCollectionInstructionDataArgs = {};
 
 export function getUnverifyCollectionInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 22 })
   ) satisfies Encoder<UnverifyCollectionInstructionDataArgs>;
 }
 
 export function getUnverifyCollectionInstructionDataDecoder() {
-  return getStructDecoder<UnverifyCollectionInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<UnverifyCollectionInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -133,15 +133,13 @@ export type UnverifySizedCollectionItemInstructionDataArgs = {};
 
 export function getUnverifySizedCollectionItemInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 31 })
   ) satisfies Encoder<UnverifySizedCollectionItemInstructionDataArgs>;
 }
 
 export function getUnverifySizedCollectionItemInstructionDataDecoder() {
-  return getStructDecoder<UnverifySizedCollectionItemInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<UnverifySizedCollectionItemInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -131,17 +131,15 @@ export type UnverifySizedCollectionItemInstructionData = {
 
 export type UnverifySizedCollectionItemInstructionDataArgs = {};
 
-export function getUnverifySizedCollectionItemInstructionDataEncoder() {
+export function getUnverifySizedCollectionItemInstructionDataEncoder(): Encoder<UnverifySizedCollectionItemInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 31 })
-  ) satisfies Encoder<UnverifySizedCollectionItemInstructionDataArgs>;
+  );
 }
 
-export function getUnverifySizedCollectionItemInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<UnverifySizedCollectionItemInstructionData>;
+export function getUnverifySizedCollectionItemInstructionDataDecoder(): Decoder<UnverifySizedCollectionItemInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getUnverifySizedCollectionItemInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
@@ -91,7 +91,7 @@ export type UpdateCandyMachineInstructionDataArgs = {
   data: CandyMachineDataArgs;
 };
 
-export function getUpdateCandyMachineInstructionDataEncoder() {
+export function getUpdateCandyMachineInstructionDataEncoder(): Encoder<UpdateCandyMachineInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -101,14 +101,14 @@ export function getUpdateCandyMachineInstructionDataEncoder() {
       ...value,
       discriminator: [219, 200, 88, 176, 158, 63, 253, 127],
     })
-  ) satisfies Encoder<UpdateCandyMachineInstructionDataArgs>;
+  );
 }
 
-export function getUpdateCandyMachineInstructionDataDecoder() {
+export function getUpdateCandyMachineInstructionDataDecoder(): Decoder<UpdateCandyMachineInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['data', getCandyMachineDataDecoder()],
-  ]) satisfies Decoder<UpdateCandyMachineInstructionData>;
+  ]);
 }
 
 export function getUpdateCandyMachineInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
@@ -93,10 +93,7 @@ export type UpdateCandyMachineInstructionDataArgs = {
 
 export function getUpdateCandyMachineInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: Array<number>;
-      data: CandyMachineDataArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
       ['data', getCandyMachineDataEncoder()],
     ]),
@@ -108,7 +105,7 @@ export function getUpdateCandyMachineInstructionDataEncoder() {
 }
 
 export function getUpdateCandyMachineInstructionDataDecoder() {
-  return getStructDecoder<UpdateCandyMachineInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['data', getCandyMachineDataDecoder()],
   ]) satisfies Decoder<UpdateCandyMachineInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
@@ -127,29 +127,12 @@ export type UpdateMetadataAccountInstructionDataArgs = {
 
 export function getUpdateMetadataAccountInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      data: OptionOrNullable<{
-        name: string;
-        symbol: string;
-        uri: string;
-        sellerFeeBasisPoints: number;
-        creators: OptionOrNullable<Array<CreatorArgs>>;
-      }>;
-      updateAuthority: OptionOrNullable<Address>;
-      primarySaleHappened: OptionOrNullable<boolean>;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       [
         'data',
         getOptionEncoder(
-          getStructEncoder<{
-            name: string;
-            symbol: string;
-            uri: string;
-            sellerFeeBasisPoints: number;
-            creators: OptionOrNullable<Array<CreatorArgs>>;
-          }>([
+          getStructEncoder([
             ['name', getStringEncoder()],
             ['symbol', getStringEncoder()],
             ['uri', getStringEncoder()],
@@ -169,18 +152,12 @@ export function getUpdateMetadataAccountInstructionDataEncoder() {
 }
 
 export function getUpdateMetadataAccountInstructionDataDecoder() {
-  return getStructDecoder<UpdateMetadataAccountInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
       'data',
       getOptionDecoder(
-        getStructDecoder<{
-          name: string;
-          symbol: string;
-          uri: string;
-          sellerFeeBasisPoints: number;
-          creators: Option<Array<Creator>>;
-        }>([
+        getStructDecoder([
           ['name', getStringDecoder()],
           ['symbol', getStringDecoder()],
           ['uri', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
@@ -125,7 +125,7 @@ export type UpdateMetadataAccountInstructionDataArgs = {
   primarySaleHappened: OptionOrNullable<boolean>;
 };
 
-export function getUpdateMetadataAccountInstructionDataEncoder() {
+export function getUpdateMetadataAccountInstructionDataEncoder(): Encoder<UpdateMetadataAccountInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -148,10 +148,10 @@ export function getUpdateMetadataAccountInstructionDataEncoder() {
       ['primarySaleHappened', getOptionEncoder(getBooleanEncoder())],
     ]),
     (value) => ({ ...value, discriminator: 1 })
-  ) satisfies Encoder<UpdateMetadataAccountInstructionDataArgs>;
+  );
 }
 
-export function getUpdateMetadataAccountInstructionDataDecoder() {
+export function getUpdateMetadataAccountInstructionDataDecoder(): Decoder<UpdateMetadataAccountInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     [
@@ -168,7 +168,7 @@ export function getUpdateMetadataAccountInstructionDataDecoder() {
     ],
     ['updateAuthority', getOptionDecoder(getAddressDecoder())],
     ['primarySaleHappened', getOptionDecoder(getBooleanDecoder())],
-  ]) satisfies Decoder<UpdateMetadataAccountInstructionData>;
+  ]);
 }
 
 export function getUpdateMetadataAccountInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
@@ -109,13 +109,7 @@ export type UpdateMetadataAccountV2InstructionDataArgs = {
 
 export function getUpdateMetadataAccountV2InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      data: OptionOrNullable<DataV2Args>;
-      updateAuthority: OptionOrNullable<Address>;
-      primarySaleHappened: OptionOrNullable<boolean>;
-      isMutable: OptionOrNullable<boolean>;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['data', getOptionEncoder(getDataV2Encoder())],
       ['updateAuthority', getOptionEncoder(getAddressEncoder())],
@@ -127,7 +121,7 @@ export function getUpdateMetadataAccountV2InstructionDataEncoder() {
 }
 
 export function getUpdateMetadataAccountV2InstructionDataDecoder() {
-  return getStructDecoder<UpdateMetadataAccountV2InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['data', getOptionDecoder(getDataV2Decoder())],
     ['updateAuthority', getOptionDecoder(getAddressDecoder())],

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
@@ -107,7 +107,7 @@ export type UpdateMetadataAccountV2InstructionDataArgs = {
   isMutable: OptionOrNullable<boolean>;
 };
 
-export function getUpdateMetadataAccountV2InstructionDataEncoder() {
+export function getUpdateMetadataAccountV2InstructionDataEncoder(): Encoder<UpdateMetadataAccountV2InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -117,17 +117,17 @@ export function getUpdateMetadataAccountV2InstructionDataEncoder() {
       ['isMutable', getOptionEncoder(getBooleanEncoder())],
     ]),
     (value) => ({ ...value, discriminator: 15 })
-  ) satisfies Encoder<UpdateMetadataAccountV2InstructionDataArgs>;
+  );
 }
 
-export function getUpdateMetadataAccountV2InstructionDataDecoder() {
+export function getUpdateMetadataAccountV2InstructionDataDecoder(): Decoder<UpdateMetadataAccountV2InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['data', getOptionDecoder(getDataV2Decoder())],
     ['updateAuthority', getOptionDecoder(getAddressDecoder())],
     ['primarySaleHappened', getOptionDecoder(getBooleanDecoder())],
     ['isMutable', getOptionDecoder(getBooleanDecoder())],
-  ]) satisfies Decoder<UpdateMetadataAccountV2InstructionData>;
+  ]);
 }
 
 export function getUpdateMetadataAccountV2InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -89,17 +89,15 @@ export type UpdatePrimarySaleHappenedViaTokenInstructionData = {
 
 export type UpdatePrimarySaleHappenedViaTokenInstructionDataArgs = {};
 
-export function getUpdatePrimarySaleHappenedViaTokenInstructionDataEncoder() {
+export function getUpdatePrimarySaleHappenedViaTokenInstructionDataEncoder(): Encoder<UpdatePrimarySaleHappenedViaTokenInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 4 })
-  ) satisfies Encoder<UpdatePrimarySaleHappenedViaTokenInstructionDataArgs>;
+  );
 }
 
-export function getUpdatePrimarySaleHappenedViaTokenInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<UpdatePrimarySaleHappenedViaTokenInstructionData>;
+export function getUpdatePrimarySaleHappenedViaTokenInstructionDataDecoder(): Decoder<UpdatePrimarySaleHappenedViaTokenInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getUpdatePrimarySaleHappenedViaTokenInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -91,15 +91,13 @@ export type UpdatePrimarySaleHappenedViaTokenInstructionDataArgs = {};
 
 export function getUpdatePrimarySaleHappenedViaTokenInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 4 })
   ) satisfies Encoder<UpdatePrimarySaleHappenedViaTokenInstructionDataArgs>;
 }
 
 export function getUpdatePrimarySaleHappenedViaTokenInstructionDataDecoder() {
-  return getStructDecoder<UpdatePrimarySaleHappenedViaTokenInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<UpdatePrimarySaleHappenedViaTokenInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/updateV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateV1.ts
@@ -256,28 +256,7 @@ export type UpdateV1InstructionDataArgs = {
 
 export function getUpdateV1InstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      updateV1Discriminator: number;
-      authorizationData: OptionOrNullable<AuthorizationDataArgs>;
-      newUpdateAuthority: OptionOrNullable<Address>;
-      data: OptionOrNullable<{
-        name: string;
-        symbol: string;
-        uri: string;
-        sellerFeeBasisPoints: number;
-        creators: OptionOrNullable<Array<CreatorArgs>>;
-      }>;
-      primarySaleHappened: OptionOrNullable<boolean>;
-      isMutable: OptionOrNullable<boolean>;
-      tokenStandard: OptionOrNullable<TokenStandardArgs>;
-      collection: OptionOrNullable<CollectionArgs>;
-      uses: OptionOrNullable<UsesArgs>;
-      collectionDetails: OptionOrNullable<CollectionDetailsArgs>;
-      programmableConfig: OptionOrNullable<ProgrammableConfigArgs>;
-      delegateState: OptionOrNullable<DelegateStateArgs>;
-      authorityType: AuthorityTypeArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['updateV1Discriminator', getU8Encoder()],
       ['authorizationData', getOptionEncoder(getAuthorizationDataEncoder())],
@@ -285,13 +264,7 @@ export function getUpdateV1InstructionDataEncoder() {
       [
         'data',
         getOptionEncoder(
-          getStructEncoder<{
-            name: string;
-            symbol: string;
-            uri: string;
-            sellerFeeBasisPoints: number;
-            creators: OptionOrNullable<Array<CreatorArgs>>;
-          }>([
+          getStructEncoder([
             ['name', getStringEncoder()],
             ['symbol', getStringEncoder()],
             ['uri', getStringEncoder()],
@@ -323,7 +296,7 @@ export function getUpdateV1InstructionDataEncoder() {
 }
 
 export function getUpdateV1InstructionDataDecoder() {
-  return getStructDecoder<UpdateV1InstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['updateV1Discriminator', getU8Decoder()],
     ['authorizationData', getOptionDecoder(getAuthorizationDataDecoder())],
@@ -331,13 +304,7 @@ export function getUpdateV1InstructionDataDecoder() {
     [
       'data',
       getOptionDecoder(
-        getStructDecoder<{
-          name: string;
-          symbol: string;
-          uri: string;
-          sellerFeeBasisPoints: number;
-          creators: Option<Array<Creator>>;
-        }>([
+        getStructDecoder([
           ['name', getStringDecoder()],
           ['symbol', getStringDecoder()],
           ['uri', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/updateV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateV1.ts
@@ -254,7 +254,7 @@ export type UpdateV1InstructionDataArgs = {
   authorityType: AuthorityTypeArgs;
 };
 
-export function getUpdateV1InstructionDataEncoder() {
+export function getUpdateV1InstructionDataEncoder(): Encoder<UpdateV1InstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -292,10 +292,10 @@ export function getUpdateV1InstructionDataEncoder() {
       updateV1Discriminator: 0,
       tokenStandard: value.tokenStandard ?? some(TokenStandard.NonFungible),
     })
-  ) satisfies Encoder<UpdateV1InstructionDataArgs>;
+  );
 }
 
-export function getUpdateV1InstructionDataDecoder() {
+export function getUpdateV1InstructionDataDecoder(): Decoder<UpdateV1InstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['updateV1Discriminator', getU8Decoder()],
@@ -322,7 +322,7 @@ export function getUpdateV1InstructionDataDecoder() {
     ['programmableConfig', getOptionDecoder(getProgrammableConfigDecoder())],
     ['delegateState', getOptionDecoder(getDelegateStateDecoder())],
     ['authorityType', getAuthorityTypeDecoder()],
-  ]) satisfies Decoder<UpdateV1InstructionData>;
+  ]);
 }
 
 export function getUpdateV1InstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/useAsset.ts
+++ b/test/packages/js-experimental/src/generated/instructions/useAsset.ts
@@ -176,21 +176,21 @@ export type UseAssetInstructionData = {
 
 export type UseAssetInstructionDataArgs = { useAssetArgs: UseAssetArgsArgs };
 
-export function getUseAssetInstructionDataEncoder() {
+export function getUseAssetInstructionDataEncoder(): Encoder<UseAssetInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['useAssetArgs', getUseAssetArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 45 })
-  ) satisfies Encoder<UseAssetInstructionDataArgs>;
+  );
 }
 
-export function getUseAssetInstructionDataDecoder() {
+export function getUseAssetInstructionDataDecoder(): Decoder<UseAssetInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['useAssetArgs', getUseAssetArgsDecoder()],
-  ]) satisfies Decoder<UseAssetInstructionData>;
+  ]);
 }
 
 export function getUseAssetInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/useAsset.ts
+++ b/test/packages/js-experimental/src/generated/instructions/useAsset.ts
@@ -178,18 +178,16 @@ export type UseAssetInstructionDataArgs = { useAssetArgs: UseAssetArgsArgs };
 
 export function getUseAssetInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; useAssetArgs: UseAssetArgsArgs }>(
-      [
-        ['discriminator', getU8Encoder()],
-        ['useAssetArgs', getUseAssetArgsEncoder()],
-      ]
-    ),
+    getStructEncoder([
+      ['discriminator', getU8Encoder()],
+      ['useAssetArgs', getUseAssetArgsEncoder()],
+    ]),
     (value) => ({ ...value, discriminator: 45 })
   ) satisfies Encoder<UseAssetInstructionDataArgs>;
 }
 
 export function getUseAssetInstructionDataDecoder() {
-  return getStructDecoder<UseAssetInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['useAssetArgs', getUseAssetArgsDecoder()],
   ]) satisfies Decoder<UseAssetInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/utilize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/utilize.ts
@@ -177,7 +177,7 @@ export type UtilizeInstructionDataArgs = { numberOfUses: number | bigint };
 
 export function getUtilizeInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; numberOfUses: number | bigint }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['numberOfUses', getU64Encoder()],
     ]),
@@ -186,7 +186,7 @@ export function getUtilizeInstructionDataEncoder() {
 }
 
 export function getUtilizeInstructionDataDecoder() {
-  return getStructDecoder<UtilizeInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['numberOfUses', getU64Decoder()],
   ]) satisfies Decoder<UtilizeInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/utilize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/utilize.ts
@@ -175,21 +175,21 @@ export type UtilizeInstructionData = {
 
 export type UtilizeInstructionDataArgs = { numberOfUses: number | bigint };
 
-export function getUtilizeInstructionDataEncoder() {
+export function getUtilizeInstructionDataEncoder(): Encoder<UtilizeInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['numberOfUses', getU64Encoder()],
     ]),
     (value) => ({ ...value, discriminator: 19 })
-  ) satisfies Encoder<UtilizeInstructionDataArgs>;
+  );
 }
 
-export function getUtilizeInstructionDataDecoder() {
+export function getUtilizeInstructionDataDecoder(): Decoder<UtilizeInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['numberOfUses', getU64Decoder()],
-  ]) satisfies Decoder<UtilizeInstructionData>;
+  ]);
 }
 
 export function getUtilizeInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/validate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/validate.ts
@@ -336,7 +336,7 @@ export type ValidateInstructionDataArgs = {
   payload: PayloadArgs;
 };
 
-export function getValidateInstructionDataEncoder() {
+export function getValidateInstructionDataEncoder(): Encoder<ValidateInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
@@ -345,16 +345,16 @@ export function getValidateInstructionDataEncoder() {
       ['payload', getPayloadEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 1 })
-  ) satisfies Encoder<ValidateInstructionDataArgs>;
+  );
 }
 
-export function getValidateInstructionDataDecoder() {
+export function getValidateInstructionDataDecoder(): Decoder<ValidateInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['ruleSetName', getStringDecoder()],
     ['operation', getOperationDecoder()],
     ['payload', getPayloadDecoder()],
-  ]) satisfies Decoder<ValidateInstructionData>;
+  ]);
 }
 
 export function getValidateInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/validate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/validate.ts
@@ -338,12 +338,7 @@ export type ValidateInstructionDataArgs = {
 
 export function getValidateInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      discriminator: number;
-      ruleSetName: string;
-      operation: OperationArgs;
-      payload: PayloadArgs;
-    }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['ruleSetName', getStringEncoder()],
       ['operation', getOperationEncoder()],
@@ -354,7 +349,7 @@ export function getValidateInstructionDataEncoder() {
 }
 
 export function getValidateInstructionDataDecoder() {
-  return getStructDecoder<ValidateInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['ruleSetName', getStringDecoder()],
     ['operation', getOperationDecoder()],

--- a/test/packages/js-experimental/src/generated/instructions/verify.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verify.ts
@@ -119,7 +119,7 @@ export type VerifyInstructionDataArgs = { verifyArgs: VerifyArgsArgs };
 
 export function getVerifyInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number; verifyArgs: VerifyArgsArgs }>([
+    getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['verifyArgs', getVerifyArgsEncoder()],
     ]),
@@ -128,7 +128,7 @@ export function getVerifyInstructionDataEncoder() {
 }
 
 export function getVerifyInstructionDataDecoder() {
-  return getStructDecoder<VerifyInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['verifyArgs', getVerifyArgsDecoder()],
   ]) satisfies Decoder<VerifyInstructionData>;

--- a/test/packages/js-experimental/src/generated/instructions/verify.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verify.ts
@@ -117,21 +117,21 @@ export type VerifyInstructionData = {
 
 export type VerifyInstructionDataArgs = { verifyArgs: VerifyArgsArgs };
 
-export function getVerifyInstructionDataEncoder() {
+export function getVerifyInstructionDataEncoder(): Encoder<VerifyInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['verifyArgs', getVerifyArgsEncoder()],
     ]),
     (value) => ({ ...value, discriminator: 47 })
-  ) satisfies Encoder<VerifyInstructionDataArgs>;
+  );
 }
 
-export function getVerifyInstructionDataDecoder() {
+export function getVerifyInstructionDataDecoder(): Decoder<VerifyInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['verifyArgs', getVerifyArgsDecoder()],
-  ]) satisfies Decoder<VerifyInstructionData>;
+  ]);
 }
 
 export function getVerifyInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
@@ -118,15 +118,13 @@ export type VerifyCollectionInstructionDataArgs = {};
 
 export function getVerifyCollectionInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 18 })
   ) satisfies Encoder<VerifyCollectionInstructionDataArgs>;
 }
 
 export function getVerifyCollectionInstructionDataDecoder() {
-  return getStructDecoder<VerifyCollectionInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<VerifyCollectionInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
@@ -116,17 +116,15 @@ export type VerifyCollectionInstructionData = { discriminator: number };
 
 export type VerifyCollectionInstructionDataArgs = {};
 
-export function getVerifyCollectionInstructionDataEncoder() {
+export function getVerifyCollectionInstructionDataEncoder(): Encoder<VerifyCollectionInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 18 })
-  ) satisfies Encoder<VerifyCollectionInstructionDataArgs>;
+  );
 }
 
-export function getVerifyCollectionInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<VerifyCollectionInstructionData>;
+export function getVerifyCollectionInstructionDataDecoder(): Decoder<VerifyCollectionInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getVerifyCollectionInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
@@ -131,17 +131,15 @@ export type VerifySizedCollectionItemInstructionData = {
 
 export type VerifySizedCollectionItemInstructionDataArgs = {};
 
-export function getVerifySizedCollectionItemInstructionDataEncoder() {
+export function getVerifySizedCollectionItemInstructionDataEncoder(): Encoder<VerifySizedCollectionItemInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 30 })
-  ) satisfies Encoder<VerifySizedCollectionItemInstructionDataArgs>;
+  );
 }
 
-export function getVerifySizedCollectionItemInstructionDataDecoder() {
-  return getStructDecoder([
-    ['discriminator', getU8Decoder()],
-  ]) satisfies Decoder<VerifySizedCollectionItemInstructionData>;
+export function getVerifySizedCollectionItemInstructionDataDecoder(): Decoder<VerifySizedCollectionItemInstructionData> {
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getVerifySizedCollectionItemInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
@@ -133,15 +133,13 @@ export type VerifySizedCollectionItemInstructionDataArgs = {};
 
 export function getVerifySizedCollectionItemInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 30 })
   ) satisfies Encoder<VerifySizedCollectionItemInstructionDataArgs>;
 }
 
 export function getVerifySizedCollectionItemInstructionDataDecoder() {
-  return getStructDecoder<VerifySizedCollectionItemInstructionData>([
+  return getStructDecoder([
     ['discriminator', getU8Decoder()],
   ]) satisfies Decoder<VerifySizedCollectionItemInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/withdraw.ts
+++ b/test/packages/js-experimental/src/generated/instructions/withdraw.ts
@@ -82,7 +82,7 @@ export type WithdrawInstructionDataArgs = {};
 
 export function getWithdrawInstructionDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{ discriminator: Array<number> }>([
+    getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
     ]),
     (value) => ({
@@ -93,7 +93,7 @@ export function getWithdrawInstructionDataEncoder() {
 }
 
 export function getWithdrawInstructionDataDecoder() {
-  return getStructDecoder<WithdrawInstructionData>([
+  return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
   ]) satisfies Decoder<WithdrawInstructionData>;
 }

--- a/test/packages/js-experimental/src/generated/instructions/withdraw.ts
+++ b/test/packages/js-experimental/src/generated/instructions/withdraw.ts
@@ -80,7 +80,7 @@ export type WithdrawInstructionData = { discriminator: Array<number> };
 
 export type WithdrawInstructionDataArgs = {};
 
-export function getWithdrawInstructionDataEncoder() {
+export function getWithdrawInstructionDataEncoder(): Encoder<WithdrawInstructionDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -89,13 +89,13 @@ export function getWithdrawInstructionDataEncoder() {
       ...value,
       discriminator: [183, 18, 70, 156, 148, 109, 161, 34],
     })
-  ) satisfies Encoder<WithdrawInstructionDataArgs>;
+  );
 }
 
-export function getWithdrawInstructionDataDecoder() {
+export function getWithdrawInstructionDataDecoder(): Decoder<WithdrawInstructionData> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
-  ]) satisfies Decoder<WithdrawInstructionData>;
+  ]);
 }
 
 export function getWithdrawInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/assetData.ts
+++ b/test/packages/js-experimental/src/generated/types/assetData.ts
@@ -101,7 +101,7 @@ export type AssetDataArgs = {
 };
 
 export function getAssetDataEncoder() {
-  return getStructEncoder<AssetDataArgs>([
+  return getStructEncoder([
     ['updateAuthority', getAddressEncoder()],
     ['name', getStringEncoder()],
     ['symbol', getStringEncoder()],
@@ -121,7 +121,7 @@ export function getAssetDataEncoder() {
 }
 
 export function getAssetDataDecoder() {
-  return getStructDecoder<AssetData>([
+  return getStructDecoder([
     ['updateAuthority', getAddressDecoder()],
     ['name', getStringDecoder()],
     ['symbol', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/types/assetData.ts
+++ b/test/packages/js-experimental/src/generated/types/assetData.ts
@@ -100,7 +100,7 @@ export type AssetDataArgs = {
   delegateState: OptionOrNullable<DelegateStateArgs>;
 };
 
-export function getAssetDataEncoder() {
+export function getAssetDataEncoder(): Encoder<AssetDataArgs> {
   return getStructEncoder([
     ['updateAuthority', getAddressEncoder()],
     ['name', getStringEncoder()],
@@ -117,10 +117,10 @@ export function getAssetDataEncoder() {
     ['collectionDetails', getOptionEncoder(getCollectionDetailsEncoder())],
     ['programmableConfig', getOptionEncoder(getProgrammableConfigEncoder())],
     ['delegateState', getOptionEncoder(getDelegateStateEncoder())],
-  ]) satisfies Encoder<AssetDataArgs>;
+  ]);
 }
 
-export function getAssetDataDecoder() {
+export function getAssetDataDecoder(): Decoder<AssetData> {
   return getStructDecoder([
     ['updateAuthority', getAddressDecoder()],
     ['name', getStringDecoder()],
@@ -137,7 +137,7 @@ export function getAssetDataDecoder() {
     ['collectionDetails', getOptionDecoder(getCollectionDetailsDecoder())],
     ['programmableConfig', getOptionDecoder(getProgrammableConfigDecoder())],
     ['delegateState', getOptionDecoder(getDelegateStateDecoder())],
-  ]) satisfies Decoder<AssetData>;
+  ]);
 }
 
 export function getAssetDataCodec(): Codec<AssetDataArgs, AssetData> {

--- a/test/packages/js-experimental/src/generated/types/authorityType.ts
+++ b/test/packages/js-experimental/src/generated/types/authorityType.ts
@@ -21,14 +21,12 @@ export enum AuthorityType {
 
 export type AuthorityTypeArgs = AuthorityType;
 
-export function getAuthorityTypeEncoder() {
-  return getScalarEnumEncoder(
-    AuthorityType
-  ) satisfies Encoder<AuthorityTypeArgs>;
+export function getAuthorityTypeEncoder(): Encoder<AuthorityTypeArgs> {
+  return getScalarEnumEncoder(AuthorityType);
 }
 
-export function getAuthorityTypeDecoder() {
-  return getScalarEnumDecoder(AuthorityType) satisfies Decoder<AuthorityType>;
+export function getAuthorityTypeDecoder(): Decoder<AuthorityType> {
+  return getScalarEnumDecoder(AuthorityType);
 }
 
 export function getAuthorityTypeCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/authorizationData.ts
+++ b/test/packages/js-experimental/src/generated/types/authorizationData.ts
@@ -17,16 +17,12 @@ export type AuthorizationData = { payload: Payload };
 
 export type AuthorizationDataArgs = { payload: PayloadArgs };
 
-export function getAuthorizationDataEncoder() {
-  return getStructEncoder([
-    ['payload', getPayloadEncoder()],
-  ]) satisfies Encoder<AuthorizationDataArgs>;
+export function getAuthorizationDataEncoder(): Encoder<AuthorizationDataArgs> {
+  return getStructEncoder([['payload', getPayloadEncoder()]]);
 }
 
-export function getAuthorizationDataDecoder() {
-  return getStructDecoder([
-    ['payload', getPayloadDecoder()],
-  ]) satisfies Decoder<AuthorizationData>;
+export function getAuthorizationDataDecoder(): Decoder<AuthorizationData> {
+  return getStructDecoder([['payload', getPayloadDecoder()]]);
 }
 
 export function getAuthorizationDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/authorizationData.ts
+++ b/test/packages/js-experimental/src/generated/types/authorizationData.ts
@@ -18,13 +18,13 @@ export type AuthorizationData = { payload: Payload };
 export type AuthorizationDataArgs = { payload: PayloadArgs };
 
 export function getAuthorizationDataEncoder() {
-  return getStructEncoder<AuthorizationDataArgs>([
+  return getStructEncoder([
     ['payload', getPayloadEncoder()],
   ]) satisfies Encoder<AuthorizationDataArgs>;
 }
 
 export function getAuthorizationDataDecoder() {
-  return getStructDecoder<AuthorizationData>([
+  return getStructDecoder([
     ['payload', getPayloadDecoder()],
   ]) satisfies Decoder<AuthorizationData>;
 }

--- a/test/packages/js-experimental/src/generated/types/burnArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/burnArgs.ts
@@ -19,16 +19,12 @@ export enum BurnArgs {
 
 export type BurnArgsArgs = BurnArgs;
 
-export function getBurnArgsEncoder() {
-  return getScalarEnumEncoder(BurnArgs, {
-    size: getU64Encoder(),
-  }) satisfies Encoder<BurnArgsArgs>;
+export function getBurnArgsEncoder(): Encoder<BurnArgsArgs> {
+  return getScalarEnumEncoder(BurnArgs, { size: getU64Encoder() });
 }
 
-export function getBurnArgsDecoder() {
-  return getScalarEnumDecoder(BurnArgs, {
-    size: getU64Decoder(),
-  }) satisfies Decoder<BurnArgs>;
+export function getBurnArgsDecoder(): Decoder<BurnArgs> {
+  return getScalarEnumDecoder(BurnArgs, { size: getU64Decoder() });
 }
 
 export function getBurnArgsCodec(): Codec<BurnArgsArgs, BurnArgs> {

--- a/test/packages/js-experimental/src/generated/types/candyMachineData.ts
+++ b/test/packages/js-experimental/src/generated/types/candyMachineData.ts
@@ -83,7 +83,7 @@ export type CandyMachineDataArgs = {
 };
 
 export function getCandyMachineDataEncoder() {
-  return getStructEncoder<CandyMachineDataArgs>([
+  return getStructEncoder([
     ['itemsAvailable', getU64Encoder()],
     ['symbol', getStringEncoder()],
     ['sellerFeeBasisPoints', getU16Encoder()],
@@ -96,7 +96,7 @@ export function getCandyMachineDataEncoder() {
 }
 
 export function getCandyMachineDataDecoder() {
-  return getStructDecoder<CandyMachineData>([
+  return getStructDecoder([
     ['itemsAvailable', getU64Decoder()],
     ['symbol', getStringDecoder()],
     ['sellerFeeBasisPoints', getU16Decoder()],

--- a/test/packages/js-experimental/src/generated/types/candyMachineData.ts
+++ b/test/packages/js-experimental/src/generated/types/candyMachineData.ts
@@ -82,7 +82,7 @@ export type CandyMachineDataArgs = {
   hiddenSettings: OptionOrNullable<HiddenSettingsArgs>;
 };
 
-export function getCandyMachineDataEncoder() {
+export function getCandyMachineDataEncoder(): Encoder<CandyMachineDataArgs> {
   return getStructEncoder([
     ['itemsAvailable', getU64Encoder()],
     ['symbol', getStringEncoder()],
@@ -92,10 +92,10 @@ export function getCandyMachineDataEncoder() {
     ['creators', getArrayEncoder(getCmCreatorEncoder())],
     ['configLineSettings', getOptionEncoder(getConfigLineSettingsEncoder())],
     ['hiddenSettings', getOptionEncoder(getHiddenSettingsEncoder())],
-  ]) satisfies Encoder<CandyMachineDataArgs>;
+  ]);
 }
 
-export function getCandyMachineDataDecoder() {
+export function getCandyMachineDataDecoder(): Decoder<CandyMachineData> {
   return getStructDecoder([
     ['itemsAvailable', getU64Decoder()],
     ['symbol', getStringDecoder()],
@@ -105,7 +105,7 @@ export function getCandyMachineDataDecoder() {
     ['creators', getArrayDecoder(getCmCreatorDecoder())],
     ['configLineSettings', getOptionDecoder(getConfigLineSettingsDecoder())],
     ['hiddenSettings', getOptionDecoder(getHiddenSettingsDecoder())],
-  ]) satisfies Decoder<CandyMachineData>;
+  ]);
 }
 
 export function getCandyMachineDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/cmCreator.ts
+++ b/test/packages/js-experimental/src/generated/types/cmCreator.ts
@@ -30,20 +30,20 @@ export type CmCreator = {
 
 export type CmCreatorArgs = CmCreator;
 
-export function getCmCreatorEncoder() {
+export function getCmCreatorEncoder(): Encoder<CmCreatorArgs> {
   return getStructEncoder([
     ['address', getAddressEncoder()],
     ['verified', getBooleanEncoder()],
     ['percentageShare', getU8Encoder()],
-  ]) satisfies Encoder<CmCreatorArgs>;
+  ]);
 }
 
-export function getCmCreatorDecoder() {
+export function getCmCreatorDecoder(): Decoder<CmCreator> {
   return getStructDecoder([
     ['address', getAddressDecoder()],
     ['verified', getBooleanDecoder()],
     ['percentageShare', getU8Decoder()],
-  ]) satisfies Decoder<CmCreator>;
+  ]);
 }
 
 export function getCmCreatorCodec(): Codec<CmCreatorArgs, CmCreator> {

--- a/test/packages/js-experimental/src/generated/types/cmCreator.ts
+++ b/test/packages/js-experimental/src/generated/types/cmCreator.ts
@@ -31,7 +31,7 @@ export type CmCreator = {
 export type CmCreatorArgs = CmCreator;
 
 export function getCmCreatorEncoder() {
-  return getStructEncoder<CmCreatorArgs>([
+  return getStructEncoder([
     ['address', getAddressEncoder()],
     ['verified', getBooleanEncoder()],
     ['percentageShare', getU8Encoder()],
@@ -39,7 +39,7 @@ export function getCmCreatorEncoder() {
 }
 
 export function getCmCreatorDecoder() {
-  return getStructDecoder<CmCreator>([
+  return getStructDecoder([
     ['address', getAddressDecoder()],
     ['verified', getBooleanDecoder()],
     ['percentageShare', getU8Decoder()],

--- a/test/packages/js-experimental/src/generated/types/collection.ts
+++ b/test/packages/js-experimental/src/generated/types/collection.ts
@@ -31,7 +31,7 @@ export type CollectionArgs = { verified?: boolean; key: Address };
 
 export function getCollectionEncoder() {
   return mapEncoder(
-    getStructEncoder<{ verified: boolean; key: Address }>([
+    getStructEncoder([
       ['verified', getBooleanEncoder()],
       ['key', getAddressEncoder()],
     ]),
@@ -40,7 +40,7 @@ export function getCollectionEncoder() {
 }
 
 export function getCollectionDecoder() {
-  return getStructDecoder<Collection>([
+  return getStructDecoder([
     ['verified', getBooleanDecoder()],
     ['key', getAddressDecoder()],
   ]) satisfies Decoder<Collection>;

--- a/test/packages/js-experimental/src/generated/types/collection.ts
+++ b/test/packages/js-experimental/src/generated/types/collection.ts
@@ -29,21 +29,21 @@ export type Collection = { verified: boolean; key: Address };
 
 export type CollectionArgs = { verified?: boolean; key: Address };
 
-export function getCollectionEncoder() {
+export function getCollectionEncoder(): Encoder<CollectionArgs> {
   return mapEncoder(
     getStructEncoder([
       ['verified', getBooleanEncoder()],
       ['key', getAddressEncoder()],
     ]),
     (value) => ({ ...value, verified: value.verified ?? false })
-  ) satisfies Encoder<CollectionArgs>;
+  );
 }
 
-export function getCollectionDecoder() {
+export function getCollectionDecoder(): Decoder<Collection> {
   return getStructDecoder([
     ['verified', getBooleanDecoder()],
     ['key', getAddressDecoder()],
-  ]) satisfies Decoder<Collection>;
+  ]);
 }
 
 export function getCollectionCodec(): Codec<CollectionArgs, Collection> {

--- a/test/packages/js-experimental/src/generated/types/collectionDetails.ts
+++ b/test/packages/js-experimental/src/generated/types/collectionDetails.ts
@@ -22,24 +22,14 @@ export type CollectionDetails = { __kind: 'V1'; size: bigint };
 export type CollectionDetailsArgs = { __kind: 'V1'; size: number | bigint };
 
 export function getCollectionDetailsEncoder() {
-  return getDataEnumEncoder<CollectionDetailsArgs>([
-    [
-      'V1',
-      getStructEncoder<GetDataEnumKindContent<CollectionDetailsArgs, 'V1'>>([
-        ['size', getU64Encoder()],
-      ]),
-    ],
+  return getDataEnumEncoder([
+    ['V1', getStructEncoder([['size', getU64Encoder()]])],
   ]) satisfies Encoder<CollectionDetailsArgs>;
 }
 
 export function getCollectionDetailsDecoder() {
-  return getDataEnumDecoder<CollectionDetails>([
-    [
-      'V1',
-      getStructDecoder<GetDataEnumKindContent<CollectionDetails, 'V1'>>([
-        ['size', getU64Decoder()],
-      ]),
-    ],
+  return getDataEnumDecoder([
+    ['V1', getStructDecoder([['size', getU64Decoder()]])],
   ]) satisfies Decoder<CollectionDetails>;
 }
 

--- a/test/packages/js-experimental/src/generated/types/collectionDetails.ts
+++ b/test/packages/js-experimental/src/generated/types/collectionDetails.ts
@@ -21,16 +21,16 @@ export type CollectionDetails = { __kind: 'V1'; size: bigint };
 
 export type CollectionDetailsArgs = { __kind: 'V1'; size: number | bigint };
 
-export function getCollectionDetailsEncoder() {
+export function getCollectionDetailsEncoder(): Encoder<CollectionDetailsArgs> {
   return getDataEnumEncoder([
     ['V1', getStructEncoder([['size', getU64Encoder()]])],
-  ]) satisfies Encoder<CollectionDetailsArgs>;
+  ]);
 }
 
-export function getCollectionDetailsDecoder() {
+export function getCollectionDetailsDecoder(): Decoder<CollectionDetails> {
   return getDataEnumDecoder([
     ['V1', getStructDecoder([['size', getU64Decoder()]])],
-  ]) satisfies Decoder<CollectionDetails>;
+  ]);
 }
 
 export function getCollectionDetailsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/configLine.ts
+++ b/test/packages/js-experimental/src/generated/types/configLine.ts
@@ -24,14 +24,14 @@ export type ConfigLine = {
 export type ConfigLineArgs = ConfigLine;
 
 export function getConfigLineEncoder() {
-  return getStructEncoder<ConfigLineArgs>([
+  return getStructEncoder([
     ['name', getStringEncoder()],
     ['uri', getStringEncoder()],
   ]) satisfies Encoder<ConfigLineArgs>;
 }
 
 export function getConfigLineDecoder() {
-  return getStructDecoder<ConfigLine>([
+  return getStructDecoder([
     ['name', getStringDecoder()],
     ['uri', getStringDecoder()],
   ]) satisfies Decoder<ConfigLine>;

--- a/test/packages/js-experimental/src/generated/types/configLine.ts
+++ b/test/packages/js-experimental/src/generated/types/configLine.ts
@@ -23,18 +23,18 @@ export type ConfigLine = {
 
 export type ConfigLineArgs = ConfigLine;
 
-export function getConfigLineEncoder() {
+export function getConfigLineEncoder(): Encoder<ConfigLineArgs> {
   return getStructEncoder([
     ['name', getStringEncoder()],
     ['uri', getStringEncoder()],
-  ]) satisfies Encoder<ConfigLineArgs>;
+  ]);
 }
 
-export function getConfigLineDecoder() {
+export function getConfigLineDecoder(): Decoder<ConfigLine> {
   return getStructDecoder([
     ['name', getStringDecoder()],
     ['uri', getStringDecoder()],
-  ]) satisfies Decoder<ConfigLine>;
+  ]);
 }
 
 export function getConfigLineCodec(): Codec<ConfigLineArgs, ConfigLine> {

--- a/test/packages/js-experimental/src/generated/types/configLineSettings.ts
+++ b/test/packages/js-experimental/src/generated/types/configLineSettings.ts
@@ -33,7 +33,7 @@ export type ConfigLineSettings = {
 export type ConfigLineSettingsArgs = ConfigLineSettings;
 
 export function getConfigLineSettingsEncoder() {
-  return getStructEncoder<ConfigLineSettingsArgs>([
+  return getStructEncoder([
     ['prefixName', getStringEncoder()],
     ['nameLength', getU32Encoder()],
     ['prefixUri', getStringEncoder()],
@@ -43,7 +43,7 @@ export function getConfigLineSettingsEncoder() {
 }
 
 export function getConfigLineSettingsDecoder() {
-  return getStructDecoder<ConfigLineSettings>([
+  return getStructDecoder([
     ['prefixName', getStringDecoder()],
     ['nameLength', getU32Decoder()],
     ['prefixUri', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/types/configLineSettings.ts
+++ b/test/packages/js-experimental/src/generated/types/configLineSettings.ts
@@ -32,24 +32,24 @@ export type ConfigLineSettings = {
 
 export type ConfigLineSettingsArgs = ConfigLineSettings;
 
-export function getConfigLineSettingsEncoder() {
+export function getConfigLineSettingsEncoder(): Encoder<ConfigLineSettingsArgs> {
   return getStructEncoder([
     ['prefixName', getStringEncoder()],
     ['nameLength', getU32Encoder()],
     ['prefixUri', getStringEncoder()],
     ['uriLength', getU32Encoder()],
     ['isSequential', getBooleanEncoder()],
-  ]) satisfies Encoder<ConfigLineSettingsArgs>;
+  ]);
 }
 
-export function getConfigLineSettingsDecoder() {
+export function getConfigLineSettingsDecoder(): Decoder<ConfigLineSettings> {
   return getStructDecoder([
     ['prefixName', getStringDecoder()],
     ['nameLength', getU32Decoder()],
     ['prefixUri', getStringDecoder()],
     ['uriLength', getU32Decoder()],
     ['isSequential', getBooleanDecoder()],
-  ]) satisfies Decoder<ConfigLineSettings>;
+  ]);
 }
 
 export function getConfigLineSettingsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/createMasterEditionArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/createMasterEditionArgs.ts
@@ -25,16 +25,12 @@ export type CreateMasterEditionArgsArgs = {
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-export function getCreateMasterEditionArgsEncoder() {
-  return getStructEncoder([
-    ['maxSupply', getOptionEncoder(getU64Encoder())],
-  ]) satisfies Encoder<CreateMasterEditionArgsArgs>;
+export function getCreateMasterEditionArgsEncoder(): Encoder<CreateMasterEditionArgsArgs> {
+  return getStructEncoder([['maxSupply', getOptionEncoder(getU64Encoder())]]);
 }
 
-export function getCreateMasterEditionArgsDecoder() {
-  return getStructDecoder([
-    ['maxSupply', getOptionDecoder(getU64Decoder())],
-  ]) satisfies Decoder<CreateMasterEditionArgs>;
+export function getCreateMasterEditionArgsDecoder(): Decoder<CreateMasterEditionArgs> {
+  return getStructDecoder([['maxSupply', getOptionDecoder(getU64Decoder())]]);
 }
 
 export function getCreateMasterEditionArgsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/createMasterEditionArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/createMasterEditionArgs.ts
@@ -26,13 +26,13 @@ export type CreateMasterEditionArgsArgs = {
 };
 
 export function getCreateMasterEditionArgsEncoder() {
-  return getStructEncoder<CreateMasterEditionArgsArgs>([
+  return getStructEncoder([
     ['maxSupply', getOptionEncoder(getU64Encoder())],
   ]) satisfies Encoder<CreateMasterEditionArgsArgs>;
 }
 
 export function getCreateMasterEditionArgsDecoder() {
-  return getStructDecoder<CreateMasterEditionArgs>([
+  return getStructDecoder([
     ['maxSupply', getOptionDecoder(getU64Decoder())],
   ]) satisfies Decoder<CreateMasterEditionArgs>;
 }

--- a/test/packages/js-experimental/src/generated/types/creator.ts
+++ b/test/packages/js-experimental/src/generated/types/creator.ts
@@ -25,7 +25,7 @@ export type Creator = { address: Address; verified: boolean; share: number };
 export type CreatorArgs = Creator;
 
 export function getCreatorEncoder() {
-  return getStructEncoder<CreatorArgs>([
+  return getStructEncoder([
     ['address', getAddressEncoder()],
     ['verified', getBooleanEncoder()],
     ['share', getU8Encoder()],
@@ -33,7 +33,7 @@ export function getCreatorEncoder() {
 }
 
 export function getCreatorDecoder() {
-  return getStructDecoder<Creator>([
+  return getStructDecoder([
     ['address', getAddressDecoder()],
     ['verified', getBooleanDecoder()],
     ['share', getU8Decoder()],

--- a/test/packages/js-experimental/src/generated/types/creator.ts
+++ b/test/packages/js-experimental/src/generated/types/creator.ts
@@ -24,20 +24,20 @@ export type Creator = { address: Address; verified: boolean; share: number };
 
 export type CreatorArgs = Creator;
 
-export function getCreatorEncoder() {
+export function getCreatorEncoder(): Encoder<CreatorArgs> {
   return getStructEncoder([
     ['address', getAddressEncoder()],
     ['verified', getBooleanEncoder()],
     ['share', getU8Encoder()],
-  ]) satisfies Encoder<CreatorArgs>;
+  ]);
 }
 
-export function getCreatorDecoder() {
+export function getCreatorDecoder(): Decoder<Creator> {
   return getStructDecoder([
     ['address', getAddressDecoder()],
     ['verified', getBooleanDecoder()],
     ['share', getU8Decoder()],
-  ]) satisfies Decoder<Creator>;
+  ]);
 }
 
 export function getCreatorCodec(): Codec<CreatorArgs, Creator> {

--- a/test/packages/js-experimental/src/generated/types/dataV2.ts
+++ b/test/packages/js-experimental/src/generated/types/dataV2.ts
@@ -56,7 +56,7 @@ export type DataV2Args = {
   uses: OptionOrNullable<UsesArgs>;
 };
 
-export function getDataV2Encoder() {
+export function getDataV2Encoder(): Encoder<DataV2Args> {
   return getStructEncoder([
     ['name', getStringEncoder()],
     ['symbol', getStringEncoder()],
@@ -65,10 +65,10 @@ export function getDataV2Encoder() {
     ['creators', getOptionEncoder(getArrayEncoder(getCreatorEncoder()))],
     ['collection', getOptionEncoder(getCollectionEncoder())],
     ['uses', getOptionEncoder(getUsesEncoder())],
-  ]) satisfies Encoder<DataV2Args>;
+  ]);
 }
 
-export function getDataV2Decoder() {
+export function getDataV2Decoder(): Decoder<DataV2> {
   return getStructDecoder([
     ['name', getStringDecoder()],
     ['symbol', getStringDecoder()],
@@ -77,7 +77,7 @@ export function getDataV2Decoder() {
     ['creators', getOptionDecoder(getArrayDecoder(getCreatorDecoder()))],
     ['collection', getOptionDecoder(getCollectionDecoder())],
     ['uses', getOptionDecoder(getUsesDecoder())],
-  ]) satisfies Decoder<DataV2>;
+  ]);
 }
 
 export function getDataV2Codec(): Codec<DataV2Args, DataV2> {

--- a/test/packages/js-experimental/src/generated/types/dataV2.ts
+++ b/test/packages/js-experimental/src/generated/types/dataV2.ts
@@ -57,7 +57,7 @@ export type DataV2Args = {
 };
 
 export function getDataV2Encoder() {
-  return getStructEncoder<DataV2Args>([
+  return getStructEncoder([
     ['name', getStringEncoder()],
     ['symbol', getStringEncoder()],
     ['uri', getStringEncoder()],
@@ -69,7 +69,7 @@ export function getDataV2Encoder() {
 }
 
 export function getDataV2Decoder() {
-  return getStructDecoder<DataV2>([
+  return getStructDecoder([
     ['name', getStringDecoder()],
     ['symbol', getStringDecoder()],
     ['uri', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/types/delegateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateArgs.ts
@@ -29,20 +29,20 @@ export type DelegateArgsArgs =
   | { __kind: 'SaleV1'; amount: number | bigint }
   | { __kind: 'TransferV1'; amount: number | bigint };
 
-export function getDelegateArgsEncoder() {
+export function getDelegateArgsEncoder(): Encoder<DelegateArgsArgs> {
   return getDataEnumEncoder([
     ['CollectionV1', getUnitEncoder()],
     ['SaleV1', getStructEncoder([['amount', getU64Encoder()]])],
     ['TransferV1', getStructEncoder([['amount', getU64Encoder()]])],
-  ]) satisfies Encoder<DelegateArgsArgs>;
+  ]);
 }
 
-export function getDelegateArgsDecoder() {
+export function getDelegateArgsDecoder(): Decoder<DelegateArgs> {
   return getDataEnumDecoder([
     ['CollectionV1', getUnitDecoder()],
     ['SaleV1', getStructDecoder([['amount', getU64Decoder()]])],
     ['TransferV1', getStructDecoder([['amount', getU64Decoder()]])],
-  ]) satisfies Decoder<DelegateArgs>;
+  ]);
 }
 
 export function getDelegateArgsCodec(): Codec<DelegateArgsArgs, DelegateArgs> {

--- a/test/packages/js-experimental/src/generated/types/delegateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateArgs.ts
@@ -30,38 +30,18 @@ export type DelegateArgsArgs =
   | { __kind: 'TransferV1'; amount: number | bigint };
 
 export function getDelegateArgsEncoder() {
-  return getDataEnumEncoder<DelegateArgsArgs>([
+  return getDataEnumEncoder([
     ['CollectionV1', getUnitEncoder()],
-    [
-      'SaleV1',
-      getStructEncoder<GetDataEnumKindContent<DelegateArgsArgs, 'SaleV1'>>([
-        ['amount', getU64Encoder()],
-      ]),
-    ],
-    [
-      'TransferV1',
-      getStructEncoder<GetDataEnumKindContent<DelegateArgsArgs, 'TransferV1'>>([
-        ['amount', getU64Encoder()],
-      ]),
-    ],
+    ['SaleV1', getStructEncoder([['amount', getU64Encoder()]])],
+    ['TransferV1', getStructEncoder([['amount', getU64Encoder()]])],
   ]) satisfies Encoder<DelegateArgsArgs>;
 }
 
 export function getDelegateArgsDecoder() {
-  return getDataEnumDecoder<DelegateArgs>([
+  return getDataEnumDecoder([
     ['CollectionV1', getUnitDecoder()],
-    [
-      'SaleV1',
-      getStructDecoder<GetDataEnumKindContent<DelegateArgs, 'SaleV1'>>([
-        ['amount', getU64Decoder()],
-      ]),
-    ],
-    [
-      'TransferV1',
-      getStructDecoder<GetDataEnumKindContent<DelegateArgs, 'TransferV1'>>([
-        ['amount', getU64Decoder()],
-      ]),
-    ],
+    ['SaleV1', getStructDecoder([['amount', getU64Decoder()]])],
+    ['TransferV1', getStructDecoder([['amount', getU64Decoder()]])],
   ]) satisfies Decoder<DelegateArgs>;
 }
 

--- a/test/packages/js-experimental/src/generated/types/delegateRole.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateRole.ts
@@ -24,12 +24,12 @@ export enum DelegateRole {
 
 export type DelegateRoleArgs = DelegateRole;
 
-export function getDelegateRoleEncoder() {
-  return getScalarEnumEncoder(DelegateRole) satisfies Encoder<DelegateRoleArgs>;
+export function getDelegateRoleEncoder(): Encoder<DelegateRoleArgs> {
+  return getScalarEnumEncoder(DelegateRole);
 }
 
-export function getDelegateRoleDecoder() {
-  return getScalarEnumDecoder(DelegateRole) satisfies Decoder<DelegateRole>;
+export function getDelegateRoleDecoder(): Decoder<DelegateRole> {
+  return getScalarEnumDecoder(DelegateRole);
 }
 
 export function getDelegateRoleCodec(): Codec<DelegateRoleArgs, DelegateRole> {

--- a/test/packages/js-experimental/src/generated/types/delegateState.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateState.ts
@@ -37,20 +37,20 @@ export type DelegateStateArgs = {
   hasData: boolean;
 };
 
-export function getDelegateStateEncoder() {
+export function getDelegateStateEncoder(): Encoder<DelegateStateArgs> {
   return getStructEncoder([
     ['role', getDelegateRoleEncoder()],
     ['delegate', getAddressEncoder()],
     ['hasData', getBooleanEncoder()],
-  ]) satisfies Encoder<DelegateStateArgs>;
+  ]);
 }
 
-export function getDelegateStateDecoder() {
+export function getDelegateStateDecoder(): Decoder<DelegateState> {
   return getStructDecoder([
     ['role', getDelegateRoleDecoder()],
     ['delegate', getAddressDecoder()],
     ['hasData', getBooleanDecoder()],
-  ]) satisfies Decoder<DelegateState>;
+  ]);
 }
 
 export function getDelegateStateCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/delegateState.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateState.ts
@@ -38,7 +38,7 @@ export type DelegateStateArgs = {
 };
 
 export function getDelegateStateEncoder() {
-  return getStructEncoder<DelegateStateArgs>([
+  return getStructEncoder([
     ['role', getDelegateRoleEncoder()],
     ['delegate', getAddressEncoder()],
     ['hasData', getBooleanEncoder()],
@@ -46,7 +46,7 @@ export function getDelegateStateEncoder() {
 }
 
 export function getDelegateStateDecoder() {
-  return getStructDecoder<DelegateState>([
+  return getStructDecoder([
     ['role', getDelegateRoleDecoder()],
     ['delegate', getAddressDecoder()],
     ['hasData', getBooleanDecoder()],

--- a/test/packages/js-experimental/src/generated/types/dummyLines.ts
+++ b/test/packages/js-experimental/src/generated/types/dummyLines.ts
@@ -27,13 +27,13 @@ export type DummyLinesArgs = {
 };
 
 export function getDummyLinesEncoder() {
-  return getStructEncoder<DummyLinesArgs>([
+  return getStructEncoder([
     ['lines', getArrayEncoder(getU64Encoder(), { size: 'remainder' })],
   ]) satisfies Encoder<DummyLinesArgs>;
 }
 
 export function getDummyLinesDecoder() {
-  return getStructDecoder<DummyLines>([
+  return getStructDecoder([
     ['lines', getArrayDecoder(getU64Decoder(), { size: 'remainder' })],
   ]) satisfies Decoder<DummyLines>;
 }

--- a/test/packages/js-experimental/src/generated/types/dummyLines.ts
+++ b/test/packages/js-experimental/src/generated/types/dummyLines.ts
@@ -26,16 +26,16 @@ export type DummyLinesArgs = {
   lines: Array<number | bigint>;
 };
 
-export function getDummyLinesEncoder() {
+export function getDummyLinesEncoder(): Encoder<DummyLinesArgs> {
   return getStructEncoder([
     ['lines', getArrayEncoder(getU64Encoder(), { size: 'remainder' })],
-  ]) satisfies Encoder<DummyLinesArgs>;
+  ]);
 }
 
-export function getDummyLinesDecoder() {
+export function getDummyLinesDecoder(): Decoder<DummyLines> {
   return getStructDecoder([
     ['lines', getArrayDecoder(getU64Decoder(), { size: 'remainder' })],
-  ]) satisfies Decoder<DummyLines>;
+  ]);
 }
 
 export function getDummyLinesCodec(): Codec<DummyLinesArgs, DummyLines> {

--- a/test/packages/js-experimental/src/generated/types/escrowAuthority.ts
+++ b/test/packages/js-experimental/src/generated/types/escrowAuthority.ts
@@ -31,24 +31,24 @@ export type EscrowAuthority =
 
 export type EscrowAuthorityArgs = EscrowAuthority;
 
-export function getEscrowAuthorityEncoder() {
+export function getEscrowAuthorityEncoder(): Encoder<EscrowAuthorityArgs> {
   return getDataEnumEncoder([
     ['TokenOwner', getUnitEncoder()],
     [
       'Creator',
       getStructEncoder([['fields', getTupleEncoder([getAddressEncoder()])]]),
     ],
-  ]) satisfies Encoder<EscrowAuthorityArgs>;
+  ]);
 }
 
-export function getEscrowAuthorityDecoder() {
+export function getEscrowAuthorityDecoder(): Decoder<EscrowAuthority> {
   return getDataEnumDecoder([
     ['TokenOwner', getUnitDecoder()],
     [
       'Creator',
       getStructDecoder([['fields', getTupleDecoder([getAddressDecoder()])]]),
     ],
-  ]) satisfies Decoder<EscrowAuthority>;
+  ]);
 }
 
 export function getEscrowAuthorityCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/escrowAuthority.ts
+++ b/test/packages/js-experimental/src/generated/types/escrowAuthority.ts
@@ -32,25 +32,21 @@ export type EscrowAuthority =
 export type EscrowAuthorityArgs = EscrowAuthority;
 
 export function getEscrowAuthorityEncoder() {
-  return getDataEnumEncoder<EscrowAuthorityArgs>([
+  return getDataEnumEncoder([
     ['TokenOwner', getUnitEncoder()],
     [
       'Creator',
-      getStructEncoder<GetDataEnumKindContent<EscrowAuthorityArgs, 'Creator'>>([
-        ['fields', getTupleEncoder([getAddressEncoder()])],
-      ]),
+      getStructEncoder([['fields', getTupleEncoder([getAddressEncoder()])]]),
     ],
   ]) satisfies Encoder<EscrowAuthorityArgs>;
 }
 
 export function getEscrowAuthorityDecoder() {
-  return getDataEnumDecoder<EscrowAuthority>([
+  return getDataEnumDecoder([
     ['TokenOwner', getUnitDecoder()],
     [
       'Creator',
-      getStructDecoder<GetDataEnumKindContent<EscrowAuthority, 'Creator'>>([
-        ['fields', getTupleDecoder([getAddressDecoder()])],
-      ]),
+      getStructDecoder([['fields', getTupleDecoder([getAddressDecoder()])]]),
     ],
   ]) satisfies Decoder<EscrowAuthority>;
 }

--- a/test/packages/js-experimental/src/generated/types/extendedPayload.ts
+++ b/test/packages/js-experimental/src/generated/types/extendedPayload.ts
@@ -38,18 +38,18 @@ export type ExtendedPayloadArgs = {
   args: [number, string];
 };
 
-export function getExtendedPayloadEncoder() {
+export function getExtendedPayloadEncoder(): Encoder<ExtendedPayloadArgs> {
   return getStructEncoder([
     ['map', getMapEncoder(getPayloadKeyEncoder(), getPayloadTypeEncoder())],
     ['args', getTupleEncoder([getU8Encoder(), getStringEncoder()])],
-  ]) satisfies Encoder<ExtendedPayloadArgs>;
+  ]);
 }
 
-export function getExtendedPayloadDecoder() {
+export function getExtendedPayloadDecoder(): Decoder<ExtendedPayload> {
   return getStructDecoder([
     ['map', getMapDecoder(getPayloadKeyDecoder(), getPayloadTypeDecoder())],
     ['args', getTupleDecoder([getU8Decoder(), getStringDecoder()])],
-  ]) satisfies Decoder<ExtendedPayload>;
+  ]);
 }
 
 export function getExtendedPayloadCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/extendedPayload.ts
+++ b/test/packages/js-experimental/src/generated/types/extendedPayload.ts
@@ -39,14 +39,14 @@ export type ExtendedPayloadArgs = {
 };
 
 export function getExtendedPayloadEncoder() {
-  return getStructEncoder<ExtendedPayloadArgs>([
+  return getStructEncoder([
     ['map', getMapEncoder(getPayloadKeyEncoder(), getPayloadTypeEncoder())],
     ['args', getTupleEncoder([getU8Encoder(), getStringEncoder()])],
   ]) satisfies Encoder<ExtendedPayloadArgs>;
 }
 
 export function getExtendedPayloadDecoder() {
-  return getStructDecoder<ExtendedPayload>([
+  return getStructDecoder([
     ['map', getMapDecoder(getPayloadKeyDecoder(), getPayloadTypeDecoder())],
     ['args', getTupleDecoder([getU8Decoder(), getStringDecoder()])],
   ]) satisfies Decoder<ExtendedPayload>;

--- a/test/packages/js-experimental/src/generated/types/hiddenSettings.ts
+++ b/test/packages/js-experimental/src/generated/types/hiddenSettings.ts
@@ -27,20 +27,20 @@ export type HiddenSettings = {
 
 export type HiddenSettingsArgs = HiddenSettings;
 
-export function getHiddenSettingsEncoder() {
+export function getHiddenSettingsEncoder(): Encoder<HiddenSettingsArgs> {
   return getStructEncoder([
     ['name', getStringEncoder()],
     ['uri', getStringEncoder()],
     ['hash', getBytesEncoder({ size: 64 })],
-  ]) satisfies Encoder<HiddenSettingsArgs>;
+  ]);
 }
 
-export function getHiddenSettingsDecoder() {
+export function getHiddenSettingsDecoder(): Decoder<HiddenSettings> {
   return getStructDecoder([
     ['name', getStringDecoder()],
     ['uri', getStringDecoder()],
     ['hash', getBytesDecoder({ size: 64 })],
-  ]) satisfies Decoder<HiddenSettings>;
+  ]);
 }
 
 export function getHiddenSettingsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/hiddenSettings.ts
+++ b/test/packages/js-experimental/src/generated/types/hiddenSettings.ts
@@ -28,7 +28,7 @@ export type HiddenSettings = {
 export type HiddenSettingsArgs = HiddenSettings;
 
 export function getHiddenSettingsEncoder() {
-  return getStructEncoder<HiddenSettingsArgs>([
+  return getStructEncoder([
     ['name', getStringEncoder()],
     ['uri', getStringEncoder()],
     ['hash', getBytesEncoder({ size: 64 })],
@@ -36,7 +36,7 @@ export function getHiddenSettingsEncoder() {
 }
 
 export function getHiddenSettingsDecoder() {
-  return getStructDecoder<HiddenSettings>([
+  return getStructDecoder([
     ['name', getStringDecoder()],
     ['uri', getStringDecoder()],
     ['hash', getBytesDecoder({ size: 64 })],

--- a/test/packages/js-experimental/src/generated/types/migrateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/migrateArgs.ts
@@ -18,12 +18,12 @@ export enum MigrateArgs {
 
 export type MigrateArgsArgs = MigrateArgs;
 
-export function getMigrateArgsEncoder() {
-  return getScalarEnumEncoder(MigrateArgs) satisfies Encoder<MigrateArgsArgs>;
+export function getMigrateArgsEncoder(): Encoder<MigrateArgsArgs> {
+  return getScalarEnumEncoder(MigrateArgs);
 }
 
-export function getMigrateArgsDecoder() {
-  return getScalarEnumDecoder(MigrateArgs) satisfies Decoder<MigrateArgs>;
+export function getMigrateArgsDecoder(): Decoder<MigrateArgs> {
+  return getScalarEnumDecoder(MigrateArgs);
 }
 
 export function getMigrateArgsCodec(): Codec<MigrateArgsArgs, MigrateArgs> {

--- a/test/packages/js-experimental/src/generated/types/mintArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintArgs.ts
@@ -42,10 +42,10 @@ export type MintArgsArgs = {
 };
 
 export function getMintArgsEncoder() {
-  return getDataEnumEncoder<MintArgsArgs>([
+  return getDataEnumEncoder([
     [
       'V1',
-      getStructEncoder<GetDataEnumKindContent<MintArgsArgs, 'V1'>>([
+      getStructEncoder([
         ['amount', getU64Encoder()],
         ['authorizationData', getOptionEncoder(getAuthorizationDataEncoder())],
       ]),
@@ -54,10 +54,10 @@ export function getMintArgsEncoder() {
 }
 
 export function getMintArgsDecoder() {
-  return getDataEnumDecoder<MintArgs>([
+  return getDataEnumDecoder([
     [
       'V1',
-      getStructDecoder<GetDataEnumKindContent<MintArgs, 'V1'>>([
+      getStructDecoder([
         ['amount', getU64Decoder()],
         ['authorizationData', getOptionDecoder(getAuthorizationDataDecoder())],
       ]),

--- a/test/packages/js-experimental/src/generated/types/mintArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintArgs.ts
@@ -41,7 +41,7 @@ export type MintArgsArgs = {
   authorizationData: OptionOrNullable<AuthorizationDataArgs>;
 };
 
-export function getMintArgsEncoder() {
+export function getMintArgsEncoder(): Encoder<MintArgsArgs> {
   return getDataEnumEncoder([
     [
       'V1',
@@ -50,10 +50,10 @@ export function getMintArgsEncoder() {
         ['authorizationData', getOptionEncoder(getAuthorizationDataEncoder())],
       ]),
     ],
-  ]) satisfies Encoder<MintArgsArgs>;
+  ]);
 }
 
-export function getMintArgsDecoder() {
+export function getMintArgsDecoder(): Decoder<MintArgs> {
   return getDataEnumDecoder([
     [
       'V1',
@@ -62,7 +62,7 @@ export function getMintArgsDecoder() {
         ['authorizationData', getOptionDecoder(getAuthorizationDataDecoder())],
       ]),
     ],
-  ]) satisfies Decoder<MintArgs>;
+  ]);
 }
 
 export function getMintArgsCodec(): Codec<MintArgsArgs, MintArgs> {

--- a/test/packages/js-experimental/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
@@ -20,13 +20,13 @@ export type MintNewEditionFromMasterEditionViaTokenArgsArgs = {
 };
 
 export function getMintNewEditionFromMasterEditionViaTokenArgsEncoder() {
-  return getStructEncoder<MintNewEditionFromMasterEditionViaTokenArgsArgs>([
+  return getStructEncoder([
     ['edition', getU64Encoder()],
   ]) satisfies Encoder<MintNewEditionFromMasterEditionViaTokenArgsArgs>;
 }
 
 export function getMintNewEditionFromMasterEditionViaTokenArgsDecoder() {
-  return getStructDecoder<MintNewEditionFromMasterEditionViaTokenArgs>([
+  return getStructDecoder([
     ['edition', getU64Decoder()],
   ]) satisfies Decoder<MintNewEditionFromMasterEditionViaTokenArgs>;
 }

--- a/test/packages/js-experimental/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
@@ -19,16 +19,12 @@ export type MintNewEditionFromMasterEditionViaTokenArgsArgs = {
   edition: number | bigint;
 };
 
-export function getMintNewEditionFromMasterEditionViaTokenArgsEncoder() {
-  return getStructEncoder([
-    ['edition', getU64Encoder()],
-  ]) satisfies Encoder<MintNewEditionFromMasterEditionViaTokenArgsArgs>;
+export function getMintNewEditionFromMasterEditionViaTokenArgsEncoder(): Encoder<MintNewEditionFromMasterEditionViaTokenArgsArgs> {
+  return getStructEncoder([['edition', getU64Encoder()]]);
 }
 
-export function getMintNewEditionFromMasterEditionViaTokenArgsDecoder() {
-  return getStructDecoder([
-    ['edition', getU64Decoder()],
-  ]) satisfies Decoder<MintNewEditionFromMasterEditionViaTokenArgs>;
+export function getMintNewEditionFromMasterEditionViaTokenArgsDecoder(): Decoder<MintNewEditionFromMasterEditionViaTokenArgs> {
+  return getStructDecoder([['edition', getU64Decoder()]]);
 }
 
 export function getMintNewEditionFromMasterEditionViaTokenArgsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/mintPrintingTokensViaTokenArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintPrintingTokensViaTokenArgs.ts
@@ -18,13 +18,13 @@ export type MintPrintingTokensViaTokenArgs = { supply: bigint };
 export type MintPrintingTokensViaTokenArgsArgs = { supply: number | bigint };
 
 export function getMintPrintingTokensViaTokenArgsEncoder() {
-  return getStructEncoder<MintPrintingTokensViaTokenArgsArgs>([
+  return getStructEncoder([
     ['supply', getU64Encoder()],
   ]) satisfies Encoder<MintPrintingTokensViaTokenArgsArgs>;
 }
 
 export function getMintPrintingTokensViaTokenArgsDecoder() {
-  return getStructDecoder<MintPrintingTokensViaTokenArgs>([
+  return getStructDecoder([
     ['supply', getU64Decoder()],
   ]) satisfies Decoder<MintPrintingTokensViaTokenArgs>;
 }

--- a/test/packages/js-experimental/src/generated/types/mintPrintingTokensViaTokenArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintPrintingTokensViaTokenArgs.ts
@@ -17,16 +17,12 @@ export type MintPrintingTokensViaTokenArgs = { supply: bigint };
 
 export type MintPrintingTokensViaTokenArgsArgs = { supply: number | bigint };
 
-export function getMintPrintingTokensViaTokenArgsEncoder() {
-  return getStructEncoder([
-    ['supply', getU64Encoder()],
-  ]) satisfies Encoder<MintPrintingTokensViaTokenArgsArgs>;
+export function getMintPrintingTokensViaTokenArgsEncoder(): Encoder<MintPrintingTokensViaTokenArgsArgs> {
+  return getStructEncoder([['supply', getU64Encoder()]]);
 }
 
-export function getMintPrintingTokensViaTokenArgsDecoder() {
-  return getStructDecoder([
-    ['supply', getU64Decoder()],
-  ]) satisfies Decoder<MintPrintingTokensViaTokenArgs>;
+export function getMintPrintingTokensViaTokenArgsDecoder(): Decoder<MintPrintingTokensViaTokenArgs> {
+  return getStructDecoder([['supply', getU64Decoder()]]);
 }
 
 export function getMintPrintingTokensViaTokenArgsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/operation.ts
+++ b/test/packages/js-experimental/src/generated/types/operation.ts
@@ -21,12 +21,12 @@ export enum Operation {
 
 export type OperationArgs = Operation;
 
-export function getOperationEncoder() {
-  return getScalarEnumEncoder(Operation) satisfies Encoder<OperationArgs>;
+export function getOperationEncoder(): Encoder<OperationArgs> {
+  return getScalarEnumEncoder(Operation);
 }
 
-export function getOperationDecoder() {
-  return getScalarEnumDecoder(Operation) satisfies Decoder<Operation>;
+export function getOperationDecoder(): Decoder<Operation> {
+  return getScalarEnumDecoder(Operation);
 }
 
 export function getOperationCodec(): Codec<OperationArgs, Operation> {

--- a/test/packages/js-experimental/src/generated/types/payload.ts
+++ b/test/packages/js-experimental/src/generated/types/payload.ts
@@ -28,16 +28,16 @@ export type Payload = { map: Map<PayloadKey, PayloadType> };
 
 export type PayloadArgs = { map: Map<PayloadKeyArgs, PayloadTypeArgs> };
 
-export function getPayloadEncoder() {
+export function getPayloadEncoder(): Encoder<PayloadArgs> {
   return getStructEncoder([
     ['map', getMapEncoder(getPayloadKeyEncoder(), getPayloadTypeEncoder())],
-  ]) satisfies Encoder<PayloadArgs>;
+  ]);
 }
 
-export function getPayloadDecoder() {
+export function getPayloadDecoder(): Decoder<Payload> {
   return getStructDecoder([
     ['map', getMapDecoder(getPayloadKeyDecoder(), getPayloadTypeDecoder())],
-  ]) satisfies Decoder<Payload>;
+  ]);
 }
 
 export function getPayloadCodec(): Codec<PayloadArgs, Payload> {

--- a/test/packages/js-experimental/src/generated/types/payload.ts
+++ b/test/packages/js-experimental/src/generated/types/payload.ts
@@ -29,13 +29,13 @@ export type Payload = { map: Map<PayloadKey, PayloadType> };
 export type PayloadArgs = { map: Map<PayloadKeyArgs, PayloadTypeArgs> };
 
 export function getPayloadEncoder() {
-  return getStructEncoder<PayloadArgs>([
+  return getStructEncoder([
     ['map', getMapEncoder(getPayloadKeyEncoder(), getPayloadTypeEncoder())],
   ]) satisfies Encoder<PayloadArgs>;
 }
 
 export function getPayloadDecoder() {
-  return getStructDecoder<Payload>([
+  return getStructDecoder([
     ['map', getMapDecoder(getPayloadKeyDecoder(), getPayloadTypeDecoder())],
   ]) satisfies Decoder<Payload>;
 }

--- a/test/packages/js-experimental/src/generated/types/payloadKey.ts
+++ b/test/packages/js-experimental/src/generated/types/payloadKey.ts
@@ -21,12 +21,12 @@ export enum PayloadKey {
 
 export type PayloadKeyArgs = PayloadKey;
 
-export function getPayloadKeyEncoder() {
-  return getScalarEnumEncoder(PayloadKey) satisfies Encoder<PayloadKeyArgs>;
+export function getPayloadKeyEncoder(): Encoder<PayloadKeyArgs> {
+  return getScalarEnumEncoder(PayloadKey);
 }
 
-export function getPayloadKeyDecoder() {
-  return getScalarEnumDecoder(PayloadKey) satisfies Decoder<PayloadKey>;
+export function getPayloadKeyDecoder(): Decoder<PayloadKey> {
+  return getScalarEnumDecoder(PayloadKey);
 }
 
 export function getPayloadKeyCodec(): Codec<PayloadKeyArgs, PayloadKey> {

--- a/test/packages/js-experimental/src/generated/types/payloadType.ts
+++ b/test/packages/js-experimental/src/generated/types/payloadType.ts
@@ -47,61 +47,53 @@ export type PayloadTypeArgs =
   | { __kind: 'Number'; fields: [number | bigint] };
 
 export function getPayloadTypeEncoder() {
-  return getDataEnumEncoder<PayloadTypeArgs>([
+  return getDataEnumEncoder([
     [
       'Pubkey',
-      getStructEncoder<GetDataEnumKindContent<PayloadTypeArgs, 'Pubkey'>>([
-        ['fields', getTupleEncoder([getAddressEncoder()])],
-      ]),
+      getStructEncoder([['fields', getTupleEncoder([getAddressEncoder()])]]),
     ],
     [
       'Seeds',
-      getStructEncoder<GetDataEnumKindContent<PayloadTypeArgs, 'Seeds'>>([
+      getStructEncoder([
         ['seeds', getArrayEncoder(getBytesEncoder({ size: getU32Encoder() }))],
       ]),
     ],
     [
       'MerkleProof',
-      getStructEncoder<GetDataEnumKindContent<PayloadTypeArgs, 'MerkleProof'>>([
+      getStructEncoder([
         ['leaf', getBytesEncoder({ size: 32 })],
         ['proof', getArrayEncoder(getBytesEncoder({ size: 32 }))],
       ]),
     ],
     [
       'Number',
-      getStructEncoder<GetDataEnumKindContent<PayloadTypeArgs, 'Number'>>([
-        ['fields', getTupleEncoder([getU64Encoder()])],
-      ]),
+      getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]]),
     ],
   ]) satisfies Encoder<PayloadTypeArgs>;
 }
 
 export function getPayloadTypeDecoder() {
-  return getDataEnumDecoder<PayloadType>([
+  return getDataEnumDecoder([
     [
       'Pubkey',
-      getStructDecoder<GetDataEnumKindContent<PayloadType, 'Pubkey'>>([
-        ['fields', getTupleDecoder([getAddressDecoder()])],
-      ]),
+      getStructDecoder([['fields', getTupleDecoder([getAddressDecoder()])]]),
     ],
     [
       'Seeds',
-      getStructDecoder<GetDataEnumKindContent<PayloadType, 'Seeds'>>([
+      getStructDecoder([
         ['seeds', getArrayDecoder(getBytesDecoder({ size: getU32Decoder() }))],
       ]),
     ],
     [
       'MerkleProof',
-      getStructDecoder<GetDataEnumKindContent<PayloadType, 'MerkleProof'>>([
+      getStructDecoder([
         ['leaf', getBytesDecoder({ size: 32 })],
         ['proof', getArrayDecoder(getBytesDecoder({ size: 32 }))],
       ]),
     ],
     [
       'Number',
-      getStructDecoder<GetDataEnumKindContent<PayloadType, 'Number'>>([
-        ['fields', getTupleDecoder([getU64Decoder()])],
-      ]),
+      getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]]),
     ],
   ]) satisfies Decoder<PayloadType>;
 }

--- a/test/packages/js-experimental/src/generated/types/payloadType.ts
+++ b/test/packages/js-experimental/src/generated/types/payloadType.ts
@@ -46,7 +46,7 @@ export type PayloadTypeArgs =
   | { __kind: 'MerkleProof'; leaf: Uint8Array; proof: Array<Uint8Array> }
   | { __kind: 'Number'; fields: [number | bigint] };
 
-export function getPayloadTypeEncoder() {
+export function getPayloadTypeEncoder(): Encoder<PayloadTypeArgs> {
   return getDataEnumEncoder([
     [
       'Pubkey',
@@ -69,10 +69,10 @@ export function getPayloadTypeEncoder() {
       'Number',
       getStructEncoder([['fields', getTupleEncoder([getU64Encoder()])]]),
     ],
-  ]) satisfies Encoder<PayloadTypeArgs>;
+  ]);
 }
 
-export function getPayloadTypeDecoder() {
+export function getPayloadTypeDecoder(): Decoder<PayloadType> {
   return getDataEnumDecoder([
     [
       'Pubkey',
@@ -95,7 +95,7 @@ export function getPayloadTypeDecoder() {
       'Number',
       getStructDecoder([['fields', getTupleDecoder([getU64Decoder()])]]),
     ],
-  ]) satisfies Decoder<PayloadType>;
+  ]);
 }
 
 export function getPayloadTypeCodec(): Codec<PayloadTypeArgs, PayloadType> {

--- a/test/packages/js-experimental/src/generated/types/programmableConfig.ts
+++ b/test/packages/js-experimental/src/generated/types/programmableConfig.ts
@@ -21,16 +21,12 @@ export type ProgrammableConfig = { ruleSet: Address };
 
 export type ProgrammableConfigArgs = ProgrammableConfig;
 
-export function getProgrammableConfigEncoder() {
-  return getStructEncoder([
-    ['ruleSet', getAddressEncoder()],
-  ]) satisfies Encoder<ProgrammableConfigArgs>;
+export function getProgrammableConfigEncoder(): Encoder<ProgrammableConfigArgs> {
+  return getStructEncoder([['ruleSet', getAddressEncoder()]]);
 }
 
-export function getProgrammableConfigDecoder() {
-  return getStructDecoder([
-    ['ruleSet', getAddressDecoder()],
-  ]) satisfies Decoder<ProgrammableConfig>;
+export function getProgrammableConfigDecoder(): Decoder<ProgrammableConfig> {
+  return getStructDecoder([['ruleSet', getAddressDecoder()]]);
 }
 
 export function getProgrammableConfigCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/programmableConfig.ts
+++ b/test/packages/js-experimental/src/generated/types/programmableConfig.ts
@@ -22,13 +22,13 @@ export type ProgrammableConfig = { ruleSet: Address };
 export type ProgrammableConfigArgs = ProgrammableConfig;
 
 export function getProgrammableConfigEncoder() {
-  return getStructEncoder<ProgrammableConfigArgs>([
+  return getStructEncoder([
     ['ruleSet', getAddressEncoder()],
   ]) satisfies Encoder<ProgrammableConfigArgs>;
 }
 
 export function getProgrammableConfigDecoder() {
-  return getStructDecoder<ProgrammableConfig>([
+  return getStructDecoder([
     ['ruleSet', getAddressDecoder()],
   ]) satisfies Decoder<ProgrammableConfig>;
 }

--- a/test/packages/js-experimental/src/generated/types/reservation.ts
+++ b/test/packages/js-experimental/src/generated/types/reservation.ts
@@ -30,20 +30,20 @@ export type ReservationArgs = {
   totalSpots: number | bigint;
 };
 
-export function getReservationEncoder() {
+export function getReservationEncoder(): Encoder<ReservationArgs> {
   return getStructEncoder([
     ['address', getAddressEncoder()],
     ['spotsRemaining', getU64Encoder()],
     ['totalSpots', getU64Encoder()],
-  ]) satisfies Encoder<ReservationArgs>;
+  ]);
 }
 
-export function getReservationDecoder() {
+export function getReservationDecoder(): Decoder<Reservation> {
   return getStructDecoder([
     ['address', getAddressDecoder()],
     ['spotsRemaining', getU64Decoder()],
     ['totalSpots', getU64Decoder()],
-  ]) satisfies Decoder<Reservation>;
+  ]);
 }
 
 export function getReservationCodec(): Codec<ReservationArgs, Reservation> {

--- a/test/packages/js-experimental/src/generated/types/reservation.ts
+++ b/test/packages/js-experimental/src/generated/types/reservation.ts
@@ -31,7 +31,7 @@ export type ReservationArgs = {
 };
 
 export function getReservationEncoder() {
-  return getStructEncoder<ReservationArgs>([
+  return getStructEncoder([
     ['address', getAddressEncoder()],
     ['spotsRemaining', getU64Encoder()],
     ['totalSpots', getU64Encoder()],
@@ -39,7 +39,7 @@ export function getReservationEncoder() {
 }
 
 export function getReservationDecoder() {
-  return getStructDecoder<Reservation>([
+  return getStructDecoder([
     ['address', getAddressDecoder()],
     ['spotsRemaining', getU64Decoder()],
     ['totalSpots', getU64Decoder()],

--- a/test/packages/js-experimental/src/generated/types/reservationListV1AccountData.ts
+++ b/test/packages/js-experimental/src/generated/types/reservationListV1AccountData.ts
@@ -54,7 +54,7 @@ export type ReservationListV1AccountDataArgs = {
   reservations: Array<ReservationV1Args>;
 };
 
-export function getReservationListV1AccountDataEncoder() {
+export function getReservationListV1AccountDataEncoder(): Encoder<ReservationListV1AccountDataArgs> {
   return mapEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -63,16 +63,16 @@ export function getReservationListV1AccountDataEncoder() {
       ['reservations', getArrayEncoder(getReservationV1Encoder())],
     ]),
     (value) => ({ ...value, key: TmKey.ReservationListV1 })
-  ) satisfies Encoder<ReservationListV1AccountDataArgs>;
+  );
 }
 
-export function getReservationListV1AccountDataDecoder() {
+export function getReservationListV1AccountDataDecoder(): Decoder<ReservationListV1AccountData> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['masterEdition', getAddressDecoder()],
     ['supplySnapshot', getOptionDecoder(getU64Decoder())],
     ['reservations', getArrayDecoder(getReservationV1Decoder())],
-  ]) satisfies Decoder<ReservationListV1AccountData>;
+  ]);
 }
 
 export function getReservationListV1AccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/reservationListV1AccountData.ts
+++ b/test/packages/js-experimental/src/generated/types/reservationListV1AccountData.ts
@@ -35,7 +35,6 @@ import {
   ReservationV1,
   ReservationV1Args,
   TmKey,
-  TmKeyArgs,
   getReservationV1Decoder,
   getReservationV1Encoder,
   getTmKeyDecoder,
@@ -57,12 +56,7 @@ export type ReservationListV1AccountDataArgs = {
 
 export function getReservationListV1AccountDataEncoder() {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKeyArgs;
-      masterEdition: Address;
-      supplySnapshot: OptionOrNullable<number | bigint>;
-      reservations: Array<ReservationV1Args>;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['masterEdition', getAddressEncoder()],
       ['supplySnapshot', getOptionEncoder(getU64Encoder())],
@@ -73,7 +67,7 @@ export function getReservationListV1AccountDataEncoder() {
 }
 
 export function getReservationListV1AccountDataDecoder() {
-  return getStructDecoder<ReservationListV1AccountData>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['masterEdition', getAddressDecoder()],
     ['supplySnapshot', getOptionDecoder(getU64Decoder())],

--- a/test/packages/js-experimental/src/generated/types/reservationV1.ts
+++ b/test/packages/js-experimental/src/generated/types/reservationV1.ts
@@ -26,20 +26,20 @@ export type ReservationV1 = {
 
 export type ReservationV1Args = ReservationV1;
 
-export function getReservationV1Encoder() {
+export function getReservationV1Encoder(): Encoder<ReservationV1Args> {
   return getStructEncoder([
     ['address', getAddressEncoder()],
     ['spotsRemaining', getU8Encoder()],
     ['totalSpots', getU8Encoder()],
-  ]) satisfies Encoder<ReservationV1Args>;
+  ]);
 }
 
-export function getReservationV1Decoder() {
+export function getReservationV1Decoder(): Decoder<ReservationV1> {
   return getStructDecoder([
     ['address', getAddressDecoder()],
     ['spotsRemaining', getU8Decoder()],
     ['totalSpots', getU8Decoder()],
-  ]) satisfies Decoder<ReservationV1>;
+  ]);
 }
 
 export function getReservationV1Codec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/reservationV1.ts
+++ b/test/packages/js-experimental/src/generated/types/reservationV1.ts
@@ -27,7 +27,7 @@ export type ReservationV1 = {
 export type ReservationV1Args = ReservationV1;
 
 export function getReservationV1Encoder() {
-  return getStructEncoder<ReservationV1Args>([
+  return getStructEncoder([
     ['address', getAddressEncoder()],
     ['spotsRemaining', getU8Encoder()],
     ['totalSpots', getU8Encoder()],
@@ -35,7 +35,7 @@ export function getReservationV1Encoder() {
 }
 
 export function getReservationV1Decoder() {
-  return getStructDecoder<ReservationV1>([
+  return getStructDecoder([
     ['address', getAddressDecoder()],
     ['spotsRemaining', getU8Decoder()],
     ['totalSpots', getU8Decoder()],

--- a/test/packages/js-experimental/src/generated/types/revokeArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/revokeArgs.ts
@@ -20,12 +20,12 @@ export enum RevokeArgs {
 
 export type RevokeArgsArgs = RevokeArgs;
 
-export function getRevokeArgsEncoder() {
-  return getScalarEnumEncoder(RevokeArgs) satisfies Encoder<RevokeArgsArgs>;
+export function getRevokeArgsEncoder(): Encoder<RevokeArgsArgs> {
+  return getScalarEnumEncoder(RevokeArgs);
 }
 
-export function getRevokeArgsDecoder() {
-  return getScalarEnumDecoder(RevokeArgs) satisfies Decoder<RevokeArgs>;
+export function getRevokeArgsDecoder(): Decoder<RevokeArgs> {
+  return getScalarEnumDecoder(RevokeArgs);
 }
 
 export function getRevokeArgsCodec(): Codec<RevokeArgsArgs, RevokeArgs> {

--- a/test/packages/js-experimental/src/generated/types/setCollectionSizeArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/setCollectionSizeArgs.ts
@@ -17,16 +17,12 @@ export type SetCollectionSizeArgs = { size: bigint };
 
 export type SetCollectionSizeArgsArgs = { size: number | bigint };
 
-export function getSetCollectionSizeArgsEncoder() {
-  return getStructEncoder([
-    ['size', getU64Encoder()],
-  ]) satisfies Encoder<SetCollectionSizeArgsArgs>;
+export function getSetCollectionSizeArgsEncoder(): Encoder<SetCollectionSizeArgsArgs> {
+  return getStructEncoder([['size', getU64Encoder()]]);
 }
 
-export function getSetCollectionSizeArgsDecoder() {
-  return getStructDecoder([
-    ['size', getU64Decoder()],
-  ]) satisfies Decoder<SetCollectionSizeArgs>;
+export function getSetCollectionSizeArgsDecoder(): Decoder<SetCollectionSizeArgs> {
+  return getStructDecoder([['size', getU64Decoder()]]);
 }
 
 export function getSetCollectionSizeArgsCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/setCollectionSizeArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/setCollectionSizeArgs.ts
@@ -18,13 +18,13 @@ export type SetCollectionSizeArgs = { size: bigint };
 export type SetCollectionSizeArgsArgs = { size: number | bigint };
 
 export function getSetCollectionSizeArgsEncoder() {
-  return getStructEncoder<SetCollectionSizeArgsArgs>([
+  return getStructEncoder([
     ['size', getU64Encoder()],
   ]) satisfies Encoder<SetCollectionSizeArgsArgs>;
 }
 
 export function getSetCollectionSizeArgsDecoder() {
-  return getStructDecoder<SetCollectionSizeArgs>([
+  return getStructDecoder([
     ['size', getU64Decoder()],
   ]) satisfies Decoder<SetCollectionSizeArgs>;
 }

--- a/test/packages/js-experimental/src/generated/types/taCreateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/taCreateArgs.ts
@@ -23,18 +23,18 @@ export type TaCreateArgs = {
 
 export type TaCreateArgsArgs = TaCreateArgs;
 
-export function getTaCreateArgsEncoder() {
+export function getTaCreateArgsEncoder(): Encoder<TaCreateArgsArgs> {
   return getStructEncoder([
     ['ruleSetName', getStringEncoder()],
     ['serializedRuleSet', getBytesEncoder({ size: getU32Encoder() })],
-  ]) satisfies Encoder<TaCreateArgsArgs>;
+  ]);
 }
 
-export function getTaCreateArgsDecoder() {
+export function getTaCreateArgsDecoder(): Decoder<TaCreateArgs> {
   return getStructDecoder([
     ['ruleSetName', getStringDecoder()],
     ['serializedRuleSet', getBytesDecoder({ size: getU32Decoder() })],
-  ]) satisfies Decoder<TaCreateArgs>;
+  ]);
 }
 
 export function getTaCreateArgsCodec(): Codec<TaCreateArgsArgs, TaCreateArgs> {

--- a/test/packages/js-experimental/src/generated/types/taCreateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/taCreateArgs.ts
@@ -24,14 +24,14 @@ export type TaCreateArgs = {
 export type TaCreateArgsArgs = TaCreateArgs;
 
 export function getTaCreateArgsEncoder() {
-  return getStructEncoder<TaCreateArgsArgs>([
+  return getStructEncoder([
     ['ruleSetName', getStringEncoder()],
     ['serializedRuleSet', getBytesEncoder({ size: getU32Encoder() })],
   ]) satisfies Encoder<TaCreateArgsArgs>;
 }
 
 export function getTaCreateArgsDecoder() {
-  return getStructDecoder<TaCreateArgs>([
+  return getStructDecoder([
     ['ruleSetName', getStringDecoder()],
     ['serializedRuleSet', getBytesDecoder({ size: getU32Decoder() })],
   ]) satisfies Decoder<TaCreateArgs>;

--- a/test/packages/js-experimental/src/generated/types/taKey.ts
+++ b/test/packages/js-experimental/src/generated/types/taKey.ts
@@ -19,12 +19,12 @@ export enum TaKey {
 
 export type TaKeyArgs = TaKey;
 
-export function getTaKeyEncoder() {
-  return getScalarEnumEncoder(TaKey) satisfies Encoder<TaKeyArgs>;
+export function getTaKeyEncoder(): Encoder<TaKeyArgs> {
+  return getScalarEnumEncoder(TaKey);
 }
 
-export function getTaKeyDecoder() {
-  return getScalarEnumDecoder(TaKey) satisfies Decoder<TaKey>;
+export function getTaKeyDecoder(): Decoder<TaKey> {
+  return getScalarEnumDecoder(TaKey);
 }
 
 export function getTaKeyCodec(): Codec<TaKeyArgs, TaKey> {

--- a/test/packages/js-experimental/src/generated/types/tmCreateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/tmCreateArgs.ts
@@ -56,7 +56,7 @@ export type TmCreateArgsArgs =
       maxSupply: OptionOrNullable<number | bigint>;
     };
 
-export function getTmCreateArgsEncoder() {
+export function getTmCreateArgsEncoder(): Encoder<TmCreateArgsArgs> {
   return getDataEnumEncoder([
     [
       'V1',
@@ -73,10 +73,10 @@ export function getTmCreateArgsEncoder() {
         ['maxSupply', getOptionEncoder(getU64Encoder())],
       ]),
     ],
-  ]) satisfies Encoder<TmCreateArgsArgs>;
+  ]);
 }
 
-export function getTmCreateArgsDecoder() {
+export function getTmCreateArgsDecoder(): Decoder<TmCreateArgs> {
   return getDataEnumDecoder([
     [
       'V1',
@@ -93,7 +93,7 @@ export function getTmCreateArgsDecoder() {
         ['maxSupply', getOptionDecoder(getU64Decoder())],
       ]),
     ],
-  ]) satisfies Decoder<TmCreateArgs>;
+  ]);
 }
 
 export function getTmCreateArgsCodec(): Codec<TmCreateArgsArgs, TmCreateArgs> {

--- a/test/packages/js-experimental/src/generated/types/tmCreateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/tmCreateArgs.ts
@@ -57,10 +57,10 @@ export type TmCreateArgsArgs =
     };
 
 export function getTmCreateArgsEncoder() {
-  return getDataEnumEncoder<TmCreateArgsArgs>([
+  return getDataEnumEncoder([
     [
       'V1',
-      getStructEncoder<GetDataEnumKindContent<TmCreateArgsArgs, 'V1'>>([
+      getStructEncoder([
         ['assetData', getAssetDataEncoder()],
         ['decimals', getOptionEncoder(getU8Encoder())],
         ['maxSupply', getOptionEncoder(getU64Encoder())],
@@ -68,7 +68,7 @@ export function getTmCreateArgsEncoder() {
     ],
     [
       'V2',
-      getStructEncoder<GetDataEnumKindContent<TmCreateArgsArgs, 'V2'>>([
+      getStructEncoder([
         ['assetData', getAssetDataEncoder()],
         ['maxSupply', getOptionEncoder(getU64Encoder())],
       ]),
@@ -77,10 +77,10 @@ export function getTmCreateArgsEncoder() {
 }
 
 export function getTmCreateArgsDecoder() {
-  return getDataEnumDecoder<TmCreateArgs>([
+  return getDataEnumDecoder([
     [
       'V1',
-      getStructDecoder<GetDataEnumKindContent<TmCreateArgs, 'V1'>>([
+      getStructDecoder([
         ['assetData', getAssetDataDecoder()],
         ['decimals', getOptionDecoder(getU8Decoder())],
         ['maxSupply', getOptionDecoder(getU64Decoder())],
@@ -88,7 +88,7 @@ export function getTmCreateArgsDecoder() {
     ],
     [
       'V2',
-      getStructDecoder<GetDataEnumKindContent<TmCreateArgs, 'V2'>>([
+      getStructDecoder([
         ['assetData', getAssetDataDecoder()],
         ['maxSupply', getOptionDecoder(getU64Decoder())],
       ]),

--- a/test/packages/js-experimental/src/generated/types/tmKey.ts
+++ b/test/packages/js-experimental/src/generated/types/tmKey.ts
@@ -29,12 +29,12 @@ export enum TmKey {
 
 export type TmKeyArgs = TmKey;
 
-export function getTmKeyEncoder() {
-  return getScalarEnumEncoder(TmKey) satisfies Encoder<TmKeyArgs>;
+export function getTmKeyEncoder(): Encoder<TmKeyArgs> {
+  return getScalarEnumEncoder(TmKey);
 }
 
-export function getTmKeyDecoder() {
-  return getScalarEnumDecoder(TmKey) satisfies Decoder<TmKey>;
+export function getTmKeyDecoder(): Decoder<TmKey> {
+  return getScalarEnumDecoder(TmKey);
 }
 
 export function getTmKeyCodec(): Codec<TmKeyArgs, TmKey> {

--- a/test/packages/js-experimental/src/generated/types/tokenStandard.ts
+++ b/test/packages/js-experimental/src/generated/types/tokenStandard.ts
@@ -22,14 +22,12 @@ export enum TokenStandard {
 
 export type TokenStandardArgs = TokenStandard;
 
-export function getTokenStandardEncoder() {
-  return getScalarEnumEncoder(
-    TokenStandard
-  ) satisfies Encoder<TokenStandardArgs>;
+export function getTokenStandardEncoder(): Encoder<TokenStandardArgs> {
+  return getScalarEnumEncoder(TokenStandard);
 }
 
-export function getTokenStandardDecoder() {
-  return getScalarEnumDecoder(TokenStandard) satisfies Decoder<TokenStandard>;
+export function getTokenStandardDecoder(): Decoder<TokenStandard> {
+  return getScalarEnumDecoder(TokenStandard);
 }
 
 export function getTokenStandardCodec(): Codec<

--- a/test/packages/js-experimental/src/generated/types/transferArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/transferArgs.ts
@@ -41,7 +41,7 @@ export type TransferArgsArgs = {
   amount: number | bigint;
 };
 
-export function getTransferArgsEncoder() {
+export function getTransferArgsEncoder(): Encoder<TransferArgsArgs> {
   return getDataEnumEncoder([
     [
       'V1',
@@ -50,10 +50,10 @@ export function getTransferArgsEncoder() {
         ['amount', getU64Encoder()],
       ]),
     ],
-  ]) satisfies Encoder<TransferArgsArgs>;
+  ]);
 }
 
-export function getTransferArgsDecoder() {
+export function getTransferArgsDecoder(): Decoder<TransferArgs> {
   return getDataEnumDecoder([
     [
       'V1',
@@ -62,7 +62,7 @@ export function getTransferArgsDecoder() {
         ['amount', getU64Decoder()],
       ]),
     ],
-  ]) satisfies Decoder<TransferArgs>;
+  ]);
 }
 
 export function getTransferArgsCodec(): Codec<TransferArgsArgs, TransferArgs> {

--- a/test/packages/js-experimental/src/generated/types/transferArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/transferArgs.ts
@@ -42,10 +42,10 @@ export type TransferArgsArgs = {
 };
 
 export function getTransferArgsEncoder() {
-  return getDataEnumEncoder<TransferArgsArgs>([
+  return getDataEnumEncoder([
     [
       'V1',
-      getStructEncoder<GetDataEnumKindContent<TransferArgsArgs, 'V1'>>([
+      getStructEncoder([
         ['authorizationData', getOptionEncoder(getAuthorizationDataEncoder())],
         ['amount', getU64Encoder()],
       ]),
@@ -54,10 +54,10 @@ export function getTransferArgsEncoder() {
 }
 
 export function getTransferArgsDecoder() {
-  return getDataEnumDecoder<TransferArgs>([
+  return getDataEnumDecoder([
     [
       'V1',
-      getStructDecoder<GetDataEnumKindContent<TransferArgs, 'V1'>>([
+      getStructDecoder([
         ['authorizationData', getOptionDecoder(getAuthorizationDataDecoder())],
         ['amount', getU64Decoder()],
       ]),

--- a/test/packages/js-experimental/src/generated/types/updateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/updateArgs.ts
@@ -122,7 +122,7 @@ export type UpdateArgsArgs = {
   authorityType: AuthorityTypeArgs;
 };
 
-export function getUpdateArgsEncoder() {
+export function getUpdateArgsEncoder(): Encoder<UpdateArgsArgs> {
   return getDataEnumEncoder([
     [
       'V1',
@@ -170,10 +170,10 @@ export function getUpdateArgsEncoder() {
         })
       ),
     ],
-  ]) satisfies Encoder<UpdateArgsArgs>;
+  ]);
 }
 
-export function getUpdateArgsDecoder() {
+export function getUpdateArgsDecoder(): Decoder<UpdateArgs> {
   return getDataEnumDecoder([
     [
       'V1',
@@ -209,7 +209,7 @@ export function getUpdateArgsDecoder() {
         ['authorityType', getAuthorityTypeDecoder()],
       ]),
     ],
-  ]) satisfies Decoder<UpdateArgs>;
+  ]);
 }
 
 export function getUpdateArgsCodec(): Codec<UpdateArgsArgs, UpdateArgs> {

--- a/test/packages/js-experimental/src/generated/types/updateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/updateArgs.ts
@@ -123,30 +123,11 @@ export type UpdateArgsArgs = {
 };
 
 export function getUpdateArgsEncoder() {
-  return getDataEnumEncoder<UpdateArgsArgs>([
+  return getDataEnumEncoder([
     [
       'V1',
       mapEncoder(
-        getStructEncoder<{
-          authorizationData: OptionOrNullable<AuthorizationDataArgs>;
-          newUpdateAuthority: OptionOrNullable<Address>;
-          data: OptionOrNullable<{
-            name: string;
-            symbol: string;
-            uri: string;
-            sellerFeeBasisPoints: number;
-            creators: OptionOrNullable<Array<CreatorArgs>>;
-          }>;
-          primarySaleHappened: OptionOrNullable<boolean>;
-          isMutable: OptionOrNullable<boolean>;
-          tokenStandard: OptionOrNullable<TokenStandardArgs>;
-          collection: OptionOrNullable<CollectionArgs>;
-          uses: OptionOrNullable<UsesArgs>;
-          collectionDetails: OptionOrNullable<CollectionDetailsArgs>;
-          programmableConfig: OptionOrNullable<ProgrammableConfigArgs>;
-          delegateState: OptionOrNullable<DelegateStateArgs>;
-          authorityType: AuthorityTypeArgs;
-        }>([
+        getStructEncoder([
           [
             'authorizationData',
             getOptionEncoder(getAuthorizationDataEncoder()),
@@ -155,13 +136,7 @@ export function getUpdateArgsEncoder() {
           [
             'data',
             getOptionEncoder(
-              getStructEncoder<{
-                name: string;
-                symbol: string;
-                uri: string;
-                sellerFeeBasisPoints: number;
-                creators: OptionOrNullable<Array<CreatorArgs>>;
-              }>([
+              getStructEncoder([
                 ['name', getStringEncoder()],
                 ['symbol', getStringEncoder()],
                 ['uri', getStringEncoder()],
@@ -199,22 +174,16 @@ export function getUpdateArgsEncoder() {
 }
 
 export function getUpdateArgsDecoder() {
-  return getDataEnumDecoder<UpdateArgs>([
+  return getDataEnumDecoder([
     [
       'V1',
-      getStructDecoder<GetDataEnumKindContent<UpdateArgs, 'V1'>>([
+      getStructDecoder([
         ['authorizationData', getOptionDecoder(getAuthorizationDataDecoder())],
         ['newUpdateAuthority', getOptionDecoder(getAddressDecoder())],
         [
           'data',
           getOptionDecoder(
-            getStructDecoder<{
-              name: string;
-              symbol: string;
-              uri: string;
-              sellerFeeBasisPoints: number;
-              creators: Option<Array<Creator>>;
-            }>([
+            getStructDecoder([
               ['name', getStringDecoder()],
               ['symbol', getStringDecoder()],
               ['uri', getStringDecoder()],

--- a/test/packages/js-experimental/src/generated/types/useAssetArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/useAssetArgs.ts
@@ -22,24 +22,14 @@ export type UseAssetArgs = { __kind: 'V1'; useCount: bigint };
 export type UseAssetArgsArgs = { __kind: 'V1'; useCount: number | bigint };
 
 export function getUseAssetArgsEncoder() {
-  return getDataEnumEncoder<UseAssetArgsArgs>([
-    [
-      'V1',
-      getStructEncoder<GetDataEnumKindContent<UseAssetArgsArgs, 'V1'>>([
-        ['useCount', getU64Encoder()],
-      ]),
-    ],
+  return getDataEnumEncoder([
+    ['V1', getStructEncoder([['useCount', getU64Encoder()]])],
   ]) satisfies Encoder<UseAssetArgsArgs>;
 }
 
 export function getUseAssetArgsDecoder() {
-  return getDataEnumDecoder<UseAssetArgs>([
-    [
-      'V1',
-      getStructDecoder<GetDataEnumKindContent<UseAssetArgs, 'V1'>>([
-        ['useCount', getU64Decoder()],
-      ]),
-    ],
+  return getDataEnumDecoder([
+    ['V1', getStructDecoder([['useCount', getU64Decoder()]])],
   ]) satisfies Decoder<UseAssetArgs>;
 }
 

--- a/test/packages/js-experimental/src/generated/types/useAssetArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/useAssetArgs.ts
@@ -21,16 +21,16 @@ export type UseAssetArgs = { __kind: 'V1'; useCount: bigint };
 
 export type UseAssetArgsArgs = { __kind: 'V1'; useCount: number | bigint };
 
-export function getUseAssetArgsEncoder() {
+export function getUseAssetArgsEncoder(): Encoder<UseAssetArgsArgs> {
   return getDataEnumEncoder([
     ['V1', getStructEncoder([['useCount', getU64Encoder()]])],
-  ]) satisfies Encoder<UseAssetArgsArgs>;
+  ]);
 }
 
-export function getUseAssetArgsDecoder() {
+export function getUseAssetArgsDecoder(): Decoder<UseAssetArgs> {
   return getDataEnumDecoder([
     ['V1', getStructDecoder([['useCount', getU64Decoder()]])],
-  ]) satisfies Decoder<UseAssetArgs>;
+  ]);
 }
 
 export function getUseAssetArgsCodec(): Codec<UseAssetArgsArgs, UseAssetArgs> {

--- a/test/packages/js-experimental/src/generated/types/useMethod.ts
+++ b/test/packages/js-experimental/src/generated/types/useMethod.ts
@@ -20,12 +20,12 @@ export enum UseMethod {
 
 export type UseMethodArgs = UseMethod;
 
-export function getUseMethodEncoder() {
-  return getScalarEnumEncoder(UseMethod) satisfies Encoder<UseMethodArgs>;
+export function getUseMethodEncoder(): Encoder<UseMethodArgs> {
+  return getScalarEnumEncoder(UseMethod);
 }
 
-export function getUseMethodDecoder() {
-  return getScalarEnumDecoder(UseMethod) satisfies Decoder<UseMethod>;
+export function getUseMethodDecoder(): Decoder<UseMethod> {
+  return getScalarEnumDecoder(UseMethod);
 }
 
 export function getUseMethodCodec(): Codec<UseMethodArgs, UseMethod> {

--- a/test/packages/js-experimental/src/generated/types/uses.ts
+++ b/test/packages/js-experimental/src/generated/types/uses.ts
@@ -27,20 +27,20 @@ export type UsesArgs = {
   total: number | bigint;
 };
 
-export function getUsesEncoder() {
+export function getUsesEncoder(): Encoder<UsesArgs> {
   return getStructEncoder([
     ['useMethod', getUseMethodEncoder()],
     ['remaining', getU64Encoder()],
     ['total', getU64Encoder()],
-  ]) satisfies Encoder<UsesArgs>;
+  ]);
 }
 
-export function getUsesDecoder() {
+export function getUsesDecoder(): Decoder<Uses> {
   return getStructDecoder([
     ['useMethod', getUseMethodDecoder()],
     ['remaining', getU64Decoder()],
     ['total', getU64Decoder()],
-  ]) satisfies Decoder<Uses>;
+  ]);
 }
 
 export function getUsesCodec(): Codec<UsesArgs, Uses> {

--- a/test/packages/js-experimental/src/generated/types/uses.ts
+++ b/test/packages/js-experimental/src/generated/types/uses.ts
@@ -28,7 +28,7 @@ export type UsesArgs = {
 };
 
 export function getUsesEncoder() {
-  return getStructEncoder<UsesArgs>([
+  return getStructEncoder([
     ['useMethod', getUseMethodEncoder()],
     ['remaining', getU64Encoder()],
     ['total', getU64Encoder()],
@@ -36,7 +36,7 @@ export function getUsesEncoder() {
 }
 
 export function getUsesDecoder() {
-  return getStructDecoder<Uses>([
+  return getStructDecoder([
     ['useMethod', getUseMethodDecoder()],
     ['remaining', getU64Decoder()],
     ['total', getU64Decoder()],

--- a/test/packages/js-experimental/src/generated/types/verifyArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/verifyArgs.ts
@@ -18,12 +18,12 @@ export enum VerifyArgs {
 
 export type VerifyArgsArgs = VerifyArgs;
 
-export function getVerifyArgsEncoder() {
-  return getScalarEnumEncoder(VerifyArgs) satisfies Encoder<VerifyArgsArgs>;
+export function getVerifyArgsEncoder(): Encoder<VerifyArgsArgs> {
+  return getScalarEnumEncoder(VerifyArgs);
 }
 
-export function getVerifyArgsDecoder() {
-  return getScalarEnumDecoder(VerifyArgs) satisfies Decoder<VerifyArgs>;
+export function getVerifyArgsDecoder(): Decoder<VerifyArgs> {
+  return getScalarEnumDecoder(VerifyArgs);
 }
 
 export function getVerifyArgsCodec(): Codec<VerifyArgsArgs, VerifyArgs> {

--- a/test/packages/js-experimental/src/hooked/createReservationListInstructionData.ts
+++ b/test/packages/js-experimental/src/hooked/createReservationListInstructionData.ts
@@ -17,17 +17,13 @@ export type CreateReservationListInstructionDataArgs = {};
 
 export function getCreateReservationListInstructionDataEncoder(): Encoder<CreateReservationListInstructionDataArgs> {
   return mapEncoder(
-    getStructEncoder<{ discriminator: number }>([
-      ['discriminator', getU8Encoder()],
-    ]),
+    getStructEncoder([['discriminator', getU8Encoder()]]),
     (value) => ({ ...value, discriminator: 42 })
-  ) as Encoder<CreateReservationListInstructionDataArgs>;
+  );
 }
 
 export function getCreateReservationListInstructionDataDecoder(): Decoder<CreateReservationListInstructionData> {
-  return getStructDecoder<CreateReservationListInstructionData>([
-    ['discriminator', getU8Decoder()],
-  ]) as Decoder<CreateReservationListInstructionData>;
+  return getStructDecoder([['discriminator', getU8Decoder()]]);
 }
 
 export function getCreateReservationListInstructionDataCodec(): Codec<

--- a/test/packages/js-experimental/src/hooked/reservationListV1AccountData.ts
+++ b/test/packages/js-experimental/src/hooked/reservationListV1AccountData.ts
@@ -48,33 +48,23 @@ export type ReservationListV1AccountDataArgs = {
 
 export function getReservationListV1AccountDataEncoder(): Encoder<ReservationListV1AccountDataArgs> {
   return mapEncoder(
-    getStructEncoder<{
-      key: TmKey;
-      masterEdition: Address;
-      supplySnapshot: OptionOrNullable<number | bigint>;
-      reservations: Array<ReservationV1Args>;
-    }>([
+    getStructEncoder([
       ['key', getTmKeyEncoder()],
       ['masterEdition', getAddressEncoder()],
       ['supplySnapshot', getOptionEncoder(getU64Encoder())],
       ['reservations', getArrayEncoder(getReservationV1Encoder())],
     ]),
     (value) => ({ ...value, key: TmKey.ReservationListV1 })
-  ) as Encoder<ReservationListV1AccountDataArgs>;
+  );
 }
 
 export function getReservationListV1AccountDataDecoder(): Decoder<ReservationListV1AccountData> {
-  return getStructDecoder<{
-    key: TmKey;
-    masterEdition: Address;
-    supplySnapshot: OptionOrNullable<number | bigint>;
-    reservations: Array<ReservationV1Args>;
-  }>([
+  return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['masterEdition', getAddressDecoder()],
     ['supplySnapshot', getOptionDecoder(getU64Decoder())],
     ['reservations', getArrayDecoder(getReservationV1Decoder())],
-  ]) as Decoder<ReservationListV1AccountData>;
+  ]);
 }
 
 export function getReservationListV1AccountDataCodec(): Codec<

--- a/test/packages/js-experimental/src/hooked/resolvers.ts
+++ b/test/packages/js-experimental/src/hooked/resolvers.ts
@@ -11,7 +11,7 @@ export const resolveMasterEditionFromTokenStandard = async ({
   args,
 }: {
   accounts: Record<string, ResolvedAccount>;
-  args: { tokenStandard?: TokenStandard };
+  args: { tokenStandard?: TokenStandard | undefined };
 }): Promise<Partial<{ value: ProgramDerivedAddress | null }>> => {
   return args.tokenStandard === TokenStandard.NonFungible ||
     args.tokenStandard === TokenStandard.ProgrammableNonFungible
@@ -26,7 +26,7 @@ export const resolveMasterEditionFromTokenStandard = async ({
 export const resolveTokenOrAta = ({
   args,
 }: {
-  args: { proof?: Address[] };
+  args: { proof?: Address[] | undefined };
 }): boolean => {
   return !!args.proof && args.proof.length > 0;
 };


### PR DESCRIPTION
This PR updates the new web3.js and the js-experimental renderer such that it supports the latest codec type inferences as implemented by https://github.com/solana-labs/solana-web3.js/pull/2181.