### PR TITLE
Add default type params to `parseXInstruction` functions

### DIFF
--- a/src/renderers/js-experimental/fragments/instructionParseFunction.njk
+++ b/src/renderers/js-experimental/fragments/instructionParseFunction.njk
@@ -23,9 +23,9 @@ export type {{ instructionParsedType }}<
 };
 
 export function {{ instructionParseFunction }}<
-  TProgram extends string,
+  TProgram extends string = '{{ programAddress }}',
   {% if hasAccounts %}
-    TAccountMetas extends readonly IAccountMeta[],
+    TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
   {% endif %}
 >(
   instruction: IInstruction<TProgram>

--- a/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
+++ b/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
@@ -274,8 +274,8 @@ export type ParsedAddConfigLinesInstruction<
 };
 
 export function parseAddConfigLinesInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
@@ -473,8 +473,8 @@ export type ParsedApproveCollectionAuthorityInstruction<
 };
 
 export function parseApproveCollectionAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
@@ -587,8 +587,8 @@ export type ParsedApproveUseAuthorityInstruction<
 };
 
 export function parseApproveUseAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -391,8 +391,8 @@ export type ParsedBubblegumSetCollectionSizeInstruction<
 };
 
 export function parseBubblegumSetCollectionSizeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/burn.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burn.ts
@@ -540,8 +540,8 @@ export type ParsedBurnInstruction<
 };
 
 export function parseBurnInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
@@ -561,8 +561,8 @@ export type ParsedBurnEditionNftInstruction<
 };
 
 export function parseBurnEditionNftInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/burnNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnNft.ts
@@ -431,8 +431,8 @@ export type ParsedBurnNftInstruction<
 };
 
 export function parseBurnNftInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
@@ -461,8 +461,8 @@ export type ParsedCloseEscrowAccountInstruction<
 };
 
 export function parseCloseEscrowAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -268,8 +268,8 @@ export type ParsedConvertMasterEditionV1ToV2Instruction<
 };
 
 export function parseConvertMasterEditionV1ToV2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createAccount.ts
@@ -255,8 +255,8 @@ export type ParsedCreateAccountInstruction<
 };
 
 export function parseCreateAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = '11111111111111111111111111111111',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
@@ -502,8 +502,8 @@ export type ParsedCreateEscrowAccountInstruction<
 };
 
 export function parseCreateEscrowAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
@@ -328,8 +328,8 @@ export type ParsedCreateFrequencyRuleInstruction<
 };
 
 export function parseCreateFrequencyRuleInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
@@ -538,8 +538,8 @@ export type ParsedCreateMasterEditionInstruction<
 };
 
 export function parseCreateMasterEditionInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
@@ -541,8 +541,8 @@ export type ParsedCreateMasterEditionV3Instruction<
 };
 
 export function parseCreateMasterEditionV3Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
@@ -744,8 +744,8 @@ export type ParsedCreateMetadataAccountInstruction<
 };
 
 export function parseCreateMetadataAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
@@ -457,8 +457,8 @@ export type ParsedCreateMetadataAccountV2Instruction<
 };
 
 export function parseCreateMetadataAccountV2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
@@ -673,8 +673,8 @@ export type ParsedCreateMetadataAccountV3Instruction<
 };
 
 export function parseCreateMetadataAccountV3Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createReservationList.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createReservationList.ts
@@ -439,8 +439,8 @@ export type ParsedCreateReservationListInstruction<
 };
 
 export function parseCreateReservationListInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
@@ -322,8 +322,8 @@ export type ParsedCreateRuleSetInstruction<
 };
 
 export function parseCreateRuleSetInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV1.ts
@@ -577,8 +577,8 @@ export type ParsedCreateV1Instruction<
 };
 
 export function parseCreateV1Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/createV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV2.ts
@@ -571,8 +571,8 @@ export type ParsedCreateV2Instruction<
 };
 
 export function parseCreateV2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/delegate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/delegate.ts
@@ -695,8 +695,8 @@ export type ParsedDelegateInstruction<
 };
 
 export function parseDelegateInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
@@ -697,8 +697,8 @@ export type ParsedDeprecatedCreateMasterEditionInstruction<
 };
 
 export function parseDeprecatedCreateMasterEditionInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -755,8 +755,8 @@ export type ParsedDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstr
 };
 
 export function parseDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
@@ -462,8 +462,8 @@ export type ParsedDeprecatedMintPrintingTokensInstruction<
 };
 
 export function parseDeprecatedMintPrintingTokensInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
@@ -537,8 +537,8 @@ export type ParsedDeprecatedMintPrintingTokensViaTokenInstruction<
 };
 
 export function parseDeprecatedMintPrintingTokensViaTokenInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
@@ -324,8 +324,8 @@ export type ParsedDeprecatedSetReservationListInstruction<
 };
 
 export function parseDeprecatedSetReservationListInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/dummy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/dummy.ts
@@ -817,8 +817,8 @@ export type ParsedDummyInstruction<
 };
 
 export function parseDummyInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
@@ -348,8 +348,8 @@ export type ParsedFreezeDelegatedAccountInstruction<
 };
 
 export function parseFreezeDelegatedAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/initialize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/initialize.ts
@@ -594,8 +594,8 @@ export type ParsedInitializeInstruction<
 };
 
 export function parseInitializeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/migrate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/migrate.ts
@@ -580,8 +580,8 @@ export type ParsedMigrateInstruction<
 };
 
 export function parseMigrateInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/mint.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mint.ts
@@ -674,8 +674,8 @@ export type ParsedMintInstruction<
 };
 
 export function parseMintInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
@@ -782,8 +782,8 @@ export type ParsedMintFromCandyMachineInstruction<
 };
 
 export function parseMintFromCandyMachineInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
@@ -716,8 +716,8 @@ export type ParsedMintNewEditionFromMasterEditionViaTokenInstruction<
 };
 
 export function parseMintNewEditionFromMasterEditionViaTokenInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -819,8 +819,8 @@ export type ParsedMintNewEditionFromMasterEditionViaVaultProxyInstruction<
 };
 
 export function parseMintNewEditionFromMasterEditionViaVaultProxyInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
@@ -177,8 +177,8 @@ export type ParsedPuffMetadataInstruction<
 };
 
 export function parsePuffMetadataInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
+++ b/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
@@ -233,8 +233,8 @@ export type ParsedRemoveCreatorVerificationInstruction<
 };
 
 export function parseRemoveCreatorVerificationInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/revoke.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revoke.ts
@@ -695,8 +695,8 @@ export type ParsedRevokeInstruction<
 };
 
 export function parseRevokeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
@@ -352,8 +352,8 @@ export type ParsedRevokeCollectionAuthorityInstruction<
 };
 
 export function parseRevokeCollectionAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
@@ -499,8 +499,8 @@ export type ParsedRevokeUseAuthorityInstruction<
 };
 
 export function parseRevokeUseAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
@@ -468,8 +468,8 @@ export type ParsedSetAndVerifyCollectionInstruction<
 };
 
 export function parseSetAndVerifyCollectionInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -471,8 +471,8 @@ export type ParsedSetAndVerifySizedCollectionItemInstruction<
 };
 
 export function parseSetAndVerifySizedCollectionItemInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
@@ -243,8 +243,8 @@ export type ParsedSetAuthorityInstruction<
 };
 
 export function parseSetAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollection.ts
@@ -685,8 +685,8 @@ export type ParsedSetCollectionInstruction<
 };
 
 export function parseSetCollectionInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
@@ -351,8 +351,8 @@ export type ParsedSetCollectionSizeInstruction<
 };
 
 export function parseSetCollectionSizeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
@@ -273,8 +273,8 @@ export type ParsedSetMintAuthorityInstruction<
 };
 
 export function parseSetMintAuthorityInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
@@ -310,8 +310,8 @@ export type ParsedSetTokenStandardInstruction<
 };
 
 export function parseSetTokenStandardInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
@@ -222,8 +222,8 @@ export type ParsedSignMetadataInstruction<
 };
 
 export function parseSignMetadataInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
@@ -348,8 +348,8 @@ export type ParsedThawDelegatedAccountInstruction<
 };
 
 export function parseThawDelegatedAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/transfer.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transfer.ts
@@ -1148,8 +1148,8 @@ export type ParsedTransferInstruction<
 };
 
 export function parseTransferInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
@@ -683,8 +683,8 @@ export type ParsedTransferOutOfEscrowInstruction<
 };
 
 export function parseTransferOutOfEscrowInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/transferSol.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferSol.ts
@@ -237,8 +237,8 @@ export type ParsedTransferSolInstruction<
 };
 
 export function parseTransferSolInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = '11111111111111111111111111111111',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
@@ -400,8 +400,8 @@ export type ParsedUnverifyCollectionInstruction<
 };
 
 export function parseUnverifyCollectionInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -436,8 +436,8 @@ export type ParsedUnverifySizedCollectionItemInstruction<
 };
 
 export function parseUnverifySizedCollectionItemInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
@@ -254,8 +254,8 @@ export type ParsedUpdateCandyMachineInstruction<
 };
 
 export function parseUpdateCandyMachineInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
@@ -330,8 +330,8 @@ export type ParsedUpdateMetadataAccountInstruction<
 };
 
 export function parseUpdateMetadataAccountInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
@@ -291,8 +291,8 @@ export type ParsedUpdateMetadataAccountV2Instruction<
 };
 
 export function parseUpdateMetadataAccountV2Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -274,8 +274,8 @@ export type ParsedUpdatePrimarySaleHappenedViaTokenInstruction<
 };
 
 export function parseUpdatePrimarySaleHappenedViaTokenInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/updateV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateV1.ts
@@ -760,8 +760,8 @@ export type ParsedUpdateV1Instruction<
 };
 
 export function parseUpdateV1Instruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/useAsset.ts
+++ b/test/packages/js-experimental/src/generated/instructions/useAsset.ts
@@ -632,8 +632,8 @@ export type ParsedUseAssetInstruction<
 };
 
 export function parseUseAssetInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/utilize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/utilize.ts
@@ -621,8 +621,8 @@ export type ParsedUtilizeInstruction<
 };
 
 export function parseUtilizeInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/validate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/validate.ts
@@ -851,8 +851,8 @@ export type ParsedValidateInstruction<
 };
 
 export function parseValidateInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/verify.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verify.ts
@@ -389,8 +389,8 @@ export type ParsedVerifyInstruction<
 };
 
 export function parseVerifyInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
@@ -385,8 +385,8 @@ export type ParsedVerifyCollectionInstruction<
 };
 
 export function parseVerifyCollectionInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
@@ -436,8 +436,8 @@ export type ParsedVerifySizedCollectionItemInstruction<
 };
 
 export function parseVerifySizedCollectionItemInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/packages/js-experimental/src/generated/instructions/withdraw.ts
+++ b/test/packages/js-experimental/src/generated/instructions/withdraw.ts
@@ -225,8 +225,8 @@ export type ParsedWithdrawInstruction<
 };
 
 export function parseWithdrawInstruction<
-  TProgram extends string,
-  TAccountMetas extends readonly IAccountMeta[]
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR',
+  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &

--- a/test/renderers/js-experimental/instructionsPage.test.ts
+++ b/test/renderers/js-experimental/instructionsPage.test.ts
@@ -1,0 +1,40 @@
+import test from "ava";
+import {
+  instructionAccountNode,
+  instructionNode,
+  programNode,
+  visit,
+} from "../../../src";
+import { getRenderMapVisitor } from "../../../src/renderers/js-experimental/getRenderMapVisitor";
+import { renderMapContains } from "./_setup";
+
+test("it renders a parse function with correct default type params", (t) => {
+  // Given the following program with 1 instruction, with 1 account for the instruction
+  const node = programNode({
+    name: "myProgram",
+    publicKey: "1111",
+    instructions: [
+      instructionNode({
+        name: "foo",
+        accounts: [
+          instructionAccountNode({
+            name: "bar",
+            isWritable: false,
+            isSigner: false,
+          }),
+        ],
+      }),
+    ],
+  });
+
+  // When we render it.
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Then we expect the following parse function type
+  renderMapContains(t, renderMap, "instructions/foo.ts", [
+    "export function parseFooInstruction<",
+    "TProgram extends string = '1111'",
+    "TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[]",
+    ">",
+  ]);
+});


### PR DESCRIPTION
Currently when we generate a `ParsedXInstruction` type it has sensible default type params:

```ts
export type ParsedTransferSolInstruction<
  TProgram extends string = "11111111111111111111111111111111",
  TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
> = {
```

But the `parseXInstruction` doesn't have default type params:
```ts
export declare function parseTransferSolInstruction<
  TProgram extends string,
  TAccountMetas extends readonly IAccountMeta[],
>(instruction: <snip>
): ParsedTransferSolInstruction<TProgram, TAccountMetas>;
```

This means that the `ParsedXInstruction` type returned by `parseXInstruction(instruction)` returned `ParsedXInstruction<string, readonly IAccountMeta[]>`

This causes a problem because the definition of `ParsedSplSystemProgramInstruction` includes `ParsedTransferSolInstruction` without specifying type params, ie using the default of the program ID

Therefore we get a type error if we try to do:
```ts
const parsedInstruction = parseTransferSolInstruction(instruction)
const x: ParsedSplSystemInstruction = {
  instructionType: SplSystemInstruction.TransferSol,
  ...parsedInstruction // program address incompatible, got string, expected programID 
}
```

I think the best fix is to just add the default type params to the `parseXInstruction` function to match the `ParsedXInstruction` type, which is what this PR does

Most changes are a result of the generated test being updated, since this changes the parse function in each instruction. Non-generated changes are to [src/renderers/js-experimental/fragments/instructionParseFunction.njk](https://github.com/metaplex-foundation/kinobi/compare/main...mcintyre94:cm-default-parse-types?expand=1#diff-85b3148a6aaa22e844e30f928fbe5edd5da69b0e42b226caee74bf01fe3c6131) + https://github.com/metaplex-foundation/kinobi/compare/main...mcintyre94:cm-default-parse-types?expand=1#diff-7924ecc400cbdbf956997331e2f3f3736f6405fd3649c66d314961724d8d89ac