### PR TITLE
Fix enum size import issue in JS renderers

### DIFF
--- a/.changeset/violet-clocks-pull.md
+++ b/.changeset/violet-clocks-pull.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Fix enum size import issue in JS renderers

--- a/src/renderers/js-experimental/getTypeManifestVisitor.ts
+++ b/src/renderers/js-experimental/getTypeManifestVisitor.ts
@@ -207,11 +207,13 @@ export function getTypeManifestVisitor(input: {
             .mapRender(
               (r) => `getDataEnumEncoder([${r}]${encoderOptionsAsString})`
             )
+            .mergeImportsWith(encoderImports)
             .addImports('solanaCodecsDataStructures', ['getDataEnumEncoder']);
           mergedManifest.decoder
             .mapRender(
               (r) => `getDataEnumDecoder([${r}]${decoderOptionsAsString})`
             )
+            .mergeImportsWith(decoderImports)
             .addImports('solanaCodecsDataStructures', ['getDataEnumDecoder']);
           return mergedManifest;
         },

--- a/src/renderers/js/getTypeManifestVisitor.ts
+++ b/src/renderers/js/getTypeManifestVisitor.ts
@@ -136,10 +136,7 @@ export function getTypeManifestVisitor(input: {
         visitEnumType(enumType, { self }) {
           const strictImports = new JavaScriptImportMap();
           const looseImports = new JavaScriptImportMap();
-          const serializerImports = new JavaScriptImportMap().add(
-            'umiSerializers',
-            'scalarEnum'
-          );
+          const serializerImports = new JavaScriptImportMap();
 
           const variantNames = enumType.variants.map((variant) =>
             pascalCase(variant.name)
@@ -176,7 +173,10 @@ export function getTypeManifestVisitor(input: {
               serializer:
                 `scalarEnum<${currentParentName.strict}>` +
                 `(${currentParentName.strict + optionsAsString})`,
-              serializerImports,
+              serializerImports: serializerImports.add(
+                'umiSerializers',
+                'scalarEnum'
+              ),
             };
           }
 
@@ -194,6 +194,9 @@ export function getTypeManifestVisitor(input: {
           });
 
           const mergedManifest = mergeManifests(variants);
+          mergedManifest.strictImports.mergeWith(strictImports);
+          mergedManifest.looseImports.mergeWith(looseImports);
+          mergedManifest.serializerImports.mergeWith(serializerImports);
           const variantSerializers = variants
             .map((variant) => variant.serializer)
             .join(', ');

--- a/test/mpl_token_metadata.json
+++ b/test/mpl_token_metadata.json
@@ -4229,6 +4229,7 @@
       "name": "DelegateArgs",
       "type": {
         "kind": "enum",
+        "size": "u16",
         "variants": [
           {
             "name": "CollectionV1"

--- a/test/packages/js-experimental/src/generated/types/delegateArgs.ts
+++ b/test/packages/js-experimental/src/generated/types/delegateArgs.ts
@@ -17,6 +17,8 @@ import {
   getDataEnumEncoder,
   getStructDecoder,
   getStructEncoder,
+  getU16Decoder,
+  getU16Encoder,
   getU64Decoder,
   getU64Encoder,
   getUnitDecoder,
@@ -34,19 +36,25 @@ export type DelegateArgsArgs =
   | { __kind: 'TransferV1'; amount: number | bigint };
 
 export function getDelegateArgsEncoder(): Encoder<DelegateArgsArgs> {
-  return getDataEnumEncoder([
-    ['CollectionV1', getUnitEncoder()],
-    ['SaleV1', getStructEncoder([['amount', getU64Encoder()]])],
-    ['TransferV1', getStructEncoder([['amount', getU64Encoder()]])],
-  ]);
+  return getDataEnumEncoder(
+    [
+      ['CollectionV1', getUnitEncoder()],
+      ['SaleV1', getStructEncoder([['amount', getU64Encoder()]])],
+      ['TransferV1', getStructEncoder([['amount', getU64Encoder()]])],
+    ],
+    { size: getU16Encoder() }
+  );
 }
 
 export function getDelegateArgsDecoder(): Decoder<DelegateArgs> {
-  return getDataEnumDecoder([
-    ['CollectionV1', getUnitDecoder()],
-    ['SaleV1', getStructDecoder([['amount', getU64Decoder()]])],
-    ['TransferV1', getStructDecoder([['amount', getU64Decoder()]])],
-  ]);
+  return getDataEnumDecoder(
+    [
+      ['CollectionV1', getUnitDecoder()],
+      ['SaleV1', getStructDecoder([['amount', getU64Decoder()]])],
+      ['TransferV1', getStructDecoder([['amount', getU64Decoder()]])],
+    ],
+    { size: getU16Decoder() }
+  );
 }
 
 export function getDelegateArgsCodec(): Codec<DelegateArgsArgs, DelegateArgs> {

--- a/test/packages/js/src/generated/types/delegateArgs.ts
+++ b/test/packages/js/src/generated/types/delegateArgs.ts
@@ -13,6 +13,7 @@ import {
   Serializer,
   dataEnum,
   struct,
+  u16,
   u64,
   unit,
 } from '@metaplex-foundation/umi/serializers';
@@ -47,7 +48,7 @@ export function getDelegateArgsSerializer(): Serializer<
         ]),
       ],
     ],
-    { description: 'DelegateArgs' }
+    { size: u16(), description: 'DelegateArgs' }
   ) as Serializer<DelegateArgsArgs, DelegateArgs>;
 }
 


### PR DESCRIPTION
When setting a custom size on a data enum, the size codec/serializer was being generated but not imported.