### PR TITLE
Clean web3.js dependencies

### DIFF
--- a/.changeset/late-starfishes-develop.md
+++ b/.changeset/late-starfishes-develop.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/kinobi': patch
+---
+
+Use @solana/codecs instead of codec sub-packages

--- a/src/renderers/js-experimental/ImportMap.ts
+++ b/src/renderers/js-experimental/ImportMap.ts
@@ -14,7 +14,6 @@ const DEFAULT_MODULE_MAP: Record<string, string> = {
   solanaPrograms: '@solana/programs',
   solanaOptions: '@solana/options',
   solanaSigners: '@solana/signers',
-  solanaTransactions: '@solana/transactions',
 
   // Internal.
   types: '../types',

--- a/test/packages/js-experimental/package.json
+++ b/test/packages/js-experimental/package.json
@@ -21,8 +21,7 @@
     "@solana/keys": "2.0.0-experimental.a7a613a",
     "@solana/programs": "2.0.0-experimental.a7a613a",
     "@solana/options": "2.0.0-experimental.a7a613a",
-    "@solana/signers": "2.0.0-experimental.a7a613a",
-    "@solana/transactions": "2.0.0-experimental.a7a613a"
+    "@solana/signers": "2.0.0-experimental.a7a613a"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/test/packages/js-experimental/package.json
+++ b/test/packages/js-experimental/package.json
@@ -15,7 +15,6 @@
     "@solana/addresses": "2.0.0-experimental.a7a613a",
     "@solana/codecs": "2.0.0-experimental.a7a613a",
     "@solana/instructions": "2.0.0-experimental.a7a613a",
-    "@solana/keys": "2.0.0-experimental.a7a613a",
     "@solana/programs": "2.0.0-experimental.a7a613a",
     "@solana/signers": "2.0.0-experimental.a7a613a"
   },

--- a/test/packages/js-experimental/package.json
+++ b/test/packages/js-experimental/package.json
@@ -13,14 +13,10 @@
   "dependencies": {
     "@solana/accounts": "2.0.0-experimental.a7a613a",
     "@solana/addresses": "2.0.0-experimental.a7a613a",
-    "@solana/codecs-core": "2.0.0-experimental.a7a613a",
-    "@solana/codecs-data-structures": "2.0.0-experimental.a7a613a",
-    "@solana/codecs-numbers": "2.0.0-experimental.a7a613a",
-    "@solana/codecs-strings": "2.0.0-experimental.a7a613a",
+    "@solana/codecs": "2.0.0-experimental.a7a613a",
     "@solana/instructions": "2.0.0-experimental.a7a613a",
     "@solana/keys": "2.0.0-experimental.a7a613a",
     "@solana/programs": "2.0.0-experimental.a7a613a",
-    "@solana/options": "2.0.0-experimental.a7a613a",
     "@solana/signers": "2.0.0-experimental.a7a613a"
   },
   "devDependencies": {

--- a/test/packages/js-experimental/pnpm-lock.yaml
+++ b/test/packages/js-experimental/pnpm-lock.yaml
@@ -11,16 +11,7 @@ dependencies:
   '@solana/addresses':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
-  '@solana/codecs-core':
-    specifier: 2.0.0-experimental.a7a613a
-    version: 2.0.0-experimental.a7a613a
-  '@solana/codecs-data-structures':
-    specifier: 2.0.0-experimental.a7a613a
-    version: 2.0.0-experimental.a7a613a
-  '@solana/codecs-numbers':
-    specifier: 2.0.0-experimental.a7a613a
-    version: 2.0.0-experimental.a7a613a
-  '@solana/codecs-strings':
+  '@solana/codecs':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/instructions':
@@ -29,9 +20,6 @@ dependencies:
   '@solana/keys':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
-  '@solana/options':
-    specifier: 2.0.0-experimental.a7a613a
-    version: 2.0.0-experimental.a7a613a
   '@solana/programs':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a
@@ -97,6 +85,18 @@ packages:
       '@solana/codecs-core': 2.0.0-experimental.a7a613a
       '@solana/codecs-numbers': 2.0.0-experimental.a7a613a
       fastestsmallesttextencoderdecoder: 1.0.22
+    dev: false
+
+  /@solana/codecs@2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22):
+    resolution: {integrity: sha512-9egdKvdYisL1pc4EXQJmikuIJISJFvmRkSFq147xSQoTg19J7wKikILqa39/jnthqE1NwyVgZgkv/h2ILoB/8A==}
+    dependencies:
+      '@solana/codecs-core': 2.0.0-experimental.a7a613a
+      '@solana/codecs-data-structures': 2.0.0-experimental.a7a613a
+      '@solana/codecs-numbers': 2.0.0-experimental.a7a613a
+      '@solana/codecs-strings': 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/options': 2.0.0-experimental.a7a613a
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
     dev: false
 
   /@solana/errors@2.0.0-experimental.a7a613a:

--- a/test/packages/js-experimental/pnpm-lock.yaml
+++ b/test/packages/js-experimental/pnpm-lock.yaml
@@ -17,9 +17,6 @@ dependencies:
   '@solana/instructions':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a
-  '@solana/keys':
-    specifier: 2.0.0-experimental.a7a613a
-    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
   '@solana/programs':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a

--- a/test/packages/js-experimental/pnpm-lock.yaml
+++ b/test/packages/js-experimental/pnpm-lock.yaml
@@ -38,9 +38,6 @@ dependencies:
   '@solana/signers':
     specifier: 2.0.0-experimental.a7a613a
     version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
-  '@solana/transactions':
-    specifier: 2.0.0-experimental.a7a613a
-    version: 2.0.0-experimental.a7a613a(fastestsmallesttextencoderdecoder@1.0.22)
 
 devDependencies:
   typescript:

--- a/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
+++ b/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
@@ -29,20 +29,16 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   CandyMachineData,
   CandyMachineDataArgs,

--- a/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
@@ -28,20 +28,17 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type CollectionAuthorityRecord<TAddress extends string = string> =

--- a/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
@@ -25,13 +25,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import { DelegateRecordSeeds, findDelegateRecordPda } from '../pdas';
 import {
   DelegateRole,

--- a/test/packages/js-experimental/src/generated/accounts/edition.ts
+++ b/test/packages/js-experimental/src/generated/accounts/edition.ts
@@ -29,13 +29,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type Edition<TAddress extends string = string> = Account<

--- a/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
+++ b/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
@@ -25,15 +25,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type EditionMarker<TAddress extends string = string> = Account<

--- a/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
+++ b/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
@@ -25,18 +25,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getI64Decoder,
   getI64Encoder,
+  getStructDecoder,
+  getStructEncoder,
   getU64Decoder,
   getU64Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import { findFrequencyAccountPda } from '../pdas';
 import { TaKey } from '../types';
 

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
@@ -28,20 +28,17 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import { MasterEditionV1Seeds, findMasterEditionV1Pda } from '../pdas';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
@@ -24,20 +24,17 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import { MasterEditionV2Seeds, findMasterEditionV2Pda } from '../pdas';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 

--- a/test/packages/js-experimental/src/generated/accounts/metadata.ts
+++ b/test/packages/js-experimental/src/generated/accounts/metadata.ts
@@ -28,30 +28,25 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU16Decoder,
   getU16Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
+  mapEncoder,
+} from '@solana/codecs';
 import { MetadataSeeds, findMetadataPda } from '../pdas';
 import {
   Collection,

--- a/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
@@ -28,22 +28,19 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getArrayDecoder,
-  getArrayEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
+  getArrayDecoder,
+  getArrayEncoder,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   Reservation,
   ReservationArgs,

--- a/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
+++ b/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
@@ -29,13 +29,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   EscrowAuthority,
   EscrowAuthorityArgs,

--- a/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
@@ -25,18 +25,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
 export type UseAuthorityRecord<TAddress extends string = string> = Account<

--- a/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
+++ b/test/packages/js-experimental/src/generated/instructions/addConfigLines.ts
@@ -12,22 +12,18 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU32Decoder,
   getU32Encoder,
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveCollectionAuthority.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/approveUseAuthority.ts
@@ -12,18 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/burn.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burn.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnEditionNft.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/burnNft.ts
+++ b/test/packages/js-experimental/src/generated/instructions/burnNft.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/closeEscrowAccount.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/convertMasterEditionV1ToV2.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createAccount.ts
@@ -16,18 +16,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU32Decoder,
   getU32Encoder,
   getU64Decoder,
   getU64Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createEscrowAccount.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createFrequencyRule.ts
@@ -12,19 +12,16 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getI64Decoder,
   getI64Encoder,
+  getStringDecoder,
+  getStringEncoder,
+  getStructDecoder,
+  getStructEncoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEdition.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMasterEditionV3.ts
@@ -13,13 +13,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccount.ts
@@ -12,24 +12,25 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU16Decoder,
   getU16Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -41,12 +42,6 @@ import {
   WritableAccount,
   WritableSignerAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import { getMetadataSize } from '../accounts';
 import { findMetadataPda } from '../pdas';

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV2.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getBooleanDecoder,
   getBooleanEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createMetadataAccountV3.ts
@@ -11,16 +11,19 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -32,12 +35,6 @@ import {
   WritableAccount,
   WritableSignerAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import { findMetadataPda } from '../pdas';
 import {

--- a/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createRuleSet.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/createV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV1.ts
@@ -11,19 +11,19 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -35,12 +35,6 @@ import {
   WritableAccount,
   WritableSignerAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
   ResolvedAccount,

--- a/test/packages/js-experimental/src/generated/instructions/createV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createV2.ts
@@ -11,19 +11,19 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -35,12 +35,6 @@ import {
   WritableAccount,
   WritableSignerAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
   ResolvedAccount,

--- a/test/packages/js-experimental/src/generated/instructions/delegate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/delegate.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedCreateMasterEdition.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintNewEditionFromMasterEditionViaPrintingToken.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokens.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedMintPrintingTokensViaToken.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
+++ b/test/packages/js-experimental/src/generated/instructions/deprecatedSetReservationList.ts
@@ -11,21 +11,21 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -35,12 +35,6 @@ import {
   ReadonlySignerAccount,
   WritableAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
   ResolvedAccount,

--- a/test/packages/js-experimental/src/generated/instructions/dummy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/dummy.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/freezeDelegatedAccount.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/initialize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/initialize.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/migrate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/migrate.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/mint.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mint.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintFromCandyMachine.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaToken.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/mintNewEditionFromMasterEditionViaVaultProxy.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/puffMetadata.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
+++ b/test/packages/js-experimental/src/generated/instructions/removeCreatorVerification.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/revoke.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revoke.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeCollectionAuthority.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/revokeUseAuthority.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifyCollection.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setAuthority.ts
@@ -16,15 +16,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollection.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setCollectionSize.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setMintAuthority.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
+++ b/test/packages/js-experimental/src/generated/instructions/setTokenStandard.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
+++ b/test/packages/js-experimental/src/generated/instructions/signMetadata.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/thawDelegatedAccount.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/transfer.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transfer.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferOutOfEscrow.ts
@@ -12,18 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/transferSol.ts
+++ b/test/packages/js-experimental/src/generated/instructions/transferSol.ts
@@ -12,18 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU32Decoder,
   getU32Encoder,
   getU64Decoder,
   getU64Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifyCollection.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateCandyMachine.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccount.ts
@@ -15,24 +15,25 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU16Decoder,
   getU16Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -42,12 +43,6 @@ import {
   ReadonlySignerAccount,
   WritableAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
   ResolvedAccount,

--- a/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateMetadataAccountV2.ts
@@ -15,16 +15,19 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -34,12 +37,6 @@ import {
   ReadonlySignerAccount,
   WritableAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
   ResolvedAccount,

--- a/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updatePrimarySaleHappenedViaToken.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/updateV1.ts
+++ b/test/packages/js-experimental/src/generated/instructions/updateV1.ts
@@ -15,24 +15,26 @@ import {
   Codec,
   Decoder,
   Encoder,
+  Option,
+  OptionOrNullable,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU16Decoder,
   getU16Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  mapEncoder,
+  some,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,
@@ -43,13 +45,6 @@ import {
   ReadonlySignerAccount,
   WritableAccount,
 } from '@solana/instructions';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-  some,
-} from '@solana/options';
 import { IAccountSignerMeta, TransactionSigner } from '@solana/signers';
 import {
   ResolvedAccount,

--- a/test/packages/js-experimental/src/generated/instructions/useAsset.ts
+++ b/test/packages/js-experimental/src/generated/instructions/useAsset.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/utilize.ts
+++ b/test/packages/js-experimental/src/generated/instructions/utilize.ts
@@ -12,18 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/validate.ts
+++ b/test/packages/js-experimental/src/generated/instructions/validate.ts
@@ -12,14 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/verify.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verify.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifyCollection.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/test/packages/js-experimental/src/generated/instructions/verifySizedCollectionItem.ts
@@ -12,13 +12,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/instructions/withdraw.ts
+++ b/test/packages/js-experimental/src/generated/instructions/withdraw.ts
@@ -12,15 +12,14 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   AccountRole,
   IAccountMeta,

--- a/test/packages/js-experimental/src/generated/pdas/delegateRecord.ts
+++ b/test/packages/js-experimental/src/generated/pdas/delegateRecord.ts
@@ -12,7 +12,7 @@ import {
   getAddressEncoder,
   getProgramDerivedAddress,
 } from '@solana/addresses';
-import { getStringEncoder } from '@solana/codecs-strings';
+import { getStringEncoder } from '@solana/codecs';
 import { DelegateRoleArgs, getDelegateRoleEncoder } from '../types';
 
 export type DelegateRecordSeeds = {

--- a/test/packages/js-experimental/src/generated/pdas/frequencyAccount.ts
+++ b/test/packages/js-experimental/src/generated/pdas/frequencyAccount.ts
@@ -12,7 +12,7 @@ import {
   getAddressEncoder,
   getProgramDerivedAddress,
 } from '@solana/addresses';
-import { getStringEncoder } from '@solana/codecs-strings';
+import { getStringEncoder } from '@solana/codecs';
 
 export async function findFrequencyAccountPda(
   config: { programAddress?: Address | undefined } = {}

--- a/test/packages/js-experimental/src/generated/pdas/masterEditionV1.ts
+++ b/test/packages/js-experimental/src/generated/pdas/masterEditionV1.ts
@@ -12,7 +12,7 @@ import {
   getAddressEncoder,
   getProgramDerivedAddress,
 } from '@solana/addresses';
-import { getStringEncoder } from '@solana/codecs-strings';
+import { getStringEncoder } from '@solana/codecs';
 import { DelegateRoleArgs, getDelegateRoleEncoder } from '../types';
 
 export type MasterEditionV1Seeds = {

--- a/test/packages/js-experimental/src/generated/pdas/masterEditionV2.ts
+++ b/test/packages/js-experimental/src/generated/pdas/masterEditionV2.ts
@@ -12,7 +12,7 @@ import {
   getAddressEncoder,
   getProgramDerivedAddress,
 } from '@solana/addresses';
-import { getStringEncoder } from '@solana/codecs-strings';
+import { getStringEncoder } from '@solana/codecs';
 
 export type MasterEditionV2Seeds = {
   /** The address of the mint account */

--- a/test/packages/js-experimental/src/generated/pdas/metadata.ts
+++ b/test/packages/js-experimental/src/generated/pdas/metadata.ts
@@ -12,7 +12,7 @@ import {
   getAddressEncoder,
   getProgramDerivedAddress,
 } from '@solana/addresses';
-import { getStringEncoder } from '@solana/codecs-strings';
+import { getStringEncoder } from '@solana/codecs';
 
 export type MetadataSeeds = {
   /** The address of the mint account */

--- a/test/packages/js-experimental/src/generated/programs/mplTokenAuthRules.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplTokenAuthRules.ts
@@ -7,7 +7,7 @@
  */
 
 import { Address } from '@solana/addresses';
-import { getU64Encoder, getU8Encoder } from '@solana/codecs-numbers';
+import { getU64Encoder, getU8Encoder } from '@solana/codecs';
 import { Program, ProgramWithErrors } from '@solana/programs';
 import {
   MplTokenAuthRulesProgramError,

--- a/test/packages/js-experimental/src/generated/programs/mplTokenMetadata.ts
+++ b/test/packages/js-experimental/src/generated/programs/mplTokenMetadata.ts
@@ -7,7 +7,7 @@
  */
 
 import { Address } from '@solana/addresses';
-import { getU8Encoder } from '@solana/codecs-numbers';
+import { getU8Encoder } from '@solana/codecs';
 import { Program, ProgramWithErrors } from '@solana/programs';
 import {
   MplTokenMetadataProgramError,

--- a/test/packages/js-experimental/src/generated/programs/splSystem.ts
+++ b/test/packages/js-experimental/src/generated/programs/splSystem.ts
@@ -7,7 +7,7 @@
  */
 
 import { Address } from '@solana/addresses';
-import { getU32Encoder } from '@solana/codecs-numbers';
+import { getU32Encoder } from '@solana/codecs';
 import { Program } from '@solana/programs';
 import {
   ParsedCreateAccountInstruction,

--- a/test/packages/js-experimental/src/generated/types/assetData.ts
+++ b/test/packages/js-experimental/src/generated/types/assetData.ts
@@ -11,28 +11,28 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  Option,
+  OptionOrNullable,
+  combineCodec,
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU16Decoder,
   getU16Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
+} from '@solana/codecs';
 import {
   Collection,
   CollectionArgs,

--- a/test/packages/js-experimental/src/generated/types/authorityType.ts
+++ b/test/packages/js-experimental/src/generated/types/authorityType.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum AuthorityType {
   Metadata,

--- a/test/packages/js-experimental/src/generated/types/authorizationData.ts
+++ b/test/packages/js-experimental/src/generated/types/authorizationData.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 import { Payload, PayloadArgs, getPayloadDecoder, getPayloadEncoder } from '.';
 
 export type AuthorizationData = { payload: Payload };

--- a/test/packages/js-experimental/src/generated/types/burnArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/burnArgs.ts
@@ -6,12 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export enum BurnArgs {
   V1,

--- a/test/packages/js-experimental/src/generated/types/candyMachineData.ts
+++ b/test/packages/js-experimental/src/generated/types/candyMachineData.ts
@@ -6,28 +6,28 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  Option,
+  OptionOrNullable,
+  combineCodec,
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU16Decoder,
   getU16Encoder,
   getU64Decoder,
   getU64Encoder,
-} from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
+} from '@solana/codecs';
 import {
   CmCreator,
   CmCreatorArgs,

--- a/test/packages/js-experimental/src/generated/types/cmCreator.ts
+++ b/test/packages/js-experimental/src/generated/types/cmCreator.ts
@@ -11,14 +11,18 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getBooleanDecoder,
   getBooleanEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+} from '@solana/codecs';
 
 export type CmCreator = {
   /** Pubkey address */

--- a/test/packages/js-experimental/src/generated/types/collection.ts
+++ b/test/packages/js-experimental/src/generated/types/collection.ts
@@ -16,14 +16,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getBooleanDecoder,
   getBooleanEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
+  mapEncoder,
+} from '@solana/codecs';
 
 export type Collection = { verified: boolean; key: Address };
 

--- a/test/packages/js-experimental/src/generated/types/collectionDetails.ts
+++ b/test/packages/js-experimental/src/generated/types/collectionDetails.ts
@@ -6,16 +6,20 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
+  combineCodec,
   getDataEnumDecoder,
   getDataEnumEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type CollectionDetails = { __kind: 'V1'; size: bigint };
 

--- a/test/packages/js-experimental/src/generated/types/configLine.ts
+++ b/test/packages/js-experimental/src/generated/types/configLine.ts
@@ -6,12 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+} from '@solana/codecs';
 
 /** Config line struct for storing asset (NFT) data pre-mint. */
 export type ConfigLine = {

--- a/test/packages/js-experimental/src/generated/types/configLineSettings.ts
+++ b/test/packages/js-experimental/src/generated/types/configLineSettings.ts
@@ -6,15 +6,20 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getBooleanDecoder,
   getBooleanEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU32Decoder, getU32Encoder } from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  getU32Decoder,
+  getU32Encoder,
+} from '@solana/codecs';
 
 /** Config line settings to allocate space for individual name + URI. */
 export type ConfigLineSettings = {

--- a/test/packages/js-experimental/src/generated/types/createMasterEditionArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/createMasterEditionArgs.ts
@@ -6,18 +6,20 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
+  Codec,
+  Decoder,
+  Encoder,
   Option,
   OptionOrNullable,
+  combineCodec,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type CreateMasterEditionArgs = { maxSupply: Option<bigint> };
 

--- a/test/packages/js-experimental/src/generated/types/creator.ts
+++ b/test/packages/js-experimental/src/generated/types/creator.ts
@@ -11,14 +11,18 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getBooleanDecoder,
   getBooleanEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+} from '@solana/codecs';
 
 export type Creator = { address: Address; verified: boolean; share: number };
 

--- a/test/packages/js-experimental/src/generated/types/dataV2.ts
+++ b/test/packages/js-experimental/src/generated/types/dataV2.ts
@@ -6,21 +6,24 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
-  getArrayDecoder,
-  getArrayEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU16Decoder, getU16Encoder } from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
-import {
+  Codec,
+  Decoder,
+  Encoder,
   Option,
   OptionOrNullable,
+  combineCodec,
+  getArrayDecoder,
+  getArrayEncoder,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStringDecoder,
+  getStringEncoder,
+  getStructDecoder,
+  getStructEncoder,
+  getU16Decoder,
+  getU16Encoder,
+} from '@solana/codecs';
 import {
   Collection,
   CollectionArgs,

--- a/test/packages/js-experimental/src/generated/types/delegateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateArgs.ts
@@ -6,18 +6,22 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
+  combineCodec,
   getDataEnumDecoder,
   getDataEnumEncoder,
   getStructDecoder,
   getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
   getUnitDecoder,
   getUnitEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+} from '@solana/codecs';
 
 export type DelegateArgs =
   | { __kind: 'CollectionV1' }

--- a/test/packages/js-experimental/src/generated/types/delegateRole.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateRole.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum DelegateRole {
   Authority,

--- a/test/packages/js-experimental/src/generated/types/delegateState.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateState.ts
@@ -11,13 +11,16 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getBooleanDecoder,
   getBooleanEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 import {
   DelegateRole,
   DelegateRoleArgs,

--- a/test/packages/js-experimental/src/generated/types/dummyLines.ts
+++ b/test/packages/js-experimental/src/generated/types/dummyLines.ts
@@ -6,14 +6,18 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getArrayDecoder,
   getArrayEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 /** Dummy lines. */
 export type DummyLines = {

--- a/test/packages/js-experimental/src/generated/types/escrowAuthority.ts
+++ b/test/packages/js-experimental/src/generated/types/escrowAuthority.ts
@@ -11,10 +11,13 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
+  combineCodec,
   getDataEnumDecoder,
   getDataEnumEncoder,
   getStructDecoder,
@@ -23,7 +26,7 @@ import {
   getTupleEncoder,
   getUnitDecoder,
   getUnitEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export type EscrowAuthority =
   | { __kind: 'TokenOwner' }

--- a/test/packages/js-experimental/src/generated/types/extendedPayload.ts
+++ b/test/packages/js-experimental/src/generated/types/extendedPayload.ts
@@ -6,17 +6,22 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getMapDecoder,
   getMapEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
   getTupleDecoder,
   getTupleEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  getU8Decoder,
+  getU8Encoder,
+} from '@solana/codecs';
 import {
   PayloadKey,
   PayloadKeyArgs,

--- a/test/packages/js-experimental/src/generated/types/hiddenSettings.ts
+++ b/test/packages/js-experimental/src/generated/types/hiddenSettings.ts
@@ -6,14 +6,18 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getBytesDecoder,
   getBytesEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+} from '@solana/codecs';
 
 /** Hidden settings for large mints used with off-chain data. */
 export type HiddenSettings = {

--- a/test/packages/js-experimental/src/generated/types/migrateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/migrateArgs.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum MigrateArgs {
   V1,

--- a/test/packages/js-experimental/src/generated/types/mintArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintArgs.ts
@@ -6,22 +6,24 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
-  getDataEnumDecoder,
-  getDataEnumEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
+  getDataEnumDecoder,
+  getDataEnumEncoder,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 import {
   AuthorizationData,
   AuthorizationDataArgs,

--- a/test/packages/js-experimental/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintNewEditionFromMasterEditionViaTokenArgs.ts
@@ -6,12 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type MintNewEditionFromMasterEditionViaTokenArgs = { edition: bigint };
 

--- a/test/packages/js-experimental/src/generated/types/mintPrintingTokensViaTokenArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/mintPrintingTokensViaTokenArgs.ts
@@ -6,12 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type MintPrintingTokensViaTokenArgs = { supply: bigint };
 

--- a/test/packages/js-experimental/src/generated/types/operation.ts
+++ b/test/packages/js-experimental/src/generated/types/operation.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum Operation {
   Transfer,

--- a/test/packages/js-experimental/src/generated/types/payload.ts
+++ b/test/packages/js-experimental/src/generated/types/payload.ts
@@ -6,13 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getMapDecoder,
   getMapEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 import {
   PayloadKey,
   PayloadKeyArgs,

--- a/test/packages/js-experimental/src/generated/types/payloadKey.ts
+++ b/test/packages/js-experimental/src/generated/types/payloadKey.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum PayloadKey {
   Target,

--- a/test/packages/js-experimental/src/generated/types/payloadType.ts
+++ b/test/packages/js-experimental/src/generated/types/payloadType.ts
@@ -11,10 +11,13 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
+  combineCodec,
   getArrayDecoder,
   getArrayEncoder,
   getBytesDecoder,
@@ -25,13 +28,11 @@ import {
   getStructEncoder,
   getTupleDecoder,
   getTupleEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU32Decoder,
   getU32Encoder,
   getU64Decoder,
   getU64Encoder,
-} from '@solana/codecs-numbers';
+} from '@solana/codecs';
 
 /** This is a union of all the possible payload types. */
 export type PayloadType =

--- a/test/packages/js-experimental/src/generated/types/programmableConfig.ts
+++ b/test/packages/js-experimental/src/generated/types/programmableConfig.ts
@@ -11,11 +11,14 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export type ProgrammableConfig = { ruleSet: Address };
 

--- a/test/packages/js-experimental/src/generated/types/reservation.ts
+++ b/test/packages/js-experimental/src/generated/types/reservation.ts
@@ -11,12 +11,16 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type Reservation = {
   address: Address;

--- a/test/packages/js-experimental/src/generated/types/reservationListV1AccountData.ts
+++ b/test/packages/js-experimental/src/generated/types/reservationListV1AccountData.ts
@@ -15,22 +15,19 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getArrayDecoder,
-  getArrayEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
+  getArrayDecoder,
+  getArrayEncoder,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   ReservationV1,
   ReservationV1Args,

--- a/test/packages/js-experimental/src/generated/types/reservationV1.ts
+++ b/test/packages/js-experimental/src/generated/types/reservationV1.ts
@@ -11,12 +11,16 @@ import {
   getAddressDecoder,
   getAddressEncoder,
 } from '@solana/addresses';
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+} from '@solana/codecs';
 
 export type ReservationV1 = {
   address: Address;

--- a/test/packages/js-experimental/src/generated/types/revokeArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/revokeArgs.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum RevokeArgs {
   CollectionV1,

--- a/test/packages/js-experimental/src/generated/types/setCollectionSizeArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/setCollectionSizeArgs.ts
@@ -6,12 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type SetCollectionSizeArgs = { size: bigint };
 

--- a/test/packages/js-experimental/src/generated/types/taCreateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/taCreateArgs.ts
@@ -6,15 +6,20 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getBytesDecoder,
   getBytesEncoder,
+  getStringDecoder,
+  getStringEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU32Decoder, getU32Encoder } from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
+  getU32Decoder,
+  getU32Encoder,
+} from '@solana/codecs';
 
 export type TaCreateArgs = {
   ruleSetName: string;

--- a/test/packages/js-experimental/src/generated/types/taKey.ts
+++ b/test/packages/js-experimental/src/generated/types/taKey.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum TaKey {
   Uninitialized,

--- a/test/packages/js-experimental/src/generated/types/tmCreateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/tmCreateArgs.ts
@@ -6,27 +6,26 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
+  Option,
+  OptionOrNullable,
+  combineCodec,
   getDataEnumDecoder,
   getDataEnumEncoder,
+  getOptionDecoder,
+  getOptionEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import {
   getU64Decoder,
   getU64Encoder,
   getU8Decoder,
   getU8Encoder,
-} from '@solana/codecs-numbers';
-import {
-  Option,
-  OptionOrNullable,
-  getOptionDecoder,
-  getOptionEncoder,
-} from '@solana/options';
+} from '@solana/codecs';
 import {
   AssetData,
   AssetDataArgs,

--- a/test/packages/js-experimental/src/generated/types/tmKey.ts
+++ b/test/packages/js-experimental/src/generated/types/tmKey.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum TmKey {
   Uninitialized,

--- a/test/packages/js-experimental/src/generated/types/tokenStandard.ts
+++ b/test/packages/js-experimental/src/generated/types/tokenStandard.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum TokenStandard {
   NonFungible,

--- a/test/packages/js-experimental/src/generated/types/transferArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/transferArgs.ts
@@ -6,22 +6,24 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
-  getDataEnumDecoder,
-  getDataEnumEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
+  getDataEnumDecoder,
+  getDataEnumEncoder,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 import {
   AuthorizationData,
   AuthorizationDataArgs,

--- a/test/packages/js-experimental/src/generated/types/updateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/updateArgs.ts
@@ -15,30 +15,28 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   GetDataEnumKind,
   GetDataEnumKindContent,
+  Option,
+  OptionOrNullable,
+  combineCodec,
   getArrayDecoder,
   getArrayEncoder,
   getBooleanDecoder,
   getBooleanEncoder,
   getDataEnumDecoder,
   getDataEnumEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU16Decoder, getU16Encoder } from '@solana/codecs-numbers';
-import { getStringDecoder, getStringEncoder } from '@solana/codecs-strings';
-import {
-  Option,
-  OptionOrNullable,
   getOptionDecoder,
   getOptionEncoder,
+  getStringDecoder,
+  getStringEncoder,
+  getStructDecoder,
+  getStructEncoder,
+  getU16Decoder,
+  getU16Encoder,
+  mapEncoder,
   some,
-} from '@solana/options';
+} from '@solana/codecs';
 import {
   AuthorityType,
   AuthorityTypeArgs,

--- a/test/packages/js-experimental/src/generated/types/useAssetArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/useAssetArgs.ts
@@ -6,16 +6,20 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
   GetDataEnumKind,
   GetDataEnumKindContent,
+  combineCodec,
   getDataEnumDecoder,
   getDataEnumEncoder,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 
 export type UseAssetArgs = { __kind: 'V1'; useCount: bigint };
 

--- a/test/packages/js-experimental/src/generated/types/useMethod.ts
+++ b/test/packages/js-experimental/src/generated/types/useMethod.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum UseMethod {
   Burn,

--- a/test/packages/js-experimental/src/generated/types/uses.ts
+++ b/test/packages/js-experimental/src/generated/types/uses.ts
@@ -6,12 +6,16 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+  getU64Decoder,
+  getU64Encoder,
+} from '@solana/codecs';
 import {
   UseMethod,
   UseMethodArgs,

--- a/test/packages/js-experimental/src/generated/types/verifyArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/verifyArgs.ts
@@ -6,11 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Codec, Decoder, Encoder, combineCodec } from '@solana/codecs-core';
 import {
+  Codec,
+  Decoder,
+  Encoder,
+  combineCodec,
   getScalarEnumDecoder,
   getScalarEnumEncoder,
-} from '@solana/codecs-data-structures';
+} from '@solana/codecs';
 
 export enum VerifyArgs {
   V1,

--- a/test/packages/js-experimental/src/hooked/createReservationListInstructionData.ts
+++ b/test/packages/js-experimental/src/hooked/createReservationListInstructionData.ts
@@ -3,13 +3,12 @@ import {
   Decoder,
   Encoder,
   combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
   getStructDecoder,
   getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
+  getU8Decoder,
+  getU8Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 
 export type CreateReservationListInstructionData = { discriminator: number };
 

--- a/test/packages/js-experimental/src/hooked/reservationListV1AccountData.ts
+++ b/test/packages/js-experimental/src/hooked/reservationListV1AccountData.ts
@@ -7,22 +7,19 @@ import {
   Codec,
   Decoder,
   Encoder,
-  combineCodec,
-  mapEncoder,
-} from '@solana/codecs-core';
-import {
-  getArrayDecoder,
-  getArrayEncoder,
-  getStructDecoder,
-  getStructEncoder,
-} from '@solana/codecs-data-structures';
-import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
-import {
   Option,
   OptionOrNullable,
+  combineCodec,
+  getArrayDecoder,
+  getArrayEncoder,
   getOptionDecoder,
   getOptionEncoder,
-} from '@solana/options';
+  getStructDecoder,
+  getStructEncoder,
+  getU64Decoder,
+  getU64Encoder,
+  mapEncoder,
+} from '@solana/codecs';
 import {
   ReservationV1,
   ReservationV1Args,

--- a/test/renderers/js-experimental/ImportMap.test.ts
+++ b/test/renderers/js-experimental/ImportMap.test.ts
@@ -50,7 +50,7 @@ test('it offers some default dependency mappings', (t) => {
   t.is(
     importStatements,
     "import { Address } from '@solana/addresses';\n" +
-      "import { Codec } from '@solana/codecs-core';\n" +
+      "import { Codec } from '@solana/codecs';\n" +
       "import { MyCustomType } from '../../hooked';\n" +
       "import { myHelper } from '../shared';\n" +
       "import { MyType } from '../types';"
@@ -74,4 +74,20 @@ test('it does not render empty import statements', (t) => {
   t.is(new ImportMap().toString(), '');
   t.is(new ImportMap().add('shared', []).toString(), '');
   t.is(new ImportMap().addAlias('shared', 'Foo', 'Bar').toString(), '');
+});
+
+test('it merges imports that have the same aliases together', (t) => {
+  // Given an import map with some recognized dependency keys.
+  const importMap = new ImportMap()
+    .add('packageA', 'foo')
+    .add('packageB', 'bar');
+
+  // When we render it.
+  const importStatements = importMap.toString({
+    packageA: '@solana/packages',
+    packageB: '@solana/packages',
+  });
+
+  // Then we expect the following import statements.
+  t.is(importStatements, "import { bar, foo } from '@solana/packages';");
 });

--- a/test/renderers/js-experimental/ImportMap.test.ts
+++ b/test/renderers/js-experimental/ImportMap.test.ts
@@ -5,7 +5,7 @@ test('it renders JavaScript import statements', (t) => {
   // Given an import map with 3 imports from 2 sources.
   const importMap = new ImportMap()
     .add('@solana/addresses', ['getAddressEncoder', 'Address'])
-    .add('@solana/transactions', 'Transaction');
+    .add('@solana/instructions', 'IInstructionWithData');
 
   // When we render it.
   const importStatements = importMap.toString();
@@ -14,7 +14,7 @@ test('it renders JavaScript import statements', (t) => {
   t.is(
     importStatements,
     "import { Address, getAddressEncoder } from '@solana/addresses';\n" +
-      "import { Transaction } from '@solana/transactions';"
+      "import { IInstructionWithData } from '@solana/instructions';"
   );
 });
 


### PR DESCRIPTION
- Use @solana/codecs instead of codec sub-packages.
- Remove unused @solana/transactions and @solana/keys dependencies from test package (transparent to the end user so no changeset required).