### PR TITLE
Add derive to instruction builders

### DIFF
--- a/.changeset/dry-jokes-learn.md
+++ b/.changeset/dry-jokes-learn.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Add derive to Rust instruction builders

--- a/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
@@ -15,6 +15,7 @@
   {% endif %}
   {{ '///   ' + loop.index0 + '. `[' + modifiers + ']` ' + account.name | snakeCase }}
 {% endfor %}
+#[derive(Clone, Debug)]
 pub struct {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
   instruction: Box<{{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b>>,
 }
@@ -124,6 +125,7 @@ impl<'a, 'b> {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
   }
 }
 
+#[derive(Clone, Debug)]
 struct {{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b> {
   __program: &'b solana_program::account_info::AccountInfo<'a>,
   {% for account in instruction.accounts %}

--- a/src/renderers/rust/templates/instructionsPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsPageBuilder.njk
@@ -16,7 +16,7 @@
   {{ '///   ' + loop.index0 + '. `[' + modifiers + ']` ' + account.name | snakeCase }}
   {{- " (default to `" + account.defaultValue.publicKey + "`)" if account.defaultValue.kind === 'publicKeyValueNode' }}
 {% endfor %}
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct {{ instruction.name | pascalCase }}Builder {
   {% for account in instruction.accounts %}
     {% if account.isSigner === 'either' %}

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -79,7 +79,7 @@ pub struct AddConfigLinesInstructionArgs {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct AddConfigLinesBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -264,6 +264,7 @@ impl<'a, 'b> AddConfigLinesCpi<'a, 'b> {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
+#[derive(Clone, Debug)]
 pub struct AddConfigLinesCpiBuilder<'a, 'b> {
     instruction: Box<AddConfigLinesCpiBuilderInstruction<'a, 'b>>,
 }
@@ -384,6 +385,7 @@ impl<'a, 'b> AddConfigLinesCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct AddConfigLinesCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/add_memo.rs
+++ b/test/packages/rust/src/generated/instructions/add_memo.rs
@@ -57,7 +57,7 @@ pub struct AddMemoInstructionArgs {
 ///
 /// ### Accounts:
 ///
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct AddMemoBuilder {
     memo: Option<String>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
@@ -187,6 +187,7 @@ impl<'a, 'b> AddMemoCpi<'a, 'b> {
 ///
 /// ### Accounts:
 ///
+#[derive(Clone, Debug)]
 pub struct AddMemoCpiBuilder<'a, 'b> {
     instruction: Box<AddMemoCpiBuilderInstruction<'a, 'b>>,
 }
@@ -260,6 +261,7 @@ impl<'a, 'b> AddMemoCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct AddMemoCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     memo: Option<String>,

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -110,7 +110,7 @@ impl ApproveCollectionAuthorityInstructionData {
 ///   5. `[]` mint
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ApproveCollectionAuthorityBuilder {
     collection_authority_record: Option<solana_program::pubkey::Pubkey>,
     new_collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -410,6 +410,7 @@ impl<'a, 'b> ApproveCollectionAuthorityCpi<'a, 'b> {
 ///   5. `[]` mint
 ///   6. `[]` system_program
 ///   7. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
@@ -576,6 +577,7 @@ impl<'a, 'b> ApproveCollectionAuthorityCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct ApproveCollectionAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -141,7 +141,7 @@ pub struct ApproveUseAuthorityInstructionArgs {
 ///   8. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   9. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   10. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ApproveUseAuthorityBuilder {
     use_authority_record: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -516,6 +516,7 @@ impl<'a, 'b> ApproveUseAuthorityCpi<'a, 'b> {
 ///   8. `[]` token_program
 ///   9. `[]` system_program
 ///   10. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct ApproveUseAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<ApproveUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
@@ -726,6 +727,7 @@ impl<'a, 'b> ApproveUseAuthorityCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct ApproveUseAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -105,7 +105,7 @@ pub struct BubblegumSetCollectionSizeInstructionArgs {
 ///   2. `[]` collection_mint
 ///   3. `[signer]` bubblegum_signer
 ///   4. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BubblegumSetCollectionSizeBuilder {
     collection_metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -373,6 +373,7 @@ impl<'a, 'b> BubblegumSetCollectionSizeCpi<'a, 'b> {
 ///   2. `[]` collection_mint
 ///   3. `[signer]` bubblegum_signer
 ///   4. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
     instruction: Box<BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }
@@ -526,6 +527,7 @@ impl<'a, 'b> BubblegumSetCollectionSizeCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct BubblegumSetCollectionSizeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -143,7 +143,7 @@ pub struct BurnInstructionArgs {
 ///   6. `[writable, optional]` collection_metadata
 ///   7. `[optional]` authorization_rules
 ///   8. `[optional]` authorization_rules_program
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BurnBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -500,6 +500,7 @@ impl<'a, 'b> BurnCpi<'a, 'b> {
 ///   6. `[writable, optional]` collection_metadata
 ///   7. `[optional]` authorization_rules
 ///   8. `[optional]` authorization_rules_program
+#[derive(Clone, Debug)]
 pub struct BurnCpiBuilder<'a, 'b> {
     instruction: Box<BurnCpiBuilderInstruction<'a, 'b>>,
 }
@@ -691,6 +692,7 @@ impl<'a, 'b> BurnCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct BurnCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -117,7 +117,7 @@ impl BurnEditionNftInstructionData {
 ///   7. `[writable]` print_edition_account
 ///   8. `[writable]` edition_marker_account
 ///   9. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BurnEditionNftBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -469,6 +469,7 @@ impl<'a, 'b> BurnEditionNftCpi<'a, 'b> {
 ///   7. `[writable]` print_edition_account
 ///   8. `[writable]` edition_marker_account
 ///   9. `[]` spl_token_program
+#[derive(Clone, Debug)]
 pub struct BurnEditionNftCpiBuilder<'a, 'b> {
     instruction: Box<BurnEditionNftCpiBuilderInstruction<'a, 'b>>,
 }
@@ -673,6 +674,7 @@ impl<'a, 'b> BurnEditionNftCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct BurnEditionNftCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -102,7 +102,7 @@ impl BurnNftInstructionData {
 ///   4. `[writable]` master_edition_account
 ///   5. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   6. `[writable, optional]` collection_metadata
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct BurnNftBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -380,6 +380,7 @@ impl<'a, 'b> BurnNftCpi<'a, 'b> {
 ///   4. `[writable]` master_edition_account
 ///   5. `[]` spl_token_program
 ///   6. `[writable, optional]` collection_metadata
+#[derive(Clone, Debug)]
 pub struct BurnNftCpiBuilder<'a, 'b> {
     instruction: Box<BurnNftCpiBuilderInstruction<'a, 'b>>,
 }
@@ -531,6 +532,7 @@ impl<'a, 'b> BurnNftCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct BurnNftCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -104,7 +104,7 @@ impl CloseEscrowAccountInstructionData {
 ///   5. `[writable, signer]` payer
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CloseEscrowAccountBuilder {
     escrow: Option<solana_program::pubkey::Pubkey>,
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -388,6 +388,7 @@ impl<'a, 'b> CloseEscrowAccountCpi<'a, 'b> {
 ///   5. `[writable, signer]` payer
 ///   6. `[]` system_program
 ///   7. `[]` sysvar_instructions
+#[derive(Clone, Debug)]
 pub struct CloseEscrowAccountCpiBuilder<'a, 'b> {
     instruction: Box<CloseEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -550,6 +551,7 @@ impl<'a, 'b> CloseEscrowAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CloseEscrowAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -71,7 +71,7 @@ impl ConvertMasterEditionV1ToV2InstructionData {
 ///   0. `[writable]` master_edition
 ///   1. `[writable]` one_time_auth
 ///   2. `[writable]` printing_mint
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ConvertMasterEditionV1ToV2Builder {
     master_edition: Option<solana_program::pubkey::Pubkey>,
     one_time_auth: Option<solana_program::pubkey::Pubkey>,
@@ -251,6 +251,7 @@ impl<'a, 'b> ConvertMasterEditionV1ToV2Cpi<'a, 'b> {
 ///   0. `[writable]` master_edition
 ///   1. `[writable]` one_time_auth
 ///   2. `[writable]` printing_mint
+#[derive(Clone, Debug)]
 pub struct ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
     instruction: Box<ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b>>,
 }
@@ -359,6 +360,7 @@ impl<'a, 'b> ConvertMasterEditionV1ToV2CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct ConvertMasterEditionV1ToV2CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_account.rs
@@ -75,7 +75,7 @@ pub struct CreateAccountInstructionArgs {
 ///
 ///   0. `[writable, signer]` payer
 ///   1. `[writable, signer]` new_account
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateAccountBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
     new_account: Option<solana_program::pubkey::Pubkey>,
@@ -260,6 +260,7 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
 ///
 ///   0. `[writable, signer]` payer
 ///   1. `[writable, signer]` new_account
+#[derive(Clone, Debug)]
 pub struct CreateAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -377,6 +378,7 @@ impl<'a, 'b> CreateAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -117,7 +117,7 @@ impl CreateEscrowAccountInstructionData {
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 ///   8. `[signer, optional]` authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateEscrowAccountBuilder {
     escrow: Option<solana_program::pubkey::Pubkey>,
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -430,6 +430,7 @@ impl<'a, 'b> CreateEscrowAccountCpi<'a, 'b> {
 ///   6. `[]` system_program
 ///   7. `[]` sysvar_instructions
 ///   8. `[signer, optional]` authority
+#[derive(Clone, Debug)]
 pub struct CreateEscrowAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateEscrowAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -605,6 +606,7 @@ impl<'a, 'b> CreateEscrowAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateEscrowAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -85,7 +85,7 @@ pub struct CreateFrequencyRuleInstructionArgs {
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` frequency_pda
 ///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateFrequencyRuleBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
     frequency_pda: Option<solana_program::pubkey::Pubkey>,
@@ -310,6 +310,7 @@ impl<'a, 'b> CreateFrequencyRuleCpi<'a, 'b> {
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` frequency_pda
 ///   2. `[]` system_program
+#[derive(Clone, Debug)]
 pub struct CreateFrequencyRuleCpiBuilder<'a, 'b> {
     instruction: Box<CreateFrequencyRuleCpiBuilderInstruction<'a, 'b>>,
 }
@@ -455,6 +456,7 @@ impl<'a, 'b> CreateFrequencyRuleCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateFrequencyRuleCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -123,7 +123,7 @@ pub struct CreateMasterEditionInstructionArgs {
 ///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateMasterEditionBuilder {
     edition: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -450,6 +450,7 @@ impl<'a, 'b> CreateMasterEditionCpi<'a, 'b> {
 ///   6. `[]` token_program
 ///   7. `[]` system_program
 ///   8. `[]` rent
+#[derive(Clone, Debug)]
 pub struct CreateMasterEditionCpiBuilder<'a, 'b> {
     instruction: Box<CreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }
@@ -641,6 +642,7 @@ impl<'a, 'b> CreateMasterEditionCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateMasterEditionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -130,7 +130,7 @@ pub struct CreateMasterEditionV3InstructionArgs {
 ///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   8. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateMasterEditionV3Builder {
     edition: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -463,6 +463,7 @@ impl<'a, 'b> CreateMasterEditionV3Cpi<'a, 'b> {
 ///   6. `[]` token_program
 ///   7. `[]` system_program
 ///   8. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct CreateMasterEditionV3CpiBuilder<'a, 'b> {
     instruction: Box<CreateMasterEditionV3CpiBuilderInstruction<'a, 'b>>,
 }
@@ -658,6 +659,7 @@ impl<'a, 'b> CreateMasterEditionV3CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateMasterEditionV3CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -121,7 +121,7 @@ pub struct CreateMetadataAccountInstructionDataData {
 ///   4. `[]` update_authority
 ///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   6. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateMetadataAccountBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -418,6 +418,7 @@ impl<'a, 'b> CreateMetadataAccountCpi<'a, 'b> {
 ///   4. `[]` update_authority
 ///   5. `[]` system_program
 ///   6. `[]` rent
+#[derive(Clone, Debug)]
 pub struct CreateMetadataAccountCpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -597,6 +598,7 @@ impl<'a, 'b> CreateMetadataAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateMetadataAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -117,7 +117,7 @@ pub struct CreateMetadataAccountV2InstructionArgs {
 ///   4. `[]` update_authority
 ///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   6. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateMetadataAccountV2Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -410,6 +410,7 @@ impl<'a, 'b> CreateMetadataAccountV2Cpi<'a, 'b> {
 ///   4. `[]` update_authority
 ///   5. `[]` system_program
 ///   6. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct CreateMetadataAccountV2CpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }
@@ -582,6 +583,7 @@ impl<'a, 'b> CreateMetadataAccountV2CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateMetadataAccountV2CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -119,7 +119,7 @@ pub struct CreateMetadataAccountV3InstructionArgs {
 ///   4. `[]` update_authority
 ///   5. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   6. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateMetadataAccountV3Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -420,6 +420,7 @@ impl<'a, 'b> CreateMetadataAccountV3Cpi<'a, 'b> {
 ///   4. `[]` update_authority
 ///   5. `[]` system_program
 ///   6. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct CreateMetadataAccountV3CpiBuilder<'a, 'b> {
     instruction: Box<CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b>>,
 }
@@ -600,6 +601,7 @@ impl<'a, 'b> CreateMetadataAccountV3CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateMetadataAccountV3CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -104,7 +104,7 @@ impl CreateReservationListInstructionData {
 ///   5. `[]` metadata
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateReservationListBuilder {
     reservation_list: Option<solana_program::pubkey::Pubkey>,
     payer: Option<solana_program::pubkey::Pubkey>,
@@ -391,6 +391,7 @@ impl<'a, 'b> CreateReservationListCpi<'a, 'b> {
 ///   5. `[]` metadata
 ///   6. `[]` system_program
 ///   7. `[]` rent
+#[derive(Clone, Debug)]
 pub struct CreateReservationListCpiBuilder<'a, 'b> {
     instruction: Box<CreateReservationListCpiBuilderInstruction<'a, 'b>>,
 }
@@ -556,6 +557,7 @@ impl<'a, 'b> CreateReservationListCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateReservationListCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     reservation_list: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -82,7 +82,7 @@ pub struct CreateRuleSetInstructionArgs {
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` rule_set_pda
 ///   2. `[optional]` system_program (default to `11111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateRuleSetBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
     rule_set_pda: Option<solana_program::pubkey::Pubkey>,
@@ -288,6 +288,7 @@ impl<'a, 'b> CreateRuleSetCpi<'a, 'b> {
 ///   0. `[writable, signer]` payer
 ///   1. `[writable]` rule_set_pda
 ///   2. `[]` system_program
+#[derive(Clone, Debug)]
 pub struct CreateRuleSetCpiBuilder<'a, 'b> {
     instruction: Box<CreateRuleSetCpiBuilderInstruction<'a, 'b>>,
 }
@@ -415,6 +416,7 @@ impl<'a, 'b> CreateRuleSetCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateRuleSetCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -136,7 +136,7 @@ pub struct CreateV1InstructionArgs {
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 ///   8. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateV1Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     master_edition: Option<solana_program::pubkey::Pubkey>,
@@ -490,6 +490,7 @@ impl<'a, 'b> CreateV1Cpi<'a, 'b> {
 ///   6. `[]` system_program
 ///   7. `[]` sysvar_instructions
 ///   8. `[]` spl_token_program
+#[derive(Clone, Debug)]
 pub struct CreateV1CpiBuilder<'a, 'b> {
     instruction: Box<CreateV1CpiBuilderInstruction<'a, 'b>>,
 }
@@ -705,6 +706,7 @@ impl<'a, 'b> CreateV1CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateV1CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -135,7 +135,7 @@ pub struct CreateV2InstructionArgs {
 ///   6. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   7. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 ///   8. `[optional]` spl_token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CreateV2Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     master_edition: Option<solana_program::pubkey::Pubkey>,
@@ -481,6 +481,7 @@ impl<'a, 'b> CreateV2Cpi<'a, 'b> {
 ///   6. `[]` system_program
 ///   7. `[]` sysvar_instructions
 ///   8. `[]` spl_token_program
+#[derive(Clone, Debug)]
 pub struct CreateV2CpiBuilder<'a, 'b> {
     instruction: Box<CreateV2CpiBuilderInstruction<'a, 'b>>,
 }
@@ -688,6 +689,7 @@ impl<'a, 'b> CreateV2CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct CreateV2CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -182,7 +182,7 @@ pub struct DelegateInstructionArgs {
 ///   10. `[optional]` spl_token_program
 ///   11. `[optional]` authorization_rules_program
 ///   12. `[optional]` authorization_rules
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DelegateBuilder {
     delegate_record: Option<solana_program::pubkey::Pubkey>,
     delegate: Option<solana_program::pubkey::Pubkey>,
@@ -641,6 +641,7 @@ impl<'a, 'b> DelegateCpi<'a, 'b> {
 ///   10. `[optional]` spl_token_program
 ///   11. `[optional]` authorization_rules_program
 ///   12. `[optional]` authorization_rules
+#[derive(Clone, Debug)]
 pub struct DelegateCpiBuilder<'a, 'b> {
     instruction: Box<DelegateCpiBuilderInstruction<'a, 'b>>,
 }
@@ -882,6 +883,7 @@ impl<'a, 'b> DelegateCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct DelegateCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -151,7 +151,7 @@ pub struct DeprecatedCreateMasterEditionInstructionArgs {
 ///   10. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   11. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 ///   12. `[signer]` one_time_printing_authorization_mint_authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DeprecatedCreateMasterEditionBuilder {
     edition: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -573,6 +573,7 @@ impl<'a, 'b> DeprecatedCreateMasterEditionCpi<'a, 'b> {
 ///   10. `[]` system_program
 ///   11. `[]` rent
 ///   12. `[signer]` one_time_printing_authorization_mint_authority
+#[derive(Clone, Debug)]
 pub struct DeprecatedCreateMasterEditionCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedCreateMasterEditionCpiBuilderInstruction<'a, 'b>>,
 }
@@ -827,6 +828,7 @@ impl<'a, 'b> DeprecatedCreateMasterEditionCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct DeprecatedCreateMasterEditionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -166,7 +166,7 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
 ///   13. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   14. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 ///   15. `[writable, optional]` reservation_list
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     edition: Option<solana_program::pubkey::Pubkey>,
@@ -628,6 +628,7 @@ impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpi<'a, 'b
 ///   13. `[]` system_program
 ///   14. `[]` rent
 ///   15. `[writable, optional]` reservation_list
+#[derive(Clone, Debug)]
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder<'a, 'b> {
     instruction:
         Box<DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b>>,
@@ -908,6 +909,7 @@ impl<'a, 'b> DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilder
     }
 }
 
+#[derive(Clone, Debug)]
 struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -111,7 +111,7 @@ pub struct DeprecatedMintPrintingTokensInstructionArgs {
 ///   4. `[]` master_edition
 ///   5. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   6. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DeprecatedMintPrintingTokensBuilder {
     destination: Option<solana_program::pubkey::Pubkey>,
     printing_mint: Option<solana_program::pubkey::Pubkey>,
@@ -397,6 +397,7 @@ impl<'a, 'b> DeprecatedMintPrintingTokensCpi<'a, 'b> {
 ///   4. `[]` master_edition
 ///   5. `[]` token_program
 ///   6. `[]` rent
+#[derive(Clone, Debug)]
 pub struct DeprecatedMintPrintingTokensCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedMintPrintingTokensCpiBuilderInstruction<'a, 'b>>,
 }
@@ -574,6 +575,7 @@ impl<'a, 'b> DeprecatedMintPrintingTokensCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct DeprecatedMintPrintingTokensCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -124,7 +124,7 @@ pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
 ///   6. `[]` master_edition
 ///   7. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DeprecatedMintPrintingTokensViaTokenBuilder {
     destination: Option<solana_program::pubkey::Pubkey>,
     token: Option<solana_program::pubkey::Pubkey>,
@@ -450,6 +450,7 @@ impl<'a, 'b> DeprecatedMintPrintingTokensViaTokenCpi<'a, 'b> {
 ///   6. `[]` master_edition
 ///   7. `[]` token_program
 ///   8. `[]` rent
+#[derive(Clone, Debug)]
 pub struct DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
@@ -652,6 +653,7 @@ impl<'a, 'b> DeprecatedMintPrintingTokensViaTokenCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct DeprecatedMintPrintingTokensViaTokenCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     destination: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -87,7 +87,7 @@ pub struct DeprecatedSetReservationListInstructionArgs {
 ///   0. `[writable]` master_edition
 ///   1. `[writable]` reservation_list
 ///   2. `[signer]` resource
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DeprecatedSetReservationListBuilder {
     master_edition: Option<solana_program::pubkey::Pubkey>,
     reservation_list: Option<solana_program::pubkey::Pubkey>,
@@ -310,6 +310,7 @@ impl<'a, 'b> DeprecatedSetReservationListCpi<'a, 'b> {
 ///   0. `[writable]` master_edition
 ///   1. `[writable]` reservation_list
 ///   2. `[signer]` resource
+#[derive(Clone, Debug)]
 pub struct DeprecatedSetReservationListCpiBuilder<'a, 'b> {
     instruction: Box<DeprecatedSetReservationListCpiBuilderInstruction<'a, 'b>>,
 }
@@ -455,6 +456,7 @@ impl<'a, 'b> DeprecatedSetReservationListCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct DeprecatedSetReservationListCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     master_edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -140,7 +140,7 @@ impl DummyInstructionData {
 ///   7. `[signer, optional]` delegate
 ///   8. `[writable, optional]` delegate_record
 ///   9. `[]` token_or_ata_program
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DummyBuilder {
     edition: Option<solana_program::pubkey::Pubkey>,
     mint: Option<solana_program::pubkey::Pubkey>,
@@ -489,6 +489,7 @@ impl<'a, 'b> DummyCpi<'a, 'b> {
 ///   7. `[signer, optional]` delegate
 ///   8. `[writable, optional]` delegate_record
 ///   9. `[]` token_or_ata_program
+#[derive(Clone, Debug)]
 pub struct DummyCpiBuilder<'a, 'b> {
     instruction: Box<DummyCpiBuilderInstruction<'a, 'b>>,
 }
@@ -669,6 +670,7 @@ impl<'a, 'b> DummyCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct DummyCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     edition: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -84,7 +84,7 @@ impl FreezeDelegatedAccountInstructionData {
 ///   2. `[]` edition
 ///   3. `[]` mint
 ///   4. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FreezeDelegatedAccountBuilder {
     delegate: Option<solana_program::pubkey::Pubkey>,
     token_account: Option<solana_program::pubkey::Pubkey>,
@@ -305,6 +305,7 @@ impl<'a, 'b> FreezeDelegatedAccountCpi<'a, 'b> {
 ///   2. `[]` edition
 ///   3. `[]` mint
 ///   4. `[]` token_program
+#[derive(Clone, Debug)]
 pub struct FreezeDelegatedAccountCpiBuilder<'a, 'b> {
     instruction: Box<FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -431,6 +432,7 @@ impl<'a, 'b> FreezeDelegatedAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct FreezeDelegatedAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -138,7 +138,7 @@ pub struct InitializeInstructionArgs {
 ///   8. `[writable]` collection_authority_record
 ///   9. `[optional]` token_metadata_program (default to `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`)
 ///   10. `[optional]` system_program (default to `11111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct InitializeBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority_pda: Option<solana_program::pubkey::Pubkey>,
@@ -504,6 +504,7 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
 ///   8. `[writable]` collection_authority_record
 ///   9. `[]` token_metadata_program
 ///   10. `[]` system_program
+#[derive(Clone, Debug)]
 pub struct InitializeCpiBuilder<'a, 'b> {
     instruction: Box<InitializeCpiBuilderInstruction<'a, 'b>>,
 }
@@ -722,6 +723,7 @@ impl<'a, 'b> InitializeCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct InitializeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -137,7 +137,7 @@ pub struct MigrateInstructionArgs {
 ///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   8. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 ///   9. `[optional]` authorization_rules
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MigrateBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     master_edition: Option<solana_program::pubkey::Pubkey>,
@@ -496,6 +496,7 @@ impl<'a, 'b> MigrateCpi<'a, 'b> {
 ///   7. `[]` system_program
 ///   8. `[]` sysvar_instructions
 ///   9. `[optional]` authorization_rules
+#[derive(Clone, Debug)]
 pub struct MigrateCpiBuilder<'a, 'b> {
     instruction: Box<MigrateCpiBuilderInstruction<'a, 'b>>,
 }
@@ -712,6 +713,7 @@ impl<'a, 'b> MigrateCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct MigrateCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -163,7 +163,7 @@ pub struct MintInstructionArgs {
 ///   9. `[optional]` spl_ata_program (default to `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL`)
 ///   10. `[optional]` authorization_rules_program
 ///   11. `[optional]` authorization_rules
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MintBuilder {
     token: Option<solana_program::pubkey::Pubkey>,
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -587,6 +587,7 @@ impl<'a, 'b> MintCpi<'a, 'b> {
 ///   9. `[]` spl_ata_program
 ///   10. `[optional]` authorization_rules_program
 ///   11. `[optional]` authorization_rules
+#[derive(Clone, Debug)]
 pub struct MintCpiBuilder<'a, 'b> {
     instruction: Box<MintCpiBuilderInstruction<'a, 'b>>,
 }
@@ -814,6 +815,7 @@ impl<'a, 'b> MintCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct MintCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     token: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -169,7 +169,7 @@ impl MintFromCandyMachineInstructionData {
 ///   14. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   15. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   16. `[]` recent_slothashes
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MintFromCandyMachineBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority_pda: Option<solana_program::pubkey::Pubkey>,
@@ -648,6 +648,7 @@ impl<'a, 'b> MintFromCandyMachineCpi<'a, 'b> {
 ///   14. `[]` token_program
 ///   15. `[]` system_program
 ///   16. `[]` recent_slothashes
+#[derive(Clone, Debug)]
 pub struct MintFromCandyMachineCpiBuilder<'a, 'b> {
     instruction: Box<MintFromCandyMachineCpiBuilderInstruction<'a, 'b>>,
 }
@@ -940,6 +941,7 @@ impl<'a, 'b> MintFromCandyMachineCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct MintFromCandyMachineCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -167,7 +167,7 @@ pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
 ///   11. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   12. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   13. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MintNewEditionFromMasterEditionViaTokenBuilder {
     new_metadata: Option<solana_program::pubkey::Pubkey>,
     new_edition: Option<solana_program::pubkey::Pubkey>,
@@ -612,6 +612,7 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpi<'a, 'b> {
 ///   11. `[]` token_program
 ///   12. `[]` system_program
 ///   13. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
@@ -892,6 +893,7 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaTokenCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct MintNewEditionFromMasterEditionViaTokenCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     new_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -187,7 +187,7 @@ pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
 ///   14. `[]` token_vault_program
 ///   15. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   16. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyBuilder {
     new_metadata: Option<solana_program::pubkey::Pubkey>,
     new_edition: Option<solana_program::pubkey::Pubkey>,
@@ -702,6 +702,7 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpi<'a, 'b> {
 ///   14. `[]` token_vault_program
 ///   15. `[]` system_program
 ///   16. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
     instruction: Box<MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b>>,
 }
@@ -1021,6 +1022,7 @@ impl<'a, 'b> MintNewEditionFromMasterEditionViaVaultProxyCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct MintNewEditionFromMasterEditionViaVaultProxyCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     new_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -55,7 +55,7 @@ impl PuffMetadataInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[writable]` metadata
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PuffMetadataBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
@@ -195,6 +195,7 @@ impl<'a, 'b> PuffMetadataCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[writable]` metadata
+#[derive(Clone, Debug)]
 pub struct PuffMetadataCpiBuilder<'a, 'b> {
     instruction: Box<PuffMetadataCpiBuilderInstruction<'a, 'b>>,
 }
@@ -270,6 +271,7 @@ impl<'a, 'b> PuffMetadataCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct PuffMetadataCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -64,7 +64,7 @@ impl RemoveCreatorVerificationInstructionData {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` creator
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RemoveCreatorVerificationBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     creator: Option<solana_program::pubkey::Pubkey>,
@@ -225,6 +225,7 @@ impl<'a, 'b> RemoveCreatorVerificationCpi<'a, 'b> {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` creator
+#[derive(Clone, Debug)]
 pub struct RemoveCreatorVerificationCpiBuilder<'a, 'b> {
     instruction: Box<RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b>>,
 }
@@ -312,6 +313,7 @@ impl<'a, 'b> RemoveCreatorVerificationCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct RemoveCreatorVerificationCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -182,7 +182,7 @@ pub struct RevokeInstructionArgs {
 ///   10. `[optional]` spl_token_program
 ///   11. `[optional]` authorization_rules_program
 ///   12. `[optional]` authorization_rules
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RevokeBuilder {
     delegate_record: Option<solana_program::pubkey::Pubkey>,
     delegate: Option<solana_program::pubkey::Pubkey>,
@@ -638,6 +638,7 @@ impl<'a, 'b> RevokeCpi<'a, 'b> {
 ///   10. `[optional]` spl_token_program
 ///   11. `[optional]` authorization_rules_program
 ///   12. `[optional]` authorization_rules
+#[derive(Clone, Debug)]
 pub struct RevokeCpiBuilder<'a, 'b> {
     instruction: Box<RevokeCpiBuilderInstruction<'a, 'b>>,
 }
@@ -879,6 +880,7 @@ impl<'a, 'b> RevokeCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct RevokeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     delegate_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -84,7 +84,7 @@ impl RevokeCollectionAuthorityInstructionData {
 ///   2. `[writable, signer]` revoke_authority
 ///   3. `[]` metadata
 ///   4. `[]` mint
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RevokeCollectionAuthorityBuilder {
     collection_authority_record: Option<solana_program::pubkey::Pubkey>,
     delegate_authority: Option<solana_program::pubkey::Pubkey>,
@@ -315,6 +315,7 @@ impl<'a, 'b> RevokeCollectionAuthorityCpi<'a, 'b> {
 ///   2. `[writable, signer]` revoke_authority
 ///   3. `[]` metadata
 ///   4. `[]` mint
+#[derive(Clone, Debug)]
 pub struct RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
@@ -444,6 +445,7 @@ impl<'a, 'b> RevokeCollectionAuthorityCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct RevokeCollectionAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     collection_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -116,7 +116,7 @@ impl RevokeUseAuthorityInstructionData {
 ///   6. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   7. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   8. `[optional]` rent
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RevokeUseAuthorityBuilder {
     use_authority_record: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -435,6 +435,7 @@ impl<'a, 'b> RevokeUseAuthorityCpi<'a, 'b> {
 ///   6. `[]` token_program
 ///   7. `[]` system_program
 ///   8. `[optional]` rent
+#[derive(Clone, Debug)]
 pub struct RevokeUseAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<RevokeUseAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
@@ -610,6 +611,7 @@ impl<'a, 'b> RevokeUseAuthorityCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct RevokeUseAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     use_authority_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -112,7 +112,7 @@ impl SetAndVerifyCollectionInstructionData {
 ///   5. `[]` collection
 ///   6. `[]` collection_master_edition_account
 ///   7. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetAndVerifyCollectionBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -416,6 +416,7 @@ impl<'a, 'b> SetAndVerifyCollectionCpi<'a, 'b> {
 ///   5. `[]` collection
 ///   6. `[]` collection_master_edition_account
 ///   7. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct SetAndVerifyCollectionCpiBuilder<'a, 'b> {
     instruction: Box<SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
@@ -586,6 +587,7 @@ impl<'a, 'b> SetAndVerifyCollectionCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetAndVerifyCollectionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -112,7 +112,7 @@ impl SetAndVerifySizedCollectionItemInstructionData {
 ///   5. `[writable]` collection
 ///   6. `[writable]` collection_master_edition_account
 ///   7. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetAndVerifySizedCollectionItemBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -416,6 +416,7 @@ impl<'a, 'b> SetAndVerifySizedCollectionItemCpi<'a, 'b> {
 ///   5. `[writable]` collection
 ///   6. `[writable]` collection_master_edition_account
 ///   7. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
     instruction: Box<SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
@@ -586,6 +587,7 @@ impl<'a, 'b> SetAndVerifySizedCollectionItemCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetAndVerifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -76,7 +76,7 @@ pub struct SetAuthorityInstructionArgs {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetAuthorityBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -250,6 +250,7 @@ impl<'a, 'b> SetAuthorityCpi<'a, 'b> {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
+#[derive(Clone, Debug)]
 pub struct SetAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<SetAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
@@ -352,6 +353,7 @@ impl<'a, 'b> SetAuthorityCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -146,7 +146,7 @@ impl SetCollectionInstructionData {
 ///   11. `[writable]` new_collection_authority_record
 ///   12. `[optional]` token_metadata_program (default to `metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s`)
 ///   13. `[optional]` system_program (default to `11111111111111111111111111111111`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetCollectionBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -566,6 +566,7 @@ impl<'a, 'b> SetCollectionCpi<'a, 'b> {
 ///   11. `[writable]` new_collection_authority_record
 ///   12. `[]` token_metadata_program
 ///   13. `[]` system_program
+#[derive(Clone, Debug)]
 pub struct SetCollectionCpiBuilder<'a, 'b> {
     instruction: Box<SetCollectionCpiBuilderInstruction<'a, 'b>>,
 }
@@ -816,6 +817,7 @@ impl<'a, 'b> SetCollectionCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetCollectionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -98,7 +98,7 @@ pub struct SetCollectionSizeInstructionArgs {
 ///   1. `[writable, signer]` collection_authority
 ///   2. `[]` collection_mint
 ///   3. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetCollectionSizeBuilder {
     collection_metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -344,6 +344,7 @@ impl<'a, 'b> SetCollectionSizeCpi<'a, 'b> {
 ///   1. `[writable, signer]` collection_authority
 ///   2. `[]` collection_mint
 ///   3. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct SetCollectionSizeCpiBuilder<'a, 'b> {
     instruction: Box<SetCollectionSizeCpiBuilderInstruction<'a, 'b>>,
 }
@@ -482,6 +483,7 @@ impl<'a, 'b> SetCollectionSizeCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetCollectionSizeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     collection_metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -70,7 +70,7 @@ impl SetMintAuthorityInstructionData {
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
 ///   2. `[signer]` mint_authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetMintAuthorityBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -244,6 +244,7 @@ impl<'a, 'b> SetMintAuthorityCpi<'a, 'b> {
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
 ///   2. `[signer]` mint_authority
+#[derive(Clone, Debug)]
 pub struct SetMintAuthorityCpiBuilder<'a, 'b> {
     instruction: Box<SetMintAuthorityCpiBuilderInstruction<'a, 'b>>,
 }
@@ -346,6 +347,7 @@ impl<'a, 'b> SetMintAuthorityCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetMintAuthorityCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -81,7 +81,7 @@ impl SetTokenStandardInstructionData {
 ///   1. `[writable, signer]` update_authority
 ///   2. `[]` mint
 ///   3. `[optional]` edition
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SetTokenStandardBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     update_authority: Option<solana_program::pubkey::Pubkey>,
@@ -291,6 +291,7 @@ impl<'a, 'b> SetTokenStandardCpi<'a, 'b> {
 ///   1. `[writable, signer]` update_authority
 ///   2. `[]` mint
 ///   3. `[optional]` edition
+#[derive(Clone, Debug)]
 pub struct SetTokenStandardCpiBuilder<'a, 'b> {
     instruction: Box<SetTokenStandardCpiBuilderInstruction<'a, 'b>>,
 }
@@ -403,6 +404,7 @@ impl<'a, 'b> SetTokenStandardCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SetTokenStandardCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -62,7 +62,7 @@ impl SignMetadataInstructionData {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` creator
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SignMetadataBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     creator: Option<solana_program::pubkey::Pubkey>,
@@ -221,6 +221,7 @@ impl<'a, 'b> SignMetadataCpi<'a, 'b> {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` creator
+#[derive(Clone, Debug)]
 pub struct SignMetadataCpiBuilder<'a, 'b> {
     instruction: Box<SignMetadataCpiBuilderInstruction<'a, 'b>>,
 }
@@ -308,6 +309,7 @@ impl<'a, 'b> SignMetadataCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct SignMetadataCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -84,7 +84,7 @@ impl ThawDelegatedAccountInstructionData {
 ///   2. `[]` edition
 ///   3. `[]` mint
 ///   4. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ThawDelegatedAccountBuilder {
     delegate: Option<solana_program::pubkey::Pubkey>,
     token_account: Option<solana_program::pubkey::Pubkey>,
@@ -305,6 +305,7 @@ impl<'a, 'b> ThawDelegatedAccountCpi<'a, 'b> {
 ///   2. `[]` edition
 ///   3. `[]` mint
 ///   4. `[]` token_program
+#[derive(Clone, Debug)]
 pub struct ThawDelegatedAccountCpiBuilder<'a, 'b> {
     instruction: Box<ThawDelegatedAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -431,6 +432,7 @@ impl<'a, 'b> ThawDelegatedAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct ThawDelegatedAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     delegate: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -192,7 +192,7 @@ pub struct TransferInstructionArgs {
 ///   12. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 ///   13. `[optional]` authorization_rules_program
 ///   14. `[optional]` authorization_rules
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TransferBuilder {
     authority: Option<solana_program::pubkey::Pubkey>,
     delegate_record: Option<solana_program::pubkey::Pubkey>,
@@ -694,6 +694,7 @@ impl<'a, 'b> TransferCpi<'a, 'b> {
 ///   12. `[]` sysvar_instructions
 ///   13. `[optional]` authorization_rules_program
 ///   14. `[optional]` authorization_rules
+#[derive(Clone, Debug)]
 pub struct TransferCpiBuilder<'a, 'b> {
     instruction: Box<TransferCpiBuilderInstruction<'a, 'b>>,
 }
@@ -970,6 +971,7 @@ impl<'a, 'b> TransferCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct TransferCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -158,7 +158,7 @@ pub struct TransferOutOfEscrowInstructionArgs {
 ///   10. `[optional]` token_program (default to `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 ///   11. `[optional]` sysvar_instructions (default to `Sysvar1nstructions1111111111111111111111111`)
 ///   12. `[signer, optional]` authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TransferOutOfEscrowBuilder {
     escrow: Option<solana_program::pubkey::Pubkey>,
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -568,6 +568,7 @@ impl<'a, 'b> TransferOutOfEscrowCpi<'a, 'b> {
 ///   10. `[]` token_program
 ///   11. `[]` sysvar_instructions
 ///   12. `[signer, optional]` authority
+#[derive(Clone, Debug)]
 pub struct TransferOutOfEscrowCpiBuilder<'a, 'b> {
     instruction: Box<TransferOutOfEscrowCpiBuilderInstruction<'a, 'b>>,
 }
@@ -822,6 +823,7 @@ impl<'a, 'b> TransferOutOfEscrowCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct TransferOutOfEscrowCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     escrow: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/transfer_sol.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_sol.rs
@@ -73,7 +73,7 @@ pub struct TransferSolInstructionArgs {
 ///
 ///   0. `[writable, signer]` source
 ///   1. `[writable]` destination
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct TransferSolBuilder {
     source: Option<solana_program::pubkey::Pubkey>,
     destination: Option<solana_program::pubkey::Pubkey>,
@@ -244,6 +244,7 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
 ///
 ///   0. `[writable, signer]` source
 ///   1. `[writable]` destination
+#[derive(Clone, Debug)]
 pub struct TransferSolCpiBuilder<'a, 'b> {
     instruction: Box<TransferSolCpiBuilderInstruction<'a, 'b>>,
 }
@@ -342,6 +343,7 @@ impl<'a, 'b> TransferSolCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct TransferSolCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     source: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -99,7 +99,7 @@ impl UnverifyCollectionInstructionData {
 ///   3. `[]` collection
 ///   4. `[]` collection_master_edition_account
 ///   5. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UnverifyCollectionBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -362,6 +362,7 @@ impl<'a, 'b> UnverifyCollectionCpi<'a, 'b> {
 ///   3. `[]` collection
 ///   4. `[]` collection_master_edition_account
 ///   5. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct UnverifyCollectionCpiBuilder<'a, 'b> {
     instruction: Box<UnverifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
@@ -508,6 +509,7 @@ impl<'a, 'b> UnverifyCollectionCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UnverifyCollectionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -105,7 +105,7 @@ impl UnverifySizedCollectionItemInstructionData {
 ///   4. `[writable]` collection
 ///   5. `[]` collection_master_edition_account
 ///   6. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UnverifySizedCollectionItemBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -387,6 +387,7 @@ impl<'a, 'b> UnverifySizedCollectionItemCpi<'a, 'b> {
 ///   4. `[writable]` collection
 ///   5. `[]` collection_master_edition_account
 ///   6. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
     instruction: Box<UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
@@ -542,6 +543,7 @@ impl<'a, 'b> UnverifySizedCollectionItemCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UnverifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -78,7 +78,7 @@ pub struct UpdateCandyMachineInstructionArgs {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UpdateCandyMachineBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -251,6 +251,7 @@ impl<'a, 'b> UpdateCandyMachineCpi<'a, 'b> {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[signer]` authority
+#[derive(Clone, Debug)]
 pub struct UpdateCandyMachineCpiBuilder<'a, 'b> {
     instruction: Box<UpdateCandyMachineCpiBuilderInstruction<'a, 'b>>,
 }
@@ -349,6 +350,7 @@ impl<'a, 'b> UpdateCandyMachineCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UpdateCandyMachineCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -90,7 +90,7 @@ pub struct UpdateMetadataAccountInstructionDataData {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` update_authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UpdateMetadataAccountBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     update_authority: Option<solana_program::pubkey::Pubkey>,
@@ -286,6 +286,7 @@ impl<'a, 'b> UpdateMetadataAccountCpi<'a, 'b> {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` update_authority
+#[derive(Clone, Debug)]
 pub struct UpdateMetadataAccountCpiBuilder<'a, 'b> {
     instruction: Box<UpdateMetadataAccountCpiBuilderInstruction<'a, 'b>>,
 }
@@ -403,6 +404,7 @@ impl<'a, 'b> UpdateMetadataAccountCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UpdateMetadataAccountCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -81,7 +81,7 @@ pub struct UpdateMetadataAccountV2InstructionArgs {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` update_authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UpdateMetadataAccountV2Builder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     update_authority: Option<solana_program::pubkey::Pubkey>,
@@ -285,6 +285,7 @@ impl<'a, 'b> UpdateMetadataAccountV2Cpi<'a, 'b> {
 ///
 ///   0. `[writable]` metadata
 ///   1. `[signer]` update_authority
+#[derive(Clone, Debug)]
 pub struct UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
     instruction: Box<UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b>>,
 }
@@ -410,6 +411,7 @@ impl<'a, 'b> UpdateMetadataAccountV2CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UpdateMetadataAccountV2CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -69,7 +69,7 @@ impl UpdatePrimarySaleHappenedViaTokenInstructionData {
 ///   0. `[writable]` metadata
 ///   1. `[signer]` owner
 ///   2. `[]` token
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UpdatePrimarySaleHappenedViaTokenBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     owner: Option<solana_program::pubkey::Pubkey>,
@@ -249,6 +249,7 @@ impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpi<'a, 'b> {
 ///   0. `[writable]` metadata
 ///   1. `[signer]` owner
 ///   2. `[]` token
+#[derive(Clone, Debug)]
 pub struct UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
     instruction: Box<UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b>>,
 }
@@ -342,6 +343,7 @@ impl<'a, 'b> UpdatePrimarySaleHappenedViaTokenCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UpdatePrimarySaleHappenedViaTokenCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -198,7 +198,7 @@ pub struct UpdateV1InstructionDataData {
 ///   7. `[optional]` delegate_record
 ///   8. `[optional]` authorization_rules_program
 ///   9. `[optional]` authorization_rules
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UpdateV1Builder {
     authority: Option<solana_program::pubkey::Pubkey>,
     metadata: Option<solana_program::pubkey::Pubkey>,
@@ -685,6 +685,7 @@ impl<'a, 'b> UpdateV1Cpi<'a, 'b> {
 ///   7. `[optional]` delegate_record
 ///   8. `[optional]` authorization_rules_program
 ///   9. `[optional]` authorization_rules
+#[derive(Clone, Debug)]
 pub struct UpdateV1CpiBuilder<'a, 'b> {
     instruction: Box<UpdateV1CpiBuilderInstruction<'a, 'b>>,
 }
@@ -978,6 +979,7 @@ impl<'a, 'b> UpdateV1CpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UpdateV1CpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -157,7 +157,7 @@ pub struct UseAssetInstructionArgs {
 ///   8. `[writable, optional]` use_authority_record
 ///   9. `[optional]` authorization_rules
 ///   10. `[optional]` authorization_rules_program
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UseAssetBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     token_account: Option<solana_program::pubkey::Pubkey>,
@@ -556,6 +556,7 @@ impl<'a, 'b> UseAssetCpi<'a, 'b> {
 ///   8. `[writable, optional]` use_authority_record
 ///   9. `[optional]` authorization_rules
 ///   10. `[optional]` authorization_rules_program
+#[derive(Clone, Debug)]
 pub struct UseAssetCpiBuilder<'a, 'b> {
     instruction: Box<UseAssetCpiBuilderInstruction<'a, 'b>>,
 }
@@ -777,6 +778,7 @@ impl<'a, 'b> UseAssetCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UseAssetCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -147,7 +147,7 @@ pub struct UtilizeInstructionArgs {
 ///   8. `[optional]` rent (default to `SysvarRent111111111111111111111111111111111`)
 ///   9. `[writable, optional]` use_authority_record
 ///   10. `[optional]` burner
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct UtilizeBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     token_account: Option<solana_program::pubkey::Pubkey>,
@@ -530,6 +530,7 @@ impl<'a, 'b> UtilizeCpi<'a, 'b> {
 ///   8. `[]` rent
 ///   9. `[writable, optional]` use_authority_record
 ///   10. `[optional]` burner
+#[derive(Clone, Debug)]
 pub struct UtilizeCpiBuilder<'a, 'b> {
     instruction: Box<UtilizeCpiBuilderInstruction<'a, 'b>>,
 }
@@ -747,6 +748,7 @@ impl<'a, 'b> UtilizeCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct UtilizeCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -174,7 +174,7 @@ pub struct ValidateInstructionArgs {
 ///   10. `[optional]` opt_rule_nonsigner3
 ///   11. `[optional]` opt_rule_nonsigner4
 ///   12. `[optional]` opt_rule_nonsigner5
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ValidateBuilder {
     payer: Option<solana_program::pubkey::Pubkey>,
     rule_set: Option<solana_program::pubkey::Pubkey>,
@@ -661,6 +661,7 @@ impl<'a, 'b> ValidateCpi<'a, 'b> {
 ///   10. `[optional]` opt_rule_nonsigner3
 ///   11. `[optional]` opt_rule_nonsigner4
 ///   12. `[optional]` opt_rule_nonsigner5
+#[derive(Clone, Debug)]
 pub struct ValidateCpiBuilder<'a, 'b> {
     instruction: Box<ValidateCpiBuilderInstruction<'a, 'b>>,
 }
@@ -930,6 +931,7 @@ impl<'a, 'b> ValidateCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct ValidateCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     payer: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -109,7 +109,7 @@ pub struct VerifyInstructionArgs {
 ///   2. `[writable, signer]` payer
 ///   3. `[optional]` authorization_rules
 ///   4. `[optional]` authorization_rules_program
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct VerifyBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -371,6 +371,7 @@ impl<'a, 'b> VerifyCpi<'a, 'b> {
 ///   2. `[writable, signer]` payer
 ///   3. `[optional]` authorization_rules
 ///   4. `[optional]` authorization_rules_program
+#[derive(Clone, Debug)]
 pub struct VerifyCpiBuilder<'a, 'b> {
     instruction: Box<VerifyCpiBuilderInstruction<'a, 'b>>,
 }
@@ -510,6 +511,7 @@ impl<'a, 'b> VerifyCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct VerifyCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -89,7 +89,7 @@ impl VerifyCollectionInstructionData {
 ///   3. `[]` collection_mint
 ///   4. `[]` collection
 ///   5. `[]` collection_master_edition_account
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct VerifyCollectionBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -337,6 +337,7 @@ impl<'a, 'b> VerifyCollectionCpi<'a, 'b> {
 ///   3. `[]` collection_mint
 ///   4. `[]` collection
 ///   5. `[]` collection_master_edition_account
+#[derive(Clone, Debug)]
 pub struct VerifyCollectionCpiBuilder<'a, 'b> {
     instruction: Box<VerifyCollectionCpiBuilderInstruction<'a, 'b>>,
 }
@@ -479,6 +480,7 @@ impl<'a, 'b> VerifyCollectionCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct VerifyCollectionCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -105,7 +105,7 @@ impl VerifySizedCollectionItemInstructionData {
 ///   4. `[writable]` collection
 ///   5. `[]` collection_master_edition_account
 ///   6. `[optional]` collection_authority_record
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct VerifySizedCollectionItemBuilder {
     metadata: Option<solana_program::pubkey::Pubkey>,
     collection_authority: Option<solana_program::pubkey::Pubkey>,
@@ -387,6 +387,7 @@ impl<'a, 'b> VerifySizedCollectionItemCpi<'a, 'b> {
 ///   4. `[writable]` collection
 ///   5. `[]` collection_master_edition_account
 ///   6. `[optional]` collection_authority_record
+#[derive(Clone, Debug)]
 pub struct VerifySizedCollectionItemCpiBuilder<'a, 'b> {
     instruction: Box<VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b>>,
 }
@@ -542,6 +543,7 @@ impl<'a, 'b> VerifySizedCollectionItemCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct VerifySizedCollectionItemCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     metadata: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -63,7 +63,7 @@ impl WithdrawInstructionData {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[writable, signer]` authority
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct WithdrawBuilder {
     candy_machine: Option<solana_program::pubkey::Pubkey>,
     authority: Option<solana_program::pubkey::Pubkey>,
@@ -219,6 +219,7 @@ impl<'a, 'b> WithdrawCpi<'a, 'b> {
 ///
 ///   0. `[writable]` candy_machine
 ///   1. `[writable, signer]` authority
+#[derive(Clone, Debug)]
 pub struct WithdrawCpiBuilder<'a, 'b> {
     instruction: Box<WithdrawCpiBuilderInstruction<'a, 'b>>,
 }
@@ -307,6 +308,7 @@ impl<'a, 'b> WithdrawCpiBuilder<'a, 'b> {
     }
 }
 
+#[derive(Clone, Debug)]
 struct WithdrawCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     candy_machine: Option<&'b solana_program::account_info::AccountInfo<'a>>,


### PR DESCRIPTION
This PR adds `Clone` and `Debug` derives to Rust instruction builders.