### PR TITLE
Add a TProgram param to the ParsedInstruction union type in js-experimental

### DIFF
--- a/.changeset/rotten-horses-behave.md
+++ b/.changeset/rotten-horses-behave.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Add a TProgram param to the ParsedInstruction union type in js-experimental

--- a/src/renderers/js-experimental/fragments/programInstructions.ts
+++ b/src/renderers/js-experimental/fragments/programInstructions.ts
@@ -113,6 +113,8 @@ function getProgramInstructionsParsedUnionTypeFragment(
 ): Fragment {
   const { programNode, allInstructions, nameApi } = scope;
 
+  const programAddress = programNode.publicKey;
+
   const programInstructionsType = nameApi.programInstructionsParsedUnionType(
     programNode.name
   );
@@ -131,12 +133,17 @@ function getProgramInstructionsParsedUnionTypeFragment(
     );
 
     return fragment(
-      `| { instructionType: ${programInstructionsEnum}.${instructionEnumVariant} } & ${parsedInstructionType}`
+      `| { instructionType: ${programInstructionsEnum}.${instructionEnumVariant} } & ${parsedInstructionType}<TProgram>`
     ).addImports('generatedInstructions', parsedInstructionType);
   });
 
   return mergeFragments(
-    [fragment(`export type ${programInstructionsType} =`), ...typeVariants],
+    [
+      fragment(
+        `export type ${programInstructionsType}<TProgram extends string = '${programAddress}'> =`
+      ),
+      ...typeVariants,
+    ],
     (r) => r.join('\n')
   );
 }

--- a/test/packages/js-experimental/src/generated/programs/mplCandyMachineCore.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplCandyMachineCore.ts
@@ -113,31 +113,33 @@ export function identifyMplCandyMachineCoreInstruction(
   );
 }
 
-export type ParsedMplCandyMachineCoreInstruction =
+export type ParsedMplCandyMachineCoreInstruction<
+  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR'
+> =
   | ({
       instructionType: MplCandyMachineCoreInstruction.Dummy;
-    } & ParsedDummyInstruction)
+    } & ParsedDummyInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.AddConfigLines;
-    } & ParsedAddConfigLinesInstruction)
+    } & ParsedAddConfigLinesInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.Initialize;
-    } & ParsedInitializeInstruction)
+    } & ParsedInitializeInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.MintFromCandyMachine;
-    } & ParsedMintFromCandyMachineInstruction)
+    } & ParsedMintFromCandyMachineInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.SetAuthority;
-    } & ParsedSetAuthorityInstruction)
+    } & ParsedSetAuthorityInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.SetCollection;
-    } & ParsedSetCollectionInstruction)
+    } & ParsedSetCollectionInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.SetMintAuthority;
-    } & ParsedSetMintAuthorityInstruction)
+    } & ParsedSetMintAuthorityInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.UpdateCandyMachine;
-    } & ParsedUpdateCandyMachineInstruction)
+    } & ParsedUpdateCandyMachineInstruction<TProgram>)
   | ({
       instructionType: MplCandyMachineCoreInstruction.Withdraw;
-    } & ParsedWithdrawInstruction);
+    } & ParsedWithdrawInstruction<TProgram>);

--- a/test/packages/js-experimental/src/generated/programs/mplTokenAuthRules.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplTokenAuthRules.ts
@@ -83,13 +83,15 @@ export function identifyMplTokenAuthRulesInstruction(
   );
 }
 
-export type ParsedMplTokenAuthRulesInstruction =
+export type ParsedMplTokenAuthRulesInstruction<
+  TProgram extends string = 'auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'
+> =
   | ({
       instructionType: MplTokenAuthRulesInstruction.CreateRuleSet;
-    } & ParsedCreateRuleSetInstruction)
+    } & ParsedCreateRuleSetInstruction<TProgram>)
   | ({
       instructionType: MplTokenAuthRulesInstruction.Validate;
-    } & ParsedValidateInstruction)
+    } & ParsedValidateInstruction<TProgram>)
   | ({
       instructionType: MplTokenAuthRulesInstruction.CreateFrequencyRule;
-    } & ParsedCreateFrequencyRuleInstruction);
+    } & ParsedCreateFrequencyRuleInstruction<TProgram>);

--- a/test/packages/js-experimental/src/generated/programs/mplTokenMetadata.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplTokenMetadata.ts
@@ -370,160 +370,162 @@ export function identifyMplTokenMetadataInstruction(
   );
 }
 
-export type ParsedMplTokenMetadataInstruction =
+export type ParsedMplTokenMetadataInstruction<
+  TProgram extends string = 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
+> =
   | ({
       instructionType: MplTokenMetadataInstruction.CreateMetadataAccount;
-    } & ParsedCreateMetadataAccountInstruction)
+    } & ParsedCreateMetadataAccountInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UpdateMetadataAccount;
-    } & ParsedUpdateMetadataAccountInstruction)
+    } & ParsedUpdateMetadataAccountInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.DeprecatedCreateMasterEdition;
-    } & ParsedDeprecatedCreateMasterEditionInstruction)
+    } & ParsedDeprecatedCreateMasterEditionInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.DeprecatedMintNewEditionFromMasterEditionViaPrintingToken;
-    } & ParsedDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction)
+    } & ParsedDeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UpdatePrimarySaleHappenedViaToken;
-    } & ParsedUpdatePrimarySaleHappenedViaTokenInstruction)
+    } & ParsedUpdatePrimarySaleHappenedViaTokenInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.DeprecatedSetReservationList;
-    } & ParsedDeprecatedSetReservationListInstruction)
+    } & ParsedDeprecatedSetReservationListInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateReservationList;
-    } & ParsedCreateReservationListInstruction)
+    } & ParsedCreateReservationListInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.SignMetadata;
-    } & ParsedSignMetadataInstruction)
+    } & ParsedSignMetadataInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.DeprecatedMintPrintingTokensViaToken;
-    } & ParsedDeprecatedMintPrintingTokensViaTokenInstruction)
+    } & ParsedDeprecatedMintPrintingTokensViaTokenInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.DeprecatedMintPrintingTokens;
-    } & ParsedDeprecatedMintPrintingTokensInstruction)
+    } & ParsedDeprecatedMintPrintingTokensInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateMasterEdition;
-    } & ParsedCreateMasterEditionInstruction)
+    } & ParsedCreateMasterEditionInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.MintNewEditionFromMasterEditionViaToken;
-    } & ParsedMintNewEditionFromMasterEditionViaTokenInstruction)
+    } & ParsedMintNewEditionFromMasterEditionViaTokenInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.ConvertMasterEditionV1ToV2;
-    } & ParsedConvertMasterEditionV1ToV2Instruction)
+    } & ParsedConvertMasterEditionV1ToV2Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.MintNewEditionFromMasterEditionViaVaultProxy;
-    } & ParsedMintNewEditionFromMasterEditionViaVaultProxyInstruction)
+    } & ParsedMintNewEditionFromMasterEditionViaVaultProxyInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.PuffMetadata;
-    } & ParsedPuffMetadataInstruction)
+    } & ParsedPuffMetadataInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UpdateMetadataAccountV2;
-    } & ParsedUpdateMetadataAccountV2Instruction)
+    } & ParsedUpdateMetadataAccountV2Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateMetadataAccountV2;
-    } & ParsedCreateMetadataAccountV2Instruction)
+    } & ParsedCreateMetadataAccountV2Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateMasterEditionV3;
-    } & ParsedCreateMasterEditionV3Instruction)
+    } & ParsedCreateMasterEditionV3Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.VerifyCollection;
-    } & ParsedVerifyCollectionInstruction)
+    } & ParsedVerifyCollectionInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Utilize;
-    } & ParsedUtilizeInstruction)
+    } & ParsedUtilizeInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.ApproveUseAuthority;
-    } & ParsedApproveUseAuthorityInstruction)
+    } & ParsedApproveUseAuthorityInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.RevokeUseAuthority;
-    } & ParsedRevokeUseAuthorityInstruction)
+    } & ParsedRevokeUseAuthorityInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UnverifyCollection;
-    } & ParsedUnverifyCollectionInstruction)
+    } & ParsedUnverifyCollectionInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.ApproveCollectionAuthority;
-    } & ParsedApproveCollectionAuthorityInstruction)
+    } & ParsedApproveCollectionAuthorityInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.RevokeCollectionAuthority;
-    } & ParsedRevokeCollectionAuthorityInstruction)
+    } & ParsedRevokeCollectionAuthorityInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.SetAndVerifyCollection;
-    } & ParsedSetAndVerifyCollectionInstruction)
+    } & ParsedSetAndVerifyCollectionInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.FreezeDelegatedAccount;
-    } & ParsedFreezeDelegatedAccountInstruction)
+    } & ParsedFreezeDelegatedAccountInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.ThawDelegatedAccount;
-    } & ParsedThawDelegatedAccountInstruction)
+    } & ParsedThawDelegatedAccountInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.RemoveCreatorVerification;
-    } & ParsedRemoveCreatorVerificationInstruction)
+    } & ParsedRemoveCreatorVerificationInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.BurnNft;
-    } & ParsedBurnNftInstruction)
+    } & ParsedBurnNftInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.VerifySizedCollectionItem;
-    } & ParsedVerifySizedCollectionItemInstruction)
+    } & ParsedVerifySizedCollectionItemInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UnverifySizedCollectionItem;
-    } & ParsedUnverifySizedCollectionItemInstruction)
+    } & ParsedUnverifySizedCollectionItemInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.SetAndVerifySizedCollectionItem;
-    } & ParsedSetAndVerifySizedCollectionItemInstruction)
+    } & ParsedSetAndVerifySizedCollectionItemInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateMetadataAccountV3;
-    } & ParsedCreateMetadataAccountV3Instruction)
+    } & ParsedCreateMetadataAccountV3Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.SetCollectionSize;
-    } & ParsedSetCollectionSizeInstruction)
+    } & ParsedSetCollectionSizeInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.SetTokenStandard;
-    } & ParsedSetTokenStandardInstruction)
+    } & ParsedSetTokenStandardInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.BubblegumSetCollectionSize;
-    } & ParsedBubblegumSetCollectionSizeInstruction)
+    } & ParsedBubblegumSetCollectionSizeInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.BurnEditionNft;
-    } & ParsedBurnEditionNftInstruction)
+    } & ParsedBurnEditionNftInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateEscrowAccount;
-    } & ParsedCreateEscrowAccountInstruction)
+    } & ParsedCreateEscrowAccountInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CloseEscrowAccount;
-    } & ParsedCloseEscrowAccountInstruction)
+    } & ParsedCloseEscrowAccountInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.TransferOutOfEscrow;
-    } & ParsedTransferOutOfEscrowInstruction)
+    } & ParsedTransferOutOfEscrowInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateV1;
-    } & ParsedCreateV1Instruction)
+    } & ParsedCreateV1Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.CreateV2;
-    } & ParsedCreateV2Instruction)
+    } & ParsedCreateV2Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Mint;
-    } & ParsedMintInstruction)
+    } & ParsedMintInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UpdateV1;
-    } & ParsedUpdateV1Instruction)
+    } & ParsedUpdateV1Instruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Burn;
-    } & ParsedBurnInstruction)
+    } & ParsedBurnInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.UseAsset;
-    } & ParsedUseAssetInstruction)
+    } & ParsedUseAssetInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Transfer;
-    } & ParsedTransferInstruction)
+    } & ParsedTransferInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Verify;
-    } & ParsedVerifyInstruction)
+    } & ParsedVerifyInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Delegate;
-    } & ParsedDelegateInstruction)
+    } & ParsedDelegateInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Revoke;
-    } & ParsedRevokeInstruction)
+    } & ParsedRevokeInstruction<TProgram>)
   | ({
       instructionType: MplTokenMetadataInstruction.Migrate;
-    } & ParsedMigrateInstruction);
+    } & ParsedMigrateInstruction<TProgram>);

--- a/test/packages/js-experimental/src/generated/programs/splSystem.ts
+++ b/test/packages/js-experimental/src/generated/programs/splSystem.ts
@@ -48,10 +48,12 @@ export function identifySplSystemInstruction(
   );
 }
 
-export type ParsedSplSystemInstruction =
+export type ParsedSplSystemInstruction<
+  TProgram extends string = '11111111111111111111111111111111'
+> =
   | ({
       instructionType: SplSystemInstruction.CreateAccount;
-    } & ParsedCreateAccountInstruction)
+    } & ParsedCreateAccountInstruction<TProgram>)
   | ({
       instructionType: SplSystemInstruction.TransferSol;
-    } & ParsedTransferSolInstruction);
+    } & ParsedTransferSolInstruction<TProgram>);

--- a/test/renderers/js-experimental/programsPage.test.ts
+++ b/test/renderers/js-experimental/programsPage.test.ts
@@ -254,9 +254,9 @@ test('it renders a parsed union type of all available instructions for a program
 
   // Then we expect the following program parsed instruction union type.
   renderMapContains(t, renderMap, 'programs/splToken.ts', [
-    'export type ParsedSplTokenInstruction=',
-    '|({instructionType: SplTokenInstruction.MintTokens;} & ParsedMintTokensInstruction)',
-    '|({instructionType: SplTokenInstruction.TransferTokens;} & ParsedTransferTokensInstruction)',
-    '|({instructionType: SplTokenInstruction.UpdateAuthority;} & ParsedUpdateAuthorityInstruction)',
+    "export type ParsedSplTokenInstruction<TProgram extends string='TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>=",
+    '|({instructionType: SplTokenInstruction.MintTokens;} & ParsedMintTokensInstruction<TProgram>)',
+    '|({instructionType: SplTokenInstruction.TransferTokens;} & ParsedTransferTokensInstruction<TProgram>)',
+    '|({instructionType: SplTokenInstruction.UpdateAuthority;} & ParsedUpdateAuthorityInstruction<TProgram>)',
   ]);
 });


### PR DESCRIPTION
This PR adds a type param to the parsed instruction union type, defaulting to the program address: 

```ts
export type ParsedMplCandyMachineCoreInstruction<
  TProgram extends string = 'CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR'
> =
  | ({
      instructionType: MplCandyMachineCoreInstruction.Dummy;
    } & ParsedDummyInstruction)
    } & ParsedDummyInstruction<TProgram>)
  ...
```

This doesn't change any behaviour because the `ParsedXInstruction` types already use the same default `TProgram`. But it makes this link more explicit, and over-rideable if needed.

See https://github.com/metaplex-foundation/kinobi/pull/164#issuecomment-1971244887