### PR TITLE
Render a union type for parsed instructions in js-experimental

### DIFF
--- a/.changeset/mighty-bats-relax.md
+++ b/.changeset/mighty-bats-relax.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Render a union type for parsed instructions in js-experimental

--- a/src/renderers/js-experimental/ImportMap.ts
+++ b/src/renderers/js-experimental/ImportMap.ts
@@ -27,6 +27,7 @@ const DEFAULT_MODULE_MAP: Record<string, string> = {
   generatedAccounts: '../accounts',
   generatedErrors: '../errors',
   generatedTypes: '../types',
+  generatedInstructions: '../instructions',
 };
 
 export class ImportMap {

--- a/src/renderers/js-experimental/fragments/programInstructions.ts
+++ b/src/renderers/js-experimental/fragments/programInstructions.ts
@@ -4,7 +4,6 @@ import {
   ProgramNode,
   structTypeNodeFromInstructionArgumentNodes,
 } from '../../../nodes';
-import { ImportMap } from '../ImportMap';
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
 import { Fragment, fragment, mergeFragments } from './common';
 import { getDiscriminatorConditionFragment } from './discriminatorCondition';
@@ -30,7 +29,7 @@ export function getProgramInstructionsFragment(
     [
       getProgramInstructionsEnumFragment(scopeWithInstructions),
       getProgramInstructionsIdentifierFunctionFragment(scopeWithInstructions),
-      getProgramUnionParsedInstructionTypeFragment(scopeWithInstructions),
+      getProgramInstructionsParsedUnionTypeFragment(scopeWithInstructions),
     ],
     (r) => `${r.join('\n\n')}\n`
   );
@@ -106,7 +105,7 @@ function getProgramInstructionsIdentifierFunctionFragment(
   );
 }
 
-function getProgramUnionParsedInstructionTypeFragment(
+function getProgramInstructionsParsedUnionTypeFragment(
   scope: Pick<GlobalFragmentScope, 'nameApi'> & {
     programNode: ProgramNode;
     allInstructions: InstructionNode[];
@@ -114,7 +113,7 @@ function getProgramUnionParsedInstructionTypeFragment(
 ): Fragment {
   const { programNode, allInstructions, nameApi } = scope;
 
-  const programInstructionsType = nameApi.programInstructionsTypeUnion(
+  const programInstructionsType = nameApi.programInstructionsParsedUnionType(
     programNode.name
   );
 
@@ -132,9 +131,8 @@ function getProgramUnionParsedInstructionTypeFragment(
     );
 
     return fragment(
-      `| {instructionType: ${programInstructionsEnum}.${instructionEnumVariant}} & ${parsedInstructionType}`,
-      new ImportMap().add('../instructions', parsedInstructionType)
-    );
+      `| { instructionType: ${programInstructionsEnum}.${instructionEnumVariant} } & ${parsedInstructionType}`
+    ).addImports('generatedInstructions', parsedInstructionType);
   });
 
   return mergeFragments(

--- a/src/renderers/js-experimental/nameTransformers.ts
+++ b/src/renderers/js-experimental/nameTransformers.ts
@@ -67,6 +67,7 @@ export type NameTransformerKey =
   | 'programInstructionsEnum'
   | 'programInstructionsEnumVariant'
   | 'programInstructionsIdentifierFunction'
+  | 'programInstructionsTypeUnion'
   | 'programErrorClass'
   | 'programErrorCodeEnum'
   | 'programErrorCodeMap'
@@ -147,6 +148,8 @@ export const DEFAULT_NAME_TRANSFORMERS: NameTransformers = {
   programInstructionsEnumVariant: (name) => `${pascalCase(name)}`,
   programInstructionsIdentifierFunction: (name) =>
     `identify${pascalCase(name)}Instruction`,
+  programInstructionsTypeUnion: (name) =>
+    `Parsed${pascalCase(name)}Instruction`,
   programErrorClass: (name) => `${pascalCase(name)}ProgramError`,
   programErrorCodeEnum: (name) => `${pascalCase(name)}ProgramErrorCode`,
   programErrorCodeMap: (name) => `${camelCase(name)}ProgramErrorCodeMap`,

--- a/src/renderers/js-experimental/nameTransformers.ts
+++ b/src/renderers/js-experimental/nameTransformers.ts
@@ -67,7 +67,7 @@ export type NameTransformerKey =
   | 'programInstructionsEnum'
   | 'programInstructionsEnumVariant'
   | 'programInstructionsIdentifierFunction'
-  | 'programInstructionsTypeUnion'
+  | 'programInstructionsParsedUnionType'
   | 'programErrorClass'
   | 'programErrorCodeEnum'
   | 'programErrorCodeMap'
@@ -148,7 +148,7 @@ export const DEFAULT_NAME_TRANSFORMERS: NameTransformers = {
   programInstructionsEnumVariant: (name) => `${pascalCase(name)}`,
   programInstructionsIdentifierFunction: (name) =>
     `identify${pascalCase(name)}Instruction`,
-  programInstructionsTypeUnion: (name) =>
+  programInstructionsParsedUnionType: (name) =>
     `Parsed${pascalCase(name)}Instruction`,
   programErrorClass: (name) => `${pascalCase(name)}ProgramError`,
   programErrorCodeEnum: (name) => `${pascalCase(name)}ProgramErrorCode`,

--- a/test/packages/js-experimental/src/generated/programs/mplCandyMachineCore.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplCandyMachineCore.ts
@@ -13,6 +13,17 @@ import {
   MplCandyMachineCoreProgramErrorCode,
   getMplCandyMachineCoreProgramErrorFromCode,
 } from '../errors';
+import {
+  ParsedAddConfigLinesInstruction,
+  ParsedDummyInstruction,
+  ParsedInitializeInstruction,
+  ParsedMintFromCandyMachineInstruction,
+  ParsedSetAuthorityInstruction,
+  ParsedSetCollectionInstruction,
+  ParsedSetMintAuthorityInstruction,
+  ParsedUpdateCandyMachineInstruction,
+  ParsedWithdrawInstruction,
+} from '../instructions';
 import { memcmp } from '../shared';
 
 export const MPL_CANDY_MACHINE_CORE_PROGRAM_ADDRESS =
@@ -101,3 +112,32 @@ export function identifyMplCandyMachineCoreInstruction(
     'The provided instruction could not be identified as a mplCandyMachineCore instruction.'
   );
 }
+
+export type ParsedMplCandyMachineCoreInstruction =
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.Dummy;
+    } & ParsedDummyInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.AddConfigLines;
+    } & ParsedAddConfigLinesInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.Initialize;
+    } & ParsedInitializeInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.MintFromCandyMachine;
+    } & ParsedMintFromCandyMachineInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.SetAuthority;
+    } & ParsedSetAuthorityInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.SetCollection;
+    } & ParsedSetCollectionInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.SetMintAuthority;
+    } & ParsedSetMintAuthorityInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.UpdateCandyMachine;
+    } & ParsedUpdateCandyMachineInstruction)
+  | ({
+      instructionType: MplCandyMachineCoreInstruction.Withdraw;
+    } & ParsedWithdrawInstruction);

--- a/test/packages/js-experimental/src/generated/programs/mplTokenAuthRules.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplTokenAuthRules.ts
@@ -14,6 +14,11 @@ import {
   MplTokenAuthRulesProgramErrorCode,
   getMplTokenAuthRulesProgramErrorFromCode,
 } from '../errors';
+import {
+  ParsedCreateFrequencyRuleInstruction,
+  ParsedCreateRuleSetInstruction,
+  ParsedValidateInstruction,
+} from '../instructions';
 import { memcmp } from '../shared';
 import { TaKey } from '../types';
 
@@ -77,3 +82,14 @@ export function identifyMplTokenAuthRulesInstruction(
     'The provided instruction could not be identified as a mplTokenAuthRules instruction.'
   );
 }
+
+export type ParsedMplTokenAuthRulesInstruction =
+  | ({
+      instructionType: MplTokenAuthRulesInstruction.CreateRuleSet;
+    } & ParsedCreateRuleSetInstruction)
+  | ({
+      instructionType: MplTokenAuthRulesInstruction.Validate;
+    } & ParsedValidateInstruction)
+  | ({
+      instructionType: MplTokenAuthRulesInstruction.CreateFrequencyRule;
+    } & ParsedCreateFrequencyRuleInstruction);

--- a/test/packages/js-experimental/src/generated/programs/mplTokenMetadata.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplTokenMetadata.ts
@@ -14,6 +14,60 @@ import {
   MplTokenMetadataProgramErrorCode,
   getMplTokenMetadataProgramErrorFromCode,
 } from '../errors';
+import {
+  ParsedApproveCollectionAuthorityInstruction,
+  ParsedApproveUseAuthorityInstruction,
+  ParsedBubblegumSetCollectionSizeInstruction,
+  ParsedBurnEditionNftInstruction,
+  ParsedBurnInstruction,
+  ParsedBurnNftInstruction,
+  ParsedCloseEscrowAccountInstruction,
+  ParsedConvertMasterEditionV1ToV2Instruction,
+  ParsedCreateEscrowAccountInstruction,
+  ParsedCreateMasterEditionInstruction,
+  ParsedCreateMasterEditionV3Instruction,
+  ParsedCreateMetadataAccountInstruction,
+  ParsedCreateMetadataAccountV2Instruction,
+  ParsedCreateMetadataAccountV3Instruction,
+  ParsedCreateReservationListInstruction,
+  ParsedCreateV1Instruction,
+  ParsedCreateV2Instruction,
+  ParsedDelegateInstruction,
+  ParsedDeprecatedCreateMasterEditionInstruction,
+  ParsedDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction,
+  ParsedDeprecatedMintPrintingTokensInstruction,
+  ParsedDeprecatedMintPrintingTokensViaTokenInstruction,
+  ParsedDeprecatedSetReservationListInstruction,
+  ParsedFreezeDelegatedAccountInstruction,
+  ParsedMigrateInstruction,
+  ParsedMintInstruction,
+  ParsedMintNewEditionFromMasterEditionViaTokenInstruction,
+  ParsedMintNewEditionFromMasterEditionViaVaultProxyInstruction,
+  ParsedPuffMetadataInstruction,
+  ParsedRemoveCreatorVerificationInstruction,
+  ParsedRevokeCollectionAuthorityInstruction,
+  ParsedRevokeInstruction,
+  ParsedRevokeUseAuthorityInstruction,
+  ParsedSetAndVerifyCollectionInstruction,
+  ParsedSetAndVerifySizedCollectionItemInstruction,
+  ParsedSetCollectionSizeInstruction,
+  ParsedSetTokenStandardInstruction,
+  ParsedSignMetadataInstruction,
+  ParsedThawDelegatedAccountInstruction,
+  ParsedTransferInstruction,
+  ParsedTransferOutOfEscrowInstruction,
+  ParsedUnverifyCollectionInstruction,
+  ParsedUnverifySizedCollectionItemInstruction,
+  ParsedUpdateMetadataAccountInstruction,
+  ParsedUpdateMetadataAccountV2Instruction,
+  ParsedUpdatePrimarySaleHappenedViaTokenInstruction,
+  ParsedUpdateV1Instruction,
+  ParsedUseAssetInstruction,
+  ParsedUtilizeInstruction,
+  ParsedVerifyCollectionInstruction,
+  ParsedVerifyInstruction,
+  ParsedVerifySizedCollectionItemInstruction,
+} from '../instructions';
 import { memcmp } from '../shared';
 import { TmKey, getTmKeyEncoder } from '../types';
 
@@ -315,3 +369,161 @@ export function identifyMplTokenMetadataInstruction(
     'The provided instruction could not be identified as a mplTokenMetadata instruction.'
   );
 }
+
+export type ParsedMplTokenMetadataInstruction =
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateMetadataAccount;
+    } & ParsedCreateMetadataAccountInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UpdateMetadataAccount;
+    } & ParsedUpdateMetadataAccountInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.DeprecatedCreateMasterEdition;
+    } & ParsedDeprecatedCreateMasterEditionInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.DeprecatedMintNewEditionFromMasterEditionViaPrintingToken;
+    } & ParsedDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UpdatePrimarySaleHappenedViaToken;
+    } & ParsedUpdatePrimarySaleHappenedViaTokenInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.DeprecatedSetReservationList;
+    } & ParsedDeprecatedSetReservationListInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateReservationList;
+    } & ParsedCreateReservationListInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.SignMetadata;
+    } & ParsedSignMetadataInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.DeprecatedMintPrintingTokensViaToken;
+    } & ParsedDeprecatedMintPrintingTokensViaTokenInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.DeprecatedMintPrintingTokens;
+    } & ParsedDeprecatedMintPrintingTokensInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateMasterEdition;
+    } & ParsedCreateMasterEditionInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.MintNewEditionFromMasterEditionViaToken;
+    } & ParsedMintNewEditionFromMasterEditionViaTokenInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.ConvertMasterEditionV1ToV2;
+    } & ParsedConvertMasterEditionV1ToV2Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.MintNewEditionFromMasterEditionViaVaultProxy;
+    } & ParsedMintNewEditionFromMasterEditionViaVaultProxyInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.PuffMetadata;
+    } & ParsedPuffMetadataInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UpdateMetadataAccountV2;
+    } & ParsedUpdateMetadataAccountV2Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateMetadataAccountV2;
+    } & ParsedCreateMetadataAccountV2Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateMasterEditionV3;
+    } & ParsedCreateMasterEditionV3Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.VerifyCollection;
+    } & ParsedVerifyCollectionInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Utilize;
+    } & ParsedUtilizeInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.ApproveUseAuthority;
+    } & ParsedApproveUseAuthorityInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.RevokeUseAuthority;
+    } & ParsedRevokeUseAuthorityInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UnverifyCollection;
+    } & ParsedUnverifyCollectionInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.ApproveCollectionAuthority;
+    } & ParsedApproveCollectionAuthorityInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.RevokeCollectionAuthority;
+    } & ParsedRevokeCollectionAuthorityInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.SetAndVerifyCollection;
+    } & ParsedSetAndVerifyCollectionInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.FreezeDelegatedAccount;
+    } & ParsedFreezeDelegatedAccountInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.ThawDelegatedAccount;
+    } & ParsedThawDelegatedAccountInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.RemoveCreatorVerification;
+    } & ParsedRemoveCreatorVerificationInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.BurnNft;
+    } & ParsedBurnNftInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.VerifySizedCollectionItem;
+    } & ParsedVerifySizedCollectionItemInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UnverifySizedCollectionItem;
+    } & ParsedUnverifySizedCollectionItemInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.SetAndVerifySizedCollectionItem;
+    } & ParsedSetAndVerifySizedCollectionItemInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateMetadataAccountV3;
+    } & ParsedCreateMetadataAccountV3Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.SetCollectionSize;
+    } & ParsedSetCollectionSizeInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.SetTokenStandard;
+    } & ParsedSetTokenStandardInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.BubblegumSetCollectionSize;
+    } & ParsedBubblegumSetCollectionSizeInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.BurnEditionNft;
+    } & ParsedBurnEditionNftInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateEscrowAccount;
+    } & ParsedCreateEscrowAccountInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CloseEscrowAccount;
+    } & ParsedCloseEscrowAccountInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.TransferOutOfEscrow;
+    } & ParsedTransferOutOfEscrowInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateV1;
+    } & ParsedCreateV1Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.CreateV2;
+    } & ParsedCreateV2Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Mint;
+    } & ParsedMintInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UpdateV1;
+    } & ParsedUpdateV1Instruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Burn;
+    } & ParsedBurnInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.UseAsset;
+    } & ParsedUseAssetInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Transfer;
+    } & ParsedTransferInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Verify;
+    } & ParsedVerifyInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Delegate;
+    } & ParsedDelegateInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Revoke;
+    } & ParsedRevokeInstruction)
+  | ({
+      instructionType: MplTokenMetadataInstruction.Migrate;
+    } & ParsedMigrateInstruction);

--- a/test/packages/js-experimental/src/generated/programs/splSystem.ts
+++ b/test/packages/js-experimental/src/generated/programs/splSystem.ts
@@ -9,6 +9,10 @@
 import { Address } from '@solana/addresses';
 import { getU32Encoder } from '@solana/codecs-numbers';
 import { Program } from '@solana/programs';
+import {
+  ParsedCreateAccountInstruction,
+  ParsedTransferSolInstruction,
+} from '../instructions';
 import { memcmp } from '../shared';
 
 export const SPL_SYSTEM_PROGRAM_ADDRESS =
@@ -43,3 +47,11 @@ export function identifySplSystemInstruction(
     'The provided instruction could not be identified as a splSystem instruction.'
   );
 }
+
+export type ParsedSplSystemInstruction =
+  | ({
+      instructionType: SplSystemInstruction.CreateAccount;
+    } & ParsedCreateAccountInstruction)
+  | ({
+      instructionType: SplSystemInstruction.TransferSol;
+    } & ParsedTransferSolInstruction);

--- a/test/renderers/js-experimental/programsPage.test.ts
+++ b/test/renderers/js-experimental/programsPage.test.ts
@@ -236,3 +236,27 @@ test('it checks the discriminator of sub-instructions before their parents.', (t
       `if (memcmp(data, getU8Encoder().encode(1), 0)) { return SplTokenInstruction.MintTokens; }`,
   ]);
 });
+
+test('it renders a parsed union type of all available instructions for a program', (t) => {
+  // Given the following program.
+  const node = programNode({
+    name: 'splToken',
+    publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    instructions: [
+      instructionNode({ name: 'mintTokens' }),
+      instructionNode({ name: 'transferTokens' }),
+      instructionNode({ name: 'updateAuthority' }),
+    ],
+  });
+
+  // When we render it.
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Then we expect the following program parsed instruction union type.
+  renderMapContains(t, renderMap, 'programs/splToken.ts', [
+    'export type ParsedSplTokenInstruction=',
+    '|({instructionType: SplTokenInstruction.MintTokens;} & ParsedMintTokensInstruction)',
+    '|({instructionType: SplTokenInstruction.TransferTokens;} & ParsedTransferTokensInstruction)',
+    '|({instructionType: SplTokenInstruction.UpdateAuthority;} & ParsedUpdateAuthorityInstruction)',
+  ]);
+});


### PR DESCRIPTION
This PR adds a new union type to each program, where each variant is an `instructionType` from its instruction types enum together with the parsed type. Eg:

```ts
export type ParsedMplTokenAuthRulesInstruction =
  | ({
      instructionType: MplTokenAuthRulesInstruction.CreateRuleSet;
    } & ParsedCreateRuleSetInstruction)
  | ({
      instructionType: MplTokenAuthRulesInstruction.Validate;
    } & ParsedValidateInstruction)
  | ({
      instructionType: MplTokenAuthRulesInstruction.CreateFrequencyRule;
    } & ParsedCreateFrequencyRuleInstruction);
```

This allows consumers to parse instructions and then pass them around as eg `ParsedMplTokenAuthRulesInstruction`. They can then use `instructionType` to distinguish the variants, and then access the known parsed type. Passing around `ParsedCreateRuleSetInstruction` is insufficient because it doesn't have an instruction type field that we can discriminate on.

This gives more flexibility, particularly to consumers that are dealing with parsed instructions from multiple programs. 