### PR TITLE
Add support for remaining account signers in JS experimental

### DIFF
--- a/.changeset/fast-camels-turn.md
+++ b/.changeset/fast-camels-turn.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Add support for remaining account signers in JS experimental

--- a/src/nodes/InstructionRemainingAccountsNode.ts
+++ b/src/nodes/InstructionRemainingAccountsNode.ts
@@ -7,8 +7,9 @@ export type InstructionRemainingAccountsNode = {
   readonly value: ArgumentValueNode | ResolverValueNode;
 
   // Data.
-  readonly isWritable?: boolean;
+  readonly isOptional?: boolean;
   readonly isSigner?: boolean | 'either';
+  readonly isWritable?: boolean;
 };
 
 export type InstructionRemainingAccountsNodeInput = Omit<
@@ -19,14 +20,16 @@ export type InstructionRemainingAccountsNodeInput = Omit<
 export function instructionRemainingAccountsNode(
   value: ArgumentValueNode | ResolverValueNode,
   options: {
-    isWritable?: boolean;
+    isOptional?: boolean;
     isSigner?: boolean | 'either';
+    isWritable?: boolean;
   } = {}
 ): InstructionRemainingAccountsNode {
   return {
     kind: 'instructionRemainingAccountsNode',
     value,
-    isWritable: options.isWritable,
+    isOptional: options.isOptional,
     isSigner: options.isSigner,
+    isWritable: options.isWritable,
   };
 }

--- a/src/renderers/js-experimental/fragments/instructionInputType.njk
+++ b/src/renderers/js-experimental/fragments/instructionInputType.njk
@@ -1,20 +1,15 @@
 {% import "templates/macros.njk" as macros %}
 
 export type {{ instructionInputType }}
-{%- if accounts.length > 0 -%}
+{%- if instruction.accounts.length > 0 -%}
 <
-  {%- for account in accounts -%}
-    {{ account.typeParam }} extends string = string,
+  {%- for account in instruction.accounts -%}
+    TAccount{{ account.name | pascalCase }} extends string = string,
   {% endfor %}
 >
 {% endif %}
 = {
-  {% for account in accounts %}
-    {% if account.docs.length > 0 %}
-      {{ macros.docblock(account.docs) }}
-    {% endif %}
-    {{ account.name | camelCase }}{{ account.optionalSign }}: {{ account.type }};
-  {% endfor %}
+  {{ accountsFragment }}
   {% for dataArg in dataArgs %}
     {{ dataArg.renamedName | camelCase }}{{ dataArg.optionalSign }}: {{ dataArgsType }}["{{ dataArg.name | camelCase }}"];
   {% endfor %}

--- a/src/renderers/js-experimental/fragments/instructionInputType.njk
+++ b/src/renderers/js-experimental/fragments/instructionInputType.njk
@@ -13,12 +13,13 @@ export type {{ instructionInputType }}
     {% if account.docs.length > 0 %}
       {{ macros.docblock(account.docs) }}
     {% endif %}
-    {{ account.name | camelCase }}{{ account.optionalSign }}: {{ account.type }},
+    {{ account.name | camelCase }}{{ account.optionalSign }}: {{ account.type }};
   {% endfor %}
   {% for dataArg in dataArgs %}
-    {{ dataArg.renamedName | camelCase }}{{ dataArg.optionalSign }}: {{ dataArgsType }}["{{ dataArg.name | camelCase }}"],
+    {{ dataArg.renamedName | camelCase }}{{ dataArg.optionalSign }}: {{ dataArgsType }}["{{ dataArg.name | camelCase }}"];
   {% endfor %}
   {% for extraArg in extraArgs %}
-    {{ extraArg.renamedName | camelCase }}{{ extraArg.optionalSign }}: {{ extraArgsType }}["{{ extraArg.name | camelCase }}"],
+    {{ extraArg.renamedName | camelCase }}{{ extraArg.optionalSign }}: {{ extraArgsType }}["{{ extraArg.name | camelCase }}"];
   {% endfor %}
+  {{ remainingAccountsFragment }}
 }

--- a/src/renderers/js-experimental/fragments/instructionInputType.njk
+++ b/src/renderers/js-experimental/fragments/instructionInputType.njk
@@ -9,8 +9,8 @@ export type {{ instructionInputType }}
 >
 {% endif %}
 = {{ customDataArgumentsFragment }} {
-  {{ accountsFragment }}
-  {{ dataArgumentsFragment }}
-  {{ extraArgumentsFragment }}
+  {{ accountsFragment -}}
+  {{ dataArgumentsFragment -}}
+  {{ extraArgumentsFragment -}}
   {{ remainingAccountsFragment }}
 }

--- a/src/renderers/js-experimental/fragments/instructionInputType.njk
+++ b/src/renderers/js-experimental/fragments/instructionInputType.njk
@@ -8,7 +8,7 @@ export type {{ instructionInputType }}
   {% endfor %}
 >
 {% endif %}
-= {
+= {{ customDataArgumentsFragment }} {
   {{ accountsFragment }}
   {{ dataArgumentsFragment }}
   {{ extraArgumentsFragment }}

--- a/src/renderers/js-experimental/fragments/instructionInputType.njk
+++ b/src/renderers/js-experimental/fragments/instructionInputType.njk
@@ -10,11 +10,7 @@ export type {{ instructionInputType }}
 {% endif %}
 = {
   {{ accountsFragment }}
-  {% for dataArg in dataArgs %}
-    {{ dataArg.renamedName | camelCase }}{{ dataArg.optionalSign }}: {{ dataArgsType }}["{{ dataArg.name | camelCase }}"];
-  {% endfor %}
-  {% for extraArg in extraArgs %}
-    {{ extraArg.renamedName | camelCase }}{{ extraArg.optionalSign }}: {{ extraArgsType }}["{{ extraArg.name | camelCase }}"];
-  {% endfor %}
+  {{ dataArgumentsFragment }}
+  {{ extraArgumentsFragment }}
   {{ remainingAccountsFragment }}
 }

--- a/src/renderers/js-experimental/fragments/instructionRemainingAccounts.ts
+++ b/src/renderers/js-experimental/fragments/instructionRemainingAccounts.ts
@@ -23,7 +23,9 @@ export function getInstructionRemainingAccountsFragment(
     fragments,
     (r) =>
       `// Remaining accounts.\n` +
-      `const remainingAccounts: IAccountMeta[] = [...${r.join(', ...')}]`
+      `const remainingAccounts: IAccountMeta[] = ${
+        r.length === 1 ? r[0] : `[...${r.join(', ...')}]`
+      }`
   ).addImports('solanaInstructions', ['IAccountMeta']);
 }
 

--- a/src/renderers/js-experimental/getTypeManifestVisitor.ts
+++ b/src/renderers/js-experimental/getTypeManifestVisitor.ts
@@ -7,7 +7,7 @@ import {
   structTypeNode,
   structTypeNodeFromInstructionArgumentNodes,
 } from '../../nodes';
-import { camelCase, pipe } from '../../shared';
+import { camelCase, jsDocblock, pipe } from '../../shared';
 import { Visitor, extendVisitor, staticVisitor, visit } from '../../visitors';
 import { ImportMap } from './ImportMap';
 import { TypeManifest, mergeManifests } from './TypeManifest';
@@ -427,7 +427,10 @@ export function getTypeManifestVisitor(input: {
         visitStructFieldType(structFieldType, { self }) {
           const name = camelCase(structFieldType.name);
           const childManifest = visit(structFieldType.type, self);
-          const docblock = createDocblock(structFieldType.docs);
+          const docblock =
+            structFieldType.docs.length > 0
+              ? `\n${jsDocblock(structFieldType.docs)}`
+              : '';
           const originalLooseType = childManifest.looseType.render;
           childManifest.strictType.mapRender(
             (r) => `${docblock}${name}: ${r}; `
@@ -683,13 +686,6 @@ export function getTypeManifestVisitor(input: {
         },
       })
   );
-}
-
-function createDocblock(docs: string[]): string {
-  if (docs.length <= 0) return '';
-  if (docs.length === 1) return `\n/** ${docs[0]} */\n`;
-  const lines = docs.map((doc) => ` * ${doc}`);
-  return `\n/**\n${lines.join('\n')}\n */\n`;
 }
 
 function getArrayLikeSizeOption(

--- a/src/renderers/js/getRenderMapVisitor.ts
+++ b/src/renderers/js/getRenderMapVisitor.ts
@@ -5,6 +5,7 @@ import {
   FieldDiscriminatorNode,
   getAllAccounts,
   getAllDefinedTypes,
+  getAllInstructionArguments,
   getAllInstructionsWithSubs,
   InstructionNode,
   isDataEnum,
@@ -460,7 +461,16 @@ export function getRenderMapVisitor(
           const byteDelta = node.byteDeltas?.[0] ?? undefined;
           const hasByteResolver =
             byteDelta && isNode(byteDelta.value, 'resolverValueNode');
-          const remainingAccounts = node.remainingAccounts?.[0] ?? undefined;
+          let remainingAccounts = node.remainingAccounts?.[0] ?? undefined;
+          if (
+            remainingAccounts &&
+            isNode(remainingAccounts.value, 'argumentValueNode') &&
+            getAllInstructionArguments(node).every(
+              (arg) => arg.name !== remainingAccounts?.value.name
+            )
+          ) {
+            remainingAccounts = undefined;
+          }
           const hasRemainingAccountsResolver =
             remainingAccounts &&
             isNode(remainingAccounts.value, 'resolverValueNode');
@@ -592,7 +602,10 @@ export function getRenderMapVisitor(
           }
 
           // Remaining accounts.
-          if (hasRemainingAccountsResolver) {
+          if (
+            remainingAccounts &&
+            isNode(remainingAccounts.value, 'resolverValueNode')
+          ) {
             imports.add(
               remainingAccounts.value.importFrom ?? 'hooked',
               camelCase(remainingAccounts.value.name)

--- a/src/renderers/js/getTypeManifestVisitor.ts
+++ b/src/renderers/js/getTypeManifestVisitor.ts
@@ -9,7 +9,7 @@ import {
   structTypeNode,
   structTypeNodeFromInstructionArgumentNodes,
 } from '../../nodes';
-import { camelCase, pascalCase, pipe } from '../../shared';
+import { camelCase, jsDocblock, pascalCase, pipe } from '../../shared';
 import { Visitor, extendVisitor, staticVisitor, visit } from '../../visitors';
 import { JavaScriptImportMap } from './JavaScriptImportMap';
 import { ParsedCustomDataOptions } from './customDataHelpers';
@@ -415,7 +415,10 @@ export function getTypeManifestVisitor(input: {
         visitStructFieldType(structFieldType, { self }) {
           const name = camelCase(structFieldType.name);
           const fieldChild = visit(structFieldType.type, self);
-          const docblock = createDocblock(structFieldType.docs);
+          const docblock =
+            structFieldType.docs.length > 0
+              ? `\n${jsDocblock(structFieldType.docs)}`
+              : '';
           const baseField = {
             ...fieldChild,
             strictType: `${docblock}${name}: ${fieldChild.strictType}; `,
@@ -688,13 +691,6 @@ function mergeManifests(
     ),
     isEnum: false,
   };
-}
-
-function createDocblock(docs: string[]): string {
-  if (docs.length <= 0) return '';
-  if (docs.length === 1) return `\n/** ${docs[0]} */\n`;
-  const lines = docs.map((doc) => ` * ${doc}`);
-  return `\n/**\n${lines.join('\n')}\n */\n`;
 }
 
 function getArrayLikeSizeOption(

--- a/src/renderers/rust/getTypeManifestVisitor.ts
+++ b/src/renderers/rust/getTypeManifestVisitor.ts
@@ -5,7 +5,7 @@ import {
   isScalarEnum,
   numberTypeNode,
 } from '../../nodes';
-import { pascalCase, pipe, snakeCase } from '../../shared';
+import { pascalCase, pipe, rustDocblock, snakeCase } from '../../shared';
 import { extendVisitor, mergeVisitor, visit } from '../../visitors';
 import { RustImportMap } from './RustImportMap';
 
@@ -320,7 +320,7 @@ export function getTypeManifestVisitor() {
           nestedStruct = originalNestedStruct;
 
           const fieldName = snakeCase(structFieldType.name);
-          const docblock = createDocblock(structFieldType.docs);
+          const docblock = rustDocblock(structFieldType.docs);
 
           let derive = '';
           if (fieldManifest.type === 'Pubkey') {
@@ -470,10 +470,4 @@ function mergeManifests(
     ),
     nestedStructs: manifests.flatMap((m) => m.nestedStructs),
   };
-}
-
-function createDocblock(docs: string[]): string {
-  if (docs.length <= 0) return '';
-  const lines = docs.map((doc) => `/// ${doc}`);
-  return `${lines.join('\n')}\n`;
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -59,6 +59,19 @@ export function mainCase(str: string): MainCaseString {
   return camelCase(str) as MainCaseString;
 }
 
+export function jsDocblock(docs: string[]): string {
+  if (docs.length <= 0) return '';
+  if (docs.length === 1) return `/** ${docs[0]} */\n`;
+  const lines = docs.map((doc) => ` * ${doc}`);
+  return `/**\n${lines.join('\n')}\n */\n`;
+}
+
+export function rustDocblock(docs: string[]): string {
+  if (docs.length <= 0) return '';
+  const lines = docs.map((doc) => `/// ${doc}`);
+  return `${lines.join('\n')}\n`;
+}
+
 export function readJson<T extends object>(value: string): T {
   return JSON.parse(readFileSync(value, 'utf-8')) as T;
 }
@@ -91,6 +104,8 @@ export const resolveTemplate = (
   env.addFilter('snakeCase', snakeCase);
   env.addFilter('kebabCase', kebabCase);
   env.addFilter('titleCase', titleCase);
+  env.addFilter('jsDocblock', jsDocblock);
+  env.addFilter('rustDocblock', rustDocblock);
   return env.render(file, context);
 };
 

--- a/src/visitors/getDebugStringVisitor.ts
+++ b/src/visitors/getDebugStringVisitor.ts
@@ -61,6 +61,7 @@ function getNodeDetails(node: Node): string[] {
       ];
     case 'instructionRemainingAccountsNode':
       return [
+        ...(node.isOptional ? ['optional'] : []),
         ...(node.isWritable ? ['writable'] : []),
         ...(node.isSigner === true ? ['signer'] : []),
         ...(node.isSigner === 'either' ? ['optionalSigner'] : []),

--- a/test/packages/js-experimental/src/generated/instructions/addMemo.ts
+++ b/test/packages/js-experimental/src/generated/instructions/addMemo.ts
@@ -18,11 +18,13 @@ import {
   getStructEncoder,
 } from '@solana/codecs';
 import {
+  AccountRole,
   IAccountMeta,
   IInstruction,
   IInstructionWithAccounts,
   IInstructionWithData,
 } from '@solana/instructions';
+import { TransactionSigner } from '@solana/signers';
 import { SPL_MEMO_PROGRAM_ADDRESS } from '../programs';
 
 export type AddMemoInstruction<
@@ -56,6 +58,7 @@ export function getAddMemoInstructionDataCodec(): Codec<
 
 export type AddMemoInput = {
   memo: AddMemoInstructionDataArgs['memo'];
+  signers?: Array<TransactionSigner>;
 };
 
 export function getAddMemoInstruction(
@@ -67,7 +70,17 @@ export function getAddMemoInstruction(
   // Original args.
   const args = { ...input };
 
+  // Remaining accounts.
+  const remainingAccounts: IAccountMeta[] = (args.signers ?? []).map(
+    (signer) => ({
+      address: signer.address,
+      role: AccountRole.READONLY_SIGNER,
+      signer,
+    })
+  );
+
   const instruction = {
+    accounts: remainingAccounts,
     programAddress,
     data: getAddMemoInstructionDataEncoder().encode(
       args as AddMemoInstructionDataArgs

--- a/test/packages/js-experimental/src/generated/instructions/createReservationList.ts
+++ b/test/packages/js-experimental/src/generated/instructions/createReservationList.ts
@@ -84,7 +84,7 @@ export type CreateReservationListInput<
   TAccountMetadata extends string = string,
   TAccountSystemProgram extends string = string,
   TAccountRent extends string = string,
-> = {
+> = CreateReservationListInstructionDataArgs & {
   /** PDA for ReservationList of ['metadata', program id, master edition key, 'reservation', resource-key] */
   reservationList: Address<TAccountReservationList>;
   /** Payer */

--- a/test/packages/js-experimental/src/generated/instructions/dummy.ts
+++ b/test/packages/js-experimental/src/generated/instructions/dummy.ts
@@ -265,9 +265,10 @@ export async function getDummyInstructionAsync<
   }
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = [
-    ...args.proof.map((address) => ({ address, role: AccountRole.READONLY })),
-  ];
+  const remainingAccounts: IAccountMeta[] = args.proof.map((address) => ({
+    address,
+    role: AccountRole.READONLY,
+  }));
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   const instruction = {
@@ -423,9 +424,10 @@ export function getDummyInstruction<
   }
 
   // Remaining accounts.
-  const remainingAccounts: IAccountMeta[] = [
-    ...args.proof.map((address) => ({ address, role: AccountRole.READONLY })),
-  ];
+  const remainingAccounts: IAccountMeta[] = args.proof.map((address) => ({
+    address,
+    role: AccountRole.READONLY,
+  }));
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
   const instruction = {

--- a/test/packages/js/src/generated/instructions/addMemo.ts
+++ b/test/packages/js/src/generated/instructions/addMemo.ts
@@ -61,14 +61,6 @@ export function addMemo(
     resolvedAccounts
   ).sort((a, b) => a.index - b.index);
 
-  // Remaining Accounts.
-  const remainingAccounts = resolvedArgs.signers.map((value, index) => ({
-    index,
-    value,
-    isWritable: false,
-  }));
-  orderedAccounts.push(...remainingAccounts);
-
   // Keys and Signers.
   const [keys, signers] = getAccountMetasAndSigners(
     orderedAccounts,

--- a/test/packages/js/src/generated/instructions/addMemo.ts
+++ b/test/packages/js/src/generated/instructions/addMemo.ts
@@ -61,6 +61,14 @@ export function addMemo(
     resolvedAccounts
   ).sort((a, b) => a.index - b.index);
 
+  // Remaining Accounts.
+  const remainingAccounts = resolvedArgs.signers.map((value, index) => ({
+    index,
+    value,
+    isWritable: false,
+  }));
+  orderedAccounts.push(...remainingAccounts);
+
   // Keys and Signers.
   const [keys, signers] = getAccountMetasAndSigners(
     orderedAccounts,

--- a/test/testFile.cjs
+++ b/test/testFile.cjs
@@ -176,6 +176,13 @@ kinobi.update(
         },
       },
     },
+    addMemo: {
+      remainingAccounts: [
+        k.instructionRemainingAccountsNode(k.argumentValueNode('signers'), {
+          isSigner: true,
+        }),
+      ],
+    },
   })
 );
 

--- a/test/testFile.cjs
+++ b/test/testFile.cjs
@@ -180,6 +180,7 @@ kinobi.update(
       remainingAccounts: [
         k.instructionRemainingAccountsNode(k.argumentValueNode('signers'), {
           isSigner: true,
+          isOptional: true,
         }),
       ],
     },


### PR DESCRIPTION
This PR makes it possible to have an array of signers as remaining accounts on the JS experimental renderer.

It also refactors a few fragments along the way.