### PR TITLE
[experimental] Use account name directly for data types and codecs

### DIFF
--- a/.changeset/witty-dryers-beg.md
+++ b/.changeset/witty-dryers-beg.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": minor
+---
+
+Use account name directly for data types and codecs

--- a/src/renderers/js-experimental/fragments/accountFetchHelpers.njk
+++ b/src/renderers/js-experimental/fragments/accountFetchHelpers.njk
@@ -1,6 +1,6 @@
-export function {{ decodeFunction }}<TAddress extends string = string>(encodedAccount: EncodedAccount<TAddress>): {{ accountType }}<TAddress>;
-export function {{ decodeFunction }}<TAddress extends string = string>(encodedAccount: MaybeEncodedAccount<TAddress>): {{ accountMaybeType }}<TAddress>;
-export function {{ decodeFunction }}<TAddress extends string = string>(encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>): {{ accountType }}<TAddress> | {{ accountMaybeType }}<TAddress> {
+export function {{ decodeFunction }}<TAddress extends string = string>(encodedAccount: EncodedAccount<TAddress>): Account<{{ accountType }}, TAddress>;
+export function {{ decodeFunction }}<TAddress extends string = string>(encodedAccount: MaybeEncodedAccount<TAddress>): MaybeAccount<{{ accountType }}, TAddress>;
+export function {{ decodeFunction }}<TAddress extends string = string>(encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>): Account<{{ accountType }}, TAddress> | MaybeAccount<{{ accountType }}, TAddress> {
   return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, {{ decoderFunction }});
 }
 
@@ -8,7 +8,7 @@ export async function {{ fetchFunction }}<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig,
-): Promise<{{ accountType }}<TAddress>> {
+): Promise<Account<{{ accountType }}, TAddress>> {
   const maybeAccount = await {{ fetchMaybeFunction }}(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -18,7 +18,7 @@ export async function {{ fetchMaybeFunction }}<TAddress extends string = string>
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig,
-): Promise<{{ accountMaybeType }}<TAddress>> {
+): Promise<MaybeAccount<{{ accountType }}, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return {{ decodeFunction }}(maybeAccount);
 }
@@ -27,7 +27,7 @@ export async function {{ fetchAllFunction }}(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig,
-): Promise<{{ accountType }}[]> {
+): Promise<Account<{{ accountType }}>[]> {
   const maybeAccounts = await {{ fetchAllMaybeFunction }}(rpc, addresses, config);
   assertAccountsExist(maybeAccounts);
   return maybeAccounts;
@@ -37,7 +37,7 @@ export async function {{ fetchAllMaybeFunction }}(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig,
-): Promise<{{ accountMaybeType }}[]> {
+): Promise<MaybeAccount<{{ accountType }}>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) => {{ decodeFunction }}(maybeAccount));
 }

--- a/src/renderers/js-experimental/fragments/accountFetchHelpers.ts
+++ b/src/renderers/js-experimental/fragments/accountFetchHelpers.ts
@@ -10,13 +10,17 @@ export function getAccountFetchHelpersFragment(
   }
 ): Fragment {
   const { accountNode, typeManifest, nameApi, customAccountData } = scope;
-  const decoderFunctionFragment = customAccountData.has(accountNode.name)
+  const hasCustomData = customAccountData.has(accountNode.name);
+  const accountTypeFragment = hasCustomData
+    ? typeManifest.strictType.clone()
+    : fragment(nameApi.dataType(accountNode.name));
+  const decoderFunctionFragment = hasCustomData
     ? typeManifest.decoder.clone()
     : fragment(`${nameApi.decoderFunction(accountNode.name)}()`);
 
   return fragmentFromTemplate('accountFetchHelpers.njk', {
     decoderFunction: decoderFunctionFragment.render,
-    accountType: nameApi.dataType(accountNode.name),
+    accountType: accountTypeFragment.render,
     decodeFunction: nameApi.accountDecodeFunction(accountNode.name),
     fetchFunction: nameApi.accountFetchFunction(accountNode.name),
     fetchMaybeFunction: nameApi.accountFetchMaybeFunction(accountNode.name),
@@ -25,7 +29,7 @@ export function getAccountFetchHelpersFragment(
       accountNode.name
     ),
   })
-    .mergeImportsWith(decoderFunctionFragment)
+    .mergeImportsWith(accountTypeFragment, decoderFunctionFragment)
     .addImports('solanaAddresses', ['Address'])
     .addImports('solanaAccounts', [
       'Account',

--- a/src/renderers/js-experimental/fragments/accountFetchHelpers.ts
+++ b/src/renderers/js-experimental/fragments/accountFetchHelpers.ts
@@ -10,15 +10,13 @@ export function getAccountFetchHelpersFragment(
   }
 ): Fragment {
   const { accountNode, typeManifest, nameApi, customAccountData } = scope;
-  const accountDataName = nameApi.accountDataType(accountNode.name);
   const decoderFunctionFragment = customAccountData.has(accountNode.name)
     ? typeManifest.decoder.clone()
-    : fragment(`${nameApi.decoderFunction(accountDataName)}()`);
+    : fragment(`${nameApi.decoderFunction(accountNode.name)}()`);
 
   return fragmentFromTemplate('accountFetchHelpers.njk', {
     decoderFunction: decoderFunctionFragment.render,
-    accountType: nameApi.accountType(accountNode.name),
-    accountMaybeType: nameApi.accountMaybeType(accountNode.name),
+    accountType: nameApi.dataType(accountNode.name),
     decodeFunction: nameApi.accountDecodeFunction(accountNode.name),
     fetchFunction: nameApi.accountFetchFunction(accountNode.name),
     fetchMaybeFunction: nameApi.accountFetchMaybeFunction(accountNode.name),
@@ -30,6 +28,7 @@ export function getAccountFetchHelpersFragment(
     .mergeImportsWith(decoderFunctionFragment)
     .addImports('solanaAddresses', ['Address'])
     .addImports('solanaAccounts', [
+      'Account',
       'assertAccountExists',
       'assertAccountsExist',
       'decodeAccount',
@@ -38,6 +37,7 @@ export function getAccountFetchHelpersFragment(
       'fetchEncodedAccounts',
       'FetchAccountConfig',
       'FetchAccountsConfig',
+      'MaybeAccount',
       'MaybeEncodedAccount',
     ]);
 }

--- a/src/renderers/js-experimental/fragments/accountPdaHelpers.njk
+++ b/src/renderers/js-experimental/fragments/accountPdaHelpers.njk
@@ -6,7 +6,7 @@ export async function {{ fetchFromSeedsFunction }}(
     seeds: {{ pdaSeedsType }},
   {% endif %}
   config: FetchAccountConfig & { programAddress?: Address } = {},
-): Promise<{{ accountType }}> {
+): Promise<Account<{{ accountType }}>> {
   const maybeAccount = await {{ fetchMaybeFromSeedsFunction }}(rpc, {% if hasVariableSeeds %}seeds, {% endif %}config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -18,7 +18,7 @@ export async function {{ fetchMaybeFromSeedsFunction }}(
     seeds: {{ pdaSeedsType }},
   {% endif %}
   config: FetchAccountConfig & { programAddress?: Address } = {},
-): Promise<{{ accountMaybeType }}> {
+): Promise<MaybeAccount<{{ accountType }}>> {
   const { programAddress, ...fetchConfig } = config;
   const [address] = await {{ findPdaFunction }}({% if hasVariableSeeds %}seeds, {% endif %}{ programAddress });
   return await {{ fetchMaybeFunction }}(rpc, address, fetchConfig);

--- a/src/renderers/js-experimental/fragments/accountPdaHelpers.ts
+++ b/src/renderers/js-experimental/fragments/accountPdaHelpers.ts
@@ -21,8 +21,7 @@ export function getAccountPdaHelpersFragment(
     pdaNode.seeds.filter(isNodeFilter('variablePdaSeedNode')).length > 0;
 
   return fragmentFromTemplate('accountPdaHelpers.njk', {
-    accountType: nameApi.accountType(accountNode.name),
-    accountMaybeType: nameApi.accountMaybeType(accountNode.name),
+    accountType: nameApi.dataType(accountNode.name),
     pdaSeedsType,
     findPdaFunction,
     fetchFunction: nameApi.accountFetchFunction(accountNode.name),
@@ -42,7 +41,9 @@ export function getAccountPdaHelpersFragment(
     )
     .addImports('solanaAddresses', ['Address'])
     .addImports('solanaAccounts', [
+      'Account',
       'assertAccountExists',
       'FetchAccountConfig',
+      'MaybeAccount',
     ]);
 }

--- a/src/renderers/js-experimental/fragments/accountType.njk
+++ b/src/renderers/js-experimental/fragments/accountType.njk
@@ -1,8 +1,0 @@
-{% import "templates/macros.njk" as macros %}
-
-{{ macros.docblock(docs) }}
-export type {{ accountType }}<TAddress extends string = string> = Account<{{ dataName }}, TAddress>;
-
-export type {{ accountMaybeType }}<TAddress extends string = string> = MaybeAccount<{{ dataName }}, TAddress>;
-
-{{ typeWithCodec }}

--- a/src/renderers/js-experimental/fragments/accountType.ts
+++ b/src/renderers/js-experimental/fragments/accountType.ts
@@ -1,7 +1,7 @@
 import { AccountNode } from '../../../nodes';
 import { TypeManifest } from '../TypeManifest';
 import type { GlobalFragmentScope } from '../getRenderMapVisitor';
-import { Fragment, fragment, fragmentFromTemplate } from './common';
+import { Fragment, fragment } from './common';
 import { getTypeWithCodecFragment } from './typeWithCodec';
 
 export function getAccountTypeFragment(
@@ -12,25 +12,16 @@ export function getAccountTypeFragment(
 ): Fragment {
   const { accountNode, typeManifest, nameApi, customAccountData } = scope;
   const customData = customAccountData.get(accountNode.name);
-  const accountDataName = nameApi.accountDataType(accountNode.name);
-  const typeWithCodecFragment = customData
-    ? fragment('')
-    : getTypeWithCodecFragment({
-        name: accountDataName,
-        manifest: typeManifest,
-        nameApi,
-      });
 
-  const dataNameFragment = customData
-    ? typeManifest.strictType.clone()
-    : fragment(nameApi.dataType(accountDataName));
+  if (customData) {
+    // TODO
+    // const dataNameFragment = typeManifest.strictType.clone();
+    return fragment('');
+  }
 
-  return fragmentFromTemplate('accountType.njk', {
-    accountType: nameApi.accountType(accountNode.name),
-    accountMaybeType: nameApi.accountMaybeType(accountNode.name),
-    dataName: dataNameFragment.render,
-    typeWithCodec: typeWithCodecFragment,
-  })
-    .mergeImportsWith(dataNameFragment, typeWithCodecFragment)
-    .addImports('solanaAccounts', ['Account', 'MaybeAccount']);
+  return getTypeWithCodecFragment({
+    name: accountNode.name,
+    manifest: typeManifest,
+    nameApi,
+  });
 }

--- a/src/renderers/js-experimental/fragments/accountType.ts
+++ b/src/renderers/js-experimental/fragments/accountType.ts
@@ -11,11 +11,8 @@ export function getAccountTypeFragment(
   }
 ): Fragment {
   const { accountNode, typeManifest, nameApi, customAccountData } = scope;
-  const customData = customAccountData.get(accountNode.name);
 
-  if (customData) {
-    // TODO
-    // const dataNameFragment = typeManifest.strictType.clone();
+  if (customAccountData.has(accountNode.name)) {
     return fragment('');
   }
 

--- a/src/renderers/js-experimental/fragments/pdaFunction.ts
+++ b/src/renderers/js-experimental/fragments/pdaFunction.ts
@@ -36,7 +36,6 @@ export function getPdaFunctionFragment(
     pdaNode.seeds.filter(isNodeFilter('variablePdaSeedNode')).length > 0;
 
   return fragmentFromTemplate('pdaFunction.njk', {
-    accountType: nameApi.accountType(pdaNode.name),
     pdaSeedsType: nameApi.pdaSeedsType(pdaNode.name),
     findPdaFunction: nameApi.pdaFindFunction(pdaNode.name),
     program: programNode,

--- a/src/renderers/js-experimental/getTypeManifestVisitor.ts
+++ b/src/renderers/js-experimental/getTypeManifestVisitor.ts
@@ -68,10 +68,9 @@ export function getTypeManifestVisitor(input: {
     (visitor) =>
       extendVisitor(visitor, {
         visitAccount(account, { self }) {
-          const accountDataName = nameApi.accountDataType(account.name);
           parentName = {
-            strict: nameApi.dataType(accountDataName),
-            loose: nameApi.dataArgsType(accountDataName),
+            strict: nameApi.dataType(account.name),
+            loose: nameApi.dataArgsType(account.name),
           };
           const link = customAccountData.get(account.name)?.linkNode;
           const manifest = link ? visit(link, self) : visit(account.data, self);

--- a/src/renderers/js-experimental/nameTransformers.ts
+++ b/src/renderers/js-experimental/nameTransformers.ts
@@ -29,9 +29,6 @@ export type NameTransformerKey =
   | 'codecFunction'
   | 'pdaSeedsType'
   | 'pdaFindFunction'
-  | 'accountType'
-  | 'accountMaybeType'
-  | 'accountDataType'
   | 'accountDecodeFunction'
   | 'accountFetchFunction'
   | 'accountFetchAllFunction'
@@ -99,9 +96,6 @@ export const DEFAULT_NAME_TRANSFORMERS: NameTransformers = {
   codecFunction: (name) => `get${pascalCase(name)}Codec`,
   pdaSeedsType: (name) => `${pascalCase(name)}Seeds`,
   pdaFindFunction: (name) => `find${pascalCase(name)}Pda`,
-  accountType: (name) => `${pascalCase(name)}`,
-  accountMaybeType: (name) => `Maybe${pascalCase(name)}`,
-  accountDataType: (name) => `${pascalCase(name)}AccountData`,
   accountDecodeFunction: (name) => `decode${pascalCase(name)}`,
   accountFetchFunction: (name) => `fetch${pascalCase(name)}`,
   accountFetchAllFunction: (name) => `fetchAll${pascalCase(name)}`,

--- a/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
+++ b/test/packages/js-experimental/src/generated/accounts/candyMachine.ts
@@ -46,17 +46,7 @@ import {
   getCandyMachineDataEncoder,
 } from '../types';
 
-export type CandyMachine<TAddress extends string = string> = Account<
-  CandyMachineAccountData,
-  TAddress
->;
-
-export type MaybeCandyMachine<TAddress extends string = string> = MaybeAccount<
-  CandyMachineAccountData,
-  TAddress
->;
-
-export type CandyMachineAccountData = {
+export type CandyMachine = {
   discriminator: Array<number>;
   /** Features versioning flags. */
   features: bigint;
@@ -72,7 +62,7 @@ export type CandyMachineAccountData = {
   data: CandyMachineData;
 };
 
-export type CandyMachineAccountDataArgs = {
+export type CandyMachineArgs = {
   /** Features versioning flags. */
   features: number | bigint;
   /** Authority address. */
@@ -87,7 +77,7 @@ export type CandyMachineAccountDataArgs = {
   data: CandyMachineDataArgs;
 };
 
-export function getCandyMachineAccountDataEncoder(): Encoder<CandyMachineAccountDataArgs> {
+export function getCandyMachineEncoder(): Encoder<CandyMachineArgs> {
   return transformEncoder(
     getStructEncoder([
       ['discriminator', getArrayEncoder(getU8Encoder(), { size: 8 })],
@@ -105,7 +95,7 @@ export function getCandyMachineAccountDataEncoder(): Encoder<CandyMachineAccount
   );
 }
 
-export function getCandyMachineAccountDataDecoder(): Decoder<CandyMachineAccountData> {
+export function getCandyMachineDecoder(): Decoder<CandyMachine> {
   return getStructDecoder([
     ['discriminator', getArrayDecoder(getU8Decoder(), { size: 8 })],
     ['features', getU64Decoder()],
@@ -117,28 +107,22 @@ export function getCandyMachineAccountDataDecoder(): Decoder<CandyMachineAccount
   ]);
 }
 
-export function getCandyMachineAccountDataCodec(): Codec<
-  CandyMachineAccountDataArgs,
-  CandyMachineAccountData
-> {
-  return combineCodec(
-    getCandyMachineAccountDataEncoder(),
-    getCandyMachineAccountDataDecoder()
-  );
+export function getCandyMachineCodec(): Codec<CandyMachineArgs, CandyMachine> {
+  return combineCodec(getCandyMachineEncoder(), getCandyMachineDecoder());
 }
 
 export function decodeCandyMachine<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): CandyMachine<TAddress>;
+): Account<CandyMachine, TAddress>;
 export function decodeCandyMachine<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeCandyMachine<TAddress>;
+): MaybeAccount<CandyMachine, TAddress>;
 export function decodeCandyMachine<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): CandyMachine<TAddress> | MaybeCandyMachine<TAddress> {
+): Account<CandyMachine, TAddress> | MaybeAccount<CandyMachine, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getCandyMachineAccountDataDecoder()
+    getCandyMachineDecoder()
   );
 }
 
@@ -146,7 +130,7 @@ export async function fetchCandyMachine<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<CandyMachine<TAddress>> {
+): Promise<Account<CandyMachine, TAddress>> {
   const maybeAccount = await fetchMaybeCandyMachine(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -156,7 +140,7 @@ export async function fetchMaybeCandyMachine<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeCandyMachine<TAddress>> {
+): Promise<MaybeAccount<CandyMachine, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeCandyMachine(maybeAccount);
 }
@@ -165,7 +149,7 @@ export async function fetchAllCandyMachine(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<CandyMachine[]> {
+): Promise<Account<CandyMachine>[]> {
   const maybeAccounts = await fetchAllMaybeCandyMachine(rpc, addresses, config);
   assertAccountsExist(maybeAccounts);
   return maybeAccounts;
@@ -175,7 +159,7 @@ export async function fetchAllMaybeCandyMachine(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeCandyMachine[]> {
+): Promise<MaybeAccount<CandyMachine>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) => decodeCandyMachine(maybeAccount));
 }

--- a/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/collectionAuthorityRecord.ts
@@ -41,24 +41,18 @@ import {
 } from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
-export type CollectionAuthorityRecord<TAddress extends string = string> =
-  Account<CollectionAuthorityRecordAccountData, TAddress>;
-
-export type MaybeCollectionAuthorityRecord<TAddress extends string = string> =
-  MaybeAccount<CollectionAuthorityRecordAccountData, TAddress>;
-
-export type CollectionAuthorityRecordAccountData = {
+export type CollectionAuthorityRecord = {
   key: TmKey;
   bump: number;
   updateAuthority: Option<Address>;
 };
 
-export type CollectionAuthorityRecordAccountDataArgs = {
+export type CollectionAuthorityRecordArgs = {
   bump: number;
   updateAuthority: OptionOrNullable<Address>;
 };
 
-export function getCollectionAuthorityRecordAccountDataEncoder(): Encoder<CollectionAuthorityRecordAccountDataArgs> {
+export function getCollectionAuthorityRecordEncoder(): Encoder<CollectionAuthorityRecordArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -69,7 +63,7 @@ export function getCollectionAuthorityRecordAccountDataEncoder(): Encoder<Collec
   );
 }
 
-export function getCollectionAuthorityRecordAccountDataDecoder(): Decoder<CollectionAuthorityRecordAccountData> {
+export function getCollectionAuthorityRecordDecoder(): Decoder<CollectionAuthorityRecord> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['bump', getU8Decoder()],
@@ -77,13 +71,13 @@ export function getCollectionAuthorityRecordAccountDataDecoder(): Decoder<Collec
   ]);
 }
 
-export function getCollectionAuthorityRecordAccountDataCodec(): Codec<
-  CollectionAuthorityRecordAccountDataArgs,
-  CollectionAuthorityRecordAccountData
+export function getCollectionAuthorityRecordCodec(): Codec<
+  CollectionAuthorityRecordArgs,
+  CollectionAuthorityRecord
 > {
   return combineCodec(
-    getCollectionAuthorityRecordAccountDataEncoder(),
-    getCollectionAuthorityRecordAccountDataDecoder()
+    getCollectionAuthorityRecordEncoder(),
+    getCollectionAuthorityRecordDecoder()
   );
 }
 
@@ -91,22 +85,22 @@ export function decodeCollectionAuthorityRecord<
   TAddress extends string = string,
 >(
   encodedAccount: EncodedAccount<TAddress>
-): CollectionAuthorityRecord<TAddress>;
+): Account<CollectionAuthorityRecord, TAddress>;
 export function decodeCollectionAuthorityRecord<
   TAddress extends string = string,
 >(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeCollectionAuthorityRecord<TAddress>;
+): MaybeAccount<CollectionAuthorityRecord, TAddress>;
 export function decodeCollectionAuthorityRecord<
   TAddress extends string = string,
 >(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ):
-  | CollectionAuthorityRecord<TAddress>
-  | MaybeCollectionAuthorityRecord<TAddress> {
+  | Account<CollectionAuthorityRecord, TAddress>
+  | MaybeAccount<CollectionAuthorityRecord, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getCollectionAuthorityRecordAccountDataDecoder()
+    getCollectionAuthorityRecordDecoder()
   );
 }
 
@@ -116,7 +110,7 @@ export async function fetchCollectionAuthorityRecord<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<CollectionAuthorityRecord<TAddress>> {
+): Promise<Account<CollectionAuthorityRecord, TAddress>> {
   const maybeAccount = await fetchMaybeCollectionAuthorityRecord(
     rpc,
     address,
@@ -132,7 +126,7 @@ export async function fetchMaybeCollectionAuthorityRecord<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeCollectionAuthorityRecord<TAddress>> {
+): Promise<MaybeAccount<CollectionAuthorityRecord, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeCollectionAuthorityRecord(maybeAccount);
 }
@@ -141,7 +135,7 @@ export async function fetchAllCollectionAuthorityRecord(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<CollectionAuthorityRecord[]> {
+): Promise<Account<CollectionAuthorityRecord>[]> {
   const maybeAccounts = await fetchAllMaybeCollectionAuthorityRecord(
     rpc,
     addresses,
@@ -155,7 +149,7 @@ export async function fetchAllMaybeCollectionAuthorityRecord(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeCollectionAuthorityRecord[]> {
+): Promise<MaybeAccount<CollectionAuthorityRecord>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeCollectionAuthorityRecord(maybeAccount)

--- a/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/delegateRecord.ts
@@ -42,26 +42,11 @@ import {
   getTmKeyEncoder,
 } from '../types';
 
-export type DelegateRecord<TAddress extends string = string> = Account<
-  DelegateRecordAccountData,
-  TAddress
->;
+export type DelegateRecord = { key: TmKey; role: DelegateRole; bump: number };
 
-export type MaybeDelegateRecord<TAddress extends string = string> =
-  MaybeAccount<DelegateRecordAccountData, TAddress>;
+export type DelegateRecordArgs = { role: DelegateRoleArgs; bump: number };
 
-export type DelegateRecordAccountData = {
-  key: TmKey;
-  role: DelegateRole;
-  bump: number;
-};
-
-export type DelegateRecordAccountDataArgs = {
-  role: DelegateRoleArgs;
-  bump: number;
-};
-
-export function getDelegateRecordAccountDataEncoder(): Encoder<DelegateRecordAccountDataArgs> {
+export function getDelegateRecordEncoder(): Encoder<DelegateRecordArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -72,7 +57,7 @@ export function getDelegateRecordAccountDataEncoder(): Encoder<DelegateRecordAcc
   );
 }
 
-export function getDelegateRecordAccountDataDecoder(): Decoder<DelegateRecordAccountData> {
+export function getDelegateRecordDecoder(): Decoder<DelegateRecord> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['role', getDelegateRoleDecoder()],
@@ -80,28 +65,25 @@ export function getDelegateRecordAccountDataDecoder(): Decoder<DelegateRecordAcc
   ]);
 }
 
-export function getDelegateRecordAccountDataCodec(): Codec<
-  DelegateRecordAccountDataArgs,
-  DelegateRecordAccountData
+export function getDelegateRecordCodec(): Codec<
+  DelegateRecordArgs,
+  DelegateRecord
 > {
-  return combineCodec(
-    getDelegateRecordAccountDataEncoder(),
-    getDelegateRecordAccountDataDecoder()
-  );
+  return combineCodec(getDelegateRecordEncoder(), getDelegateRecordDecoder());
 }
 
 export function decodeDelegateRecord<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): DelegateRecord<TAddress>;
+): Account<DelegateRecord, TAddress>;
 export function decodeDelegateRecord<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeDelegateRecord<TAddress>;
+): MaybeAccount<DelegateRecord, TAddress>;
 export function decodeDelegateRecord<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): DelegateRecord<TAddress> | MaybeDelegateRecord<TAddress> {
+): Account<DelegateRecord, TAddress> | MaybeAccount<DelegateRecord, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getDelegateRecordAccountDataDecoder()
+    getDelegateRecordDecoder()
   );
 }
 
@@ -109,7 +91,7 @@ export async function fetchDelegateRecord<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<DelegateRecord<TAddress>> {
+): Promise<Account<DelegateRecord, TAddress>> {
   const maybeAccount = await fetchMaybeDelegateRecord(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -121,7 +103,7 @@ export async function fetchMaybeDelegateRecord<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeDelegateRecord<TAddress>> {
+): Promise<MaybeAccount<DelegateRecord, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeDelegateRecord(maybeAccount);
 }
@@ -130,7 +112,7 @@ export async function fetchAllDelegateRecord(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<DelegateRecord[]> {
+): Promise<Account<DelegateRecord>[]> {
   const maybeAccounts = await fetchAllMaybeDelegateRecord(
     rpc,
     addresses,
@@ -144,7 +126,7 @@ export async function fetchAllMaybeDelegateRecord(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeDelegateRecord[]> {
+): Promise<MaybeAccount<DelegateRecord>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeDelegateRecord(maybeAccount)
@@ -159,7 +141,7 @@ export async function fetchDelegateRecordFromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: DelegateRecordSeeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<DelegateRecord> {
+): Promise<Account<DelegateRecord>> {
   const maybeAccount = await fetchMaybeDelegateRecordFromSeeds(
     rpc,
     seeds,
@@ -173,7 +155,7 @@ export async function fetchMaybeDelegateRecordFromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: DelegateRecordSeeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MaybeDelegateRecord> {
+): Promise<MaybeAccount<DelegateRecord>> {
   const { programAddress, ...fetchConfig } = config;
   const [address] = await findDelegateRecordPda(seeds, { programAddress });
   return await fetchMaybeDelegateRecord(rpc, address, fetchConfig);

--- a/test/packages/js-experimental/src/generated/accounts/edition.ts
+++ b/test/packages/js-experimental/src/generated/accounts/edition.ts
@@ -37,28 +37,11 @@ import {
 } from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
-export type Edition<TAddress extends string = string> = Account<
-  EditionAccountData,
-  TAddress
->;
+export type Edition = { key: TmKey; parent: Address; edition: bigint };
 
-export type MaybeEdition<TAddress extends string = string> = MaybeAccount<
-  EditionAccountData,
-  TAddress
->;
+export type EditionArgs = { parent: Address; edition: number | bigint };
 
-export type EditionAccountData = {
-  key: TmKey;
-  parent: Address;
-  edition: bigint;
-};
-
-export type EditionAccountDataArgs = {
-  parent: Address;
-  edition: number | bigint;
-};
-
-export function getEditionAccountDataEncoder(): Encoder<EditionAccountDataArgs> {
+export function getEditionEncoder(): Encoder<EditionArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -69,7 +52,7 @@ export function getEditionAccountDataEncoder(): Encoder<EditionAccountDataArgs> 
   );
 }
 
-export function getEditionAccountDataDecoder(): Decoder<EditionAccountData> {
+export function getEditionDecoder(): Decoder<Edition> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['parent', getAddressDecoder()],
@@ -77,28 +60,22 @@ export function getEditionAccountDataDecoder(): Decoder<EditionAccountData> {
   ]);
 }
 
-export function getEditionAccountDataCodec(): Codec<
-  EditionAccountDataArgs,
-  EditionAccountData
-> {
-  return combineCodec(
-    getEditionAccountDataEncoder(),
-    getEditionAccountDataDecoder()
-  );
+export function getEditionCodec(): Codec<EditionArgs, Edition> {
+  return combineCodec(getEditionEncoder(), getEditionDecoder());
 }
 
 export function decodeEdition<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): Edition<TAddress>;
+): Account<Edition, TAddress>;
 export function decodeEdition<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeEdition<TAddress>;
+): MaybeAccount<Edition, TAddress>;
 export function decodeEdition<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): Edition<TAddress> | MaybeEdition<TAddress> {
+): Account<Edition, TAddress> | MaybeAccount<Edition, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getEditionAccountDataDecoder()
+    getEditionDecoder()
   );
 }
 
@@ -106,7 +83,7 @@ export async function fetchEdition<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<Edition<TAddress>> {
+): Promise<Account<Edition, TAddress>> {
   const maybeAccount = await fetchMaybeEdition(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -116,7 +93,7 @@ export async function fetchMaybeEdition<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeEdition<TAddress>> {
+): Promise<MaybeAccount<Edition, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeEdition(maybeAccount);
 }
@@ -125,7 +102,7 @@ export async function fetchAllEdition(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<Edition[]> {
+): Promise<Account<Edition>[]> {
   const maybeAccounts = await fetchAllMaybeEdition(rpc, addresses, config);
   assertAccountsExist(maybeAccounts);
   return maybeAccounts;
@@ -135,7 +112,7 @@ export async function fetchAllMaybeEdition(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeEdition[]> {
+): Promise<MaybeAccount<Edition>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) => decodeEdition(maybeAccount));
 }

--- a/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
+++ b/test/packages/js-experimental/src/generated/accounts/editionMarker.ts
@@ -35,21 +35,11 @@ import {
 } from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
-export type EditionMarker<TAddress extends string = string> = Account<
-  EditionMarkerAccountData,
-  TAddress
->;
+export type EditionMarker = { key: TmKey; ledger: Array<number> };
 
-export type MaybeEditionMarker<TAddress extends string = string> = MaybeAccount<
-  EditionMarkerAccountData,
-  TAddress
->;
+export type EditionMarkerArgs = { ledger: Array<number> };
 
-export type EditionMarkerAccountData = { key: TmKey; ledger: Array<number> };
-
-export type EditionMarkerAccountDataArgs = { ledger: Array<number> };
-
-export function getEditionMarkerAccountDataEncoder(): Encoder<EditionMarkerAccountDataArgs> {
+export function getEditionMarkerEncoder(): Encoder<EditionMarkerArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -59,35 +49,32 @@ export function getEditionMarkerAccountDataEncoder(): Encoder<EditionMarkerAccou
   );
 }
 
-export function getEditionMarkerAccountDataDecoder(): Decoder<EditionMarkerAccountData> {
+export function getEditionMarkerDecoder(): Decoder<EditionMarker> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['ledger', getArrayDecoder(getU8Decoder(), { size: 200 })],
   ]);
 }
 
-export function getEditionMarkerAccountDataCodec(): Codec<
-  EditionMarkerAccountDataArgs,
-  EditionMarkerAccountData
+export function getEditionMarkerCodec(): Codec<
+  EditionMarkerArgs,
+  EditionMarker
 > {
-  return combineCodec(
-    getEditionMarkerAccountDataEncoder(),
-    getEditionMarkerAccountDataDecoder()
-  );
+  return combineCodec(getEditionMarkerEncoder(), getEditionMarkerDecoder());
 }
 
 export function decodeEditionMarker<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): EditionMarker<TAddress>;
+): Account<EditionMarker, TAddress>;
 export function decodeEditionMarker<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeEditionMarker<TAddress>;
+): MaybeAccount<EditionMarker, TAddress>;
 export function decodeEditionMarker<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): EditionMarker<TAddress> | MaybeEditionMarker<TAddress> {
+): Account<EditionMarker, TAddress> | MaybeAccount<EditionMarker, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getEditionMarkerAccountDataDecoder()
+    getEditionMarkerDecoder()
   );
 }
 
@@ -95,7 +82,7 @@ export async function fetchEditionMarker<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<EditionMarker<TAddress>> {
+): Promise<Account<EditionMarker, TAddress>> {
   const maybeAccount = await fetchMaybeEditionMarker(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -105,7 +92,7 @@ export async function fetchMaybeEditionMarker<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeEditionMarker<TAddress>> {
+): Promise<MaybeAccount<EditionMarker, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeEditionMarker(maybeAccount);
 }
@@ -114,7 +101,7 @@ export async function fetchAllEditionMarker(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<EditionMarker[]> {
+): Promise<Account<EditionMarker>[]> {
   const maybeAccounts = await fetchAllMaybeEditionMarker(
     rpc,
     addresses,
@@ -128,7 +115,7 @@ export async function fetchAllMaybeEditionMarker(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeEditionMarker[]> {
+): Promise<MaybeAccount<EditionMarker>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) => decodeEditionMarker(maybeAccount));
 }

--- a/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
+++ b/test/packages/js-experimental/src/generated/accounts/frequencyAccount.ts
@@ -36,15 +36,7 @@ import {
 import { findFrequencyAccountPda } from '../pdas';
 import { TaKey } from '../types';
 
-export type FrequencyAccount<TAddress extends string = string> = Account<
-  FrequencyAccountAccountData,
-  TAddress
->;
-
-export type MaybeFrequencyAccount<TAddress extends string = string> =
-  MaybeAccount<FrequencyAccountAccountData, TAddress>;
-
-export type FrequencyAccountAccountData = {
+export type FrequencyAccount = {
   /** Test with only one line. */
   key: bigint;
   /**
@@ -55,7 +47,7 @@ export type FrequencyAccountAccountData = {
   period: bigint;
 };
 
-export type FrequencyAccountAccountDataArgs = {
+export type FrequencyAccountArgs = {
   /**
    * Test with multiple lines
    * and this is the second line.
@@ -64,7 +56,7 @@ export type FrequencyAccountAccountDataArgs = {
   period: number | bigint;
 };
 
-export function getFrequencyAccountAccountDataEncoder(): Encoder<FrequencyAccountAccountDataArgs> {
+export function getFrequencyAccountEncoder(): Encoder<FrequencyAccountArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getU64Encoder()],
@@ -75,7 +67,7 @@ export function getFrequencyAccountAccountDataEncoder(): Encoder<FrequencyAccoun
   );
 }
 
-export function getFrequencyAccountAccountDataDecoder(): Decoder<FrequencyAccountAccountData> {
+export function getFrequencyAccountDecoder(): Decoder<FrequencyAccount> {
   return getStructDecoder([
     ['key', getU64Decoder()],
     ['lastUpdate', getI64Decoder()],
@@ -83,28 +75,30 @@ export function getFrequencyAccountAccountDataDecoder(): Decoder<FrequencyAccoun
   ]);
 }
 
-export function getFrequencyAccountAccountDataCodec(): Codec<
-  FrequencyAccountAccountDataArgs,
-  FrequencyAccountAccountData
+export function getFrequencyAccountCodec(): Codec<
+  FrequencyAccountArgs,
+  FrequencyAccount
 > {
   return combineCodec(
-    getFrequencyAccountAccountDataEncoder(),
-    getFrequencyAccountAccountDataDecoder()
+    getFrequencyAccountEncoder(),
+    getFrequencyAccountDecoder()
   );
 }
 
 export function decodeFrequencyAccount<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): FrequencyAccount<TAddress>;
+): Account<FrequencyAccount, TAddress>;
 export function decodeFrequencyAccount<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeFrequencyAccount<TAddress>;
+): MaybeAccount<FrequencyAccount, TAddress>;
 export function decodeFrequencyAccount<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): FrequencyAccount<TAddress> | MaybeFrequencyAccount<TAddress> {
+):
+  | Account<FrequencyAccount, TAddress>
+  | MaybeAccount<FrequencyAccount, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getFrequencyAccountAccountDataDecoder()
+    getFrequencyAccountDecoder()
   );
 }
 
@@ -112,7 +106,7 @@ export async function fetchFrequencyAccount<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<FrequencyAccount<TAddress>> {
+): Promise<Account<FrequencyAccount, TAddress>> {
   const maybeAccount = await fetchMaybeFrequencyAccount(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -124,7 +118,7 @@ export async function fetchMaybeFrequencyAccount<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeFrequencyAccount<TAddress>> {
+): Promise<MaybeAccount<FrequencyAccount, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeFrequencyAccount(maybeAccount);
 }
@@ -133,7 +127,7 @@ export async function fetchAllFrequencyAccount(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<FrequencyAccount[]> {
+): Promise<Account<FrequencyAccount>[]> {
   const maybeAccounts = await fetchAllMaybeFrequencyAccount(
     rpc,
     addresses,
@@ -147,7 +141,7 @@ export async function fetchAllMaybeFrequencyAccount(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeFrequencyAccount[]> {
+): Promise<MaybeAccount<FrequencyAccount>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeFrequencyAccount(maybeAccount)
@@ -161,7 +155,7 @@ export function getFrequencyAccountSize(): number {
 export async function fetchFrequencyAccountFromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<FrequencyAccount> {
+): Promise<Account<FrequencyAccount>> {
   const maybeAccount = await fetchMaybeFrequencyAccountFromSeeds(rpc, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -170,7 +164,7 @@ export async function fetchFrequencyAccountFromSeeds(
 export async function fetchMaybeFrequencyAccountFromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MaybeFrequencyAccount> {
+): Promise<MaybeAccount<FrequencyAccount>> {
   const { programAddress, ...fetchConfig } = config;
   const [address] = await findFrequencyAccountPda({ programAddress });
   return await fetchMaybeFrequencyAccount(rpc, address, fetchConfig);

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV1.ts
@@ -42,15 +42,7 @@ import {
 import { MasterEditionV1Seeds, findMasterEditionV1Pda } from '../pdas';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
-export type MasterEditionV1<TAddress extends string = string> = Account<
-  MasterEditionV1AccountData,
-  TAddress
->;
-
-export type MaybeMasterEditionV1<TAddress extends string = string> =
-  MaybeAccount<MasterEditionV1AccountData, TAddress>;
-
-export type MasterEditionV1AccountData = {
+export type MasterEditionV1 = {
   key: TmKey;
   supply: bigint;
   maxSupply: Option<bigint>;
@@ -58,14 +50,14 @@ export type MasterEditionV1AccountData = {
   oneTimePrintingAuthorizationMint: Address;
 };
 
-export type MasterEditionV1AccountDataArgs = {
+export type MasterEditionV1Args = {
   supply: number | bigint;
   maxSupply: OptionOrNullable<number | bigint>;
   printingMint: Address;
   oneTimePrintingAuthorizationMint: Address;
 };
 
-export function getMasterEditionV1AccountDataEncoder(): Encoder<MasterEditionV1AccountDataArgs> {
+export function getMasterEditionV1Encoder(): Encoder<MasterEditionV1Args> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -78,7 +70,7 @@ export function getMasterEditionV1AccountDataEncoder(): Encoder<MasterEditionV1A
   );
 }
 
-export function getMasterEditionV1AccountDataDecoder(): Decoder<MasterEditionV1AccountData> {
+export function getMasterEditionV1Decoder(): Decoder<MasterEditionV1> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['supply', getU64Decoder()],
@@ -88,28 +80,27 @@ export function getMasterEditionV1AccountDataDecoder(): Decoder<MasterEditionV1A
   ]);
 }
 
-export function getMasterEditionV1AccountDataCodec(): Codec<
-  MasterEditionV1AccountDataArgs,
-  MasterEditionV1AccountData
+export function getMasterEditionV1Codec(): Codec<
+  MasterEditionV1Args,
+  MasterEditionV1
 > {
-  return combineCodec(
-    getMasterEditionV1AccountDataEncoder(),
-    getMasterEditionV1AccountDataDecoder()
-  );
+  return combineCodec(getMasterEditionV1Encoder(), getMasterEditionV1Decoder());
 }
 
 export function decodeMasterEditionV1<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): MasterEditionV1<TAddress>;
+): Account<MasterEditionV1, TAddress>;
 export function decodeMasterEditionV1<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeMasterEditionV1<TAddress>;
+): MaybeAccount<MasterEditionV1, TAddress>;
 export function decodeMasterEditionV1<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): MasterEditionV1<TAddress> | MaybeMasterEditionV1<TAddress> {
+):
+  | Account<MasterEditionV1, TAddress>
+  | MaybeAccount<MasterEditionV1, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getMasterEditionV1AccountDataDecoder()
+    getMasterEditionV1Decoder()
   );
 }
 
@@ -117,7 +108,7 @@ export async function fetchMasterEditionV1<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MasterEditionV1<TAddress>> {
+): Promise<Account<MasterEditionV1, TAddress>> {
   const maybeAccount = await fetchMaybeMasterEditionV1(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -129,7 +120,7 @@ export async function fetchMaybeMasterEditionV1<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeMasterEditionV1<TAddress>> {
+): Promise<MaybeAccount<MasterEditionV1, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeMasterEditionV1(maybeAccount);
 }
@@ -138,7 +129,7 @@ export async function fetchAllMasterEditionV1(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MasterEditionV1[]> {
+): Promise<Account<MasterEditionV1>[]> {
   const maybeAccounts = await fetchAllMaybeMasterEditionV1(
     rpc,
     addresses,
@@ -152,7 +143,7 @@ export async function fetchAllMaybeMasterEditionV1(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeMasterEditionV1[]> {
+): Promise<MaybeAccount<MasterEditionV1>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeMasterEditionV1(maybeAccount)
@@ -163,7 +154,7 @@ export async function fetchMasterEditionV1FromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: MasterEditionV1Seeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MasterEditionV1> {
+): Promise<Account<MasterEditionV1>> {
   const maybeAccount = await fetchMaybeMasterEditionV1FromSeeds(
     rpc,
     seeds,
@@ -177,7 +168,7 @@ export async function fetchMaybeMasterEditionV1FromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: MasterEditionV1Seeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MaybeMasterEditionV1> {
+): Promise<MaybeAccount<MasterEditionV1>> {
   const { programAddress, ...fetchConfig } = config;
   const [address] = await findMasterEditionV1Pda(seeds, { programAddress });
   return await fetchMaybeMasterEditionV1(rpc, address, fetchConfig);

--- a/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/masterEditionV2.ts
@@ -38,26 +38,18 @@ import {
 import { MasterEditionV2Seeds, findMasterEditionV2Pda } from '../pdas';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
-export type MasterEditionV2<TAddress extends string = string> = Account<
-  MasterEditionV2AccountData,
-  TAddress
->;
-
-export type MaybeMasterEditionV2<TAddress extends string = string> =
-  MaybeAccount<MasterEditionV2AccountData, TAddress>;
-
-export type MasterEditionV2AccountData = {
+export type MasterEditionV2 = {
   key: TmKey;
   supply: bigint;
   maxSupply: Option<bigint>;
 };
 
-export type MasterEditionV2AccountDataArgs = {
+export type MasterEditionV2Args = {
   supply: number | bigint;
   maxSupply: OptionOrNullable<number | bigint>;
 };
 
-export function getMasterEditionV2AccountDataEncoder(): Encoder<MasterEditionV2AccountDataArgs> {
+export function getMasterEditionV2Encoder(): Encoder<MasterEditionV2Args> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -68,7 +60,7 @@ export function getMasterEditionV2AccountDataEncoder(): Encoder<MasterEditionV2A
   );
 }
 
-export function getMasterEditionV2AccountDataDecoder(): Decoder<MasterEditionV2AccountData> {
+export function getMasterEditionV2Decoder(): Decoder<MasterEditionV2> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['supply', getU64Decoder()],
@@ -76,28 +68,27 @@ export function getMasterEditionV2AccountDataDecoder(): Decoder<MasterEditionV2A
   ]);
 }
 
-export function getMasterEditionV2AccountDataCodec(): Codec<
-  MasterEditionV2AccountDataArgs,
-  MasterEditionV2AccountData
+export function getMasterEditionV2Codec(): Codec<
+  MasterEditionV2Args,
+  MasterEditionV2
 > {
-  return combineCodec(
-    getMasterEditionV2AccountDataEncoder(),
-    getMasterEditionV2AccountDataDecoder()
-  );
+  return combineCodec(getMasterEditionV2Encoder(), getMasterEditionV2Decoder());
 }
 
 export function decodeMasterEditionV2<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): MasterEditionV2<TAddress>;
+): Account<MasterEditionV2, TAddress>;
 export function decodeMasterEditionV2<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeMasterEditionV2<TAddress>;
+): MaybeAccount<MasterEditionV2, TAddress>;
 export function decodeMasterEditionV2<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): MasterEditionV2<TAddress> | MaybeMasterEditionV2<TAddress> {
+):
+  | Account<MasterEditionV2, TAddress>
+  | MaybeAccount<MasterEditionV2, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getMasterEditionV2AccountDataDecoder()
+    getMasterEditionV2Decoder()
   );
 }
 
@@ -105,7 +96,7 @@ export async function fetchMasterEditionV2<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MasterEditionV2<TAddress>> {
+): Promise<Account<MasterEditionV2, TAddress>> {
   const maybeAccount = await fetchMaybeMasterEditionV2(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -117,7 +108,7 @@ export async function fetchMaybeMasterEditionV2<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeMasterEditionV2<TAddress>> {
+): Promise<MaybeAccount<MasterEditionV2, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeMasterEditionV2(maybeAccount);
 }
@@ -126,7 +117,7 @@ export async function fetchAllMasterEditionV2(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MasterEditionV2[]> {
+): Promise<Account<MasterEditionV2>[]> {
   const maybeAccounts = await fetchAllMaybeMasterEditionV2(
     rpc,
     addresses,
@@ -140,7 +131,7 @@ export async function fetchAllMaybeMasterEditionV2(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeMasterEditionV2[]> {
+): Promise<MaybeAccount<MasterEditionV2>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeMasterEditionV2(maybeAccount)
@@ -155,7 +146,7 @@ export async function fetchMasterEditionV2FromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: MasterEditionV2Seeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MasterEditionV2> {
+): Promise<Account<MasterEditionV2>> {
   const maybeAccount = await fetchMaybeMasterEditionV2FromSeeds(
     rpc,
     seeds,
@@ -169,7 +160,7 @@ export async function fetchMaybeMasterEditionV2FromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: MasterEditionV2Seeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MaybeMasterEditionV2> {
+): Promise<MaybeAccount<MasterEditionV2>> {
   const { programAddress, ...fetchConfig } = config;
   const [address] = await findMasterEditionV2Pda(seeds, { programAddress });
   return await fetchMaybeMasterEditionV2(rpc, address, fetchConfig);

--- a/test/packages/js-experimental/src/generated/accounts/metadata.ts
+++ b/test/packages/js-experimental/src/generated/accounts/metadata.ts
@@ -86,17 +86,7 @@ import {
   getUsesEncoder,
 } from '../types';
 
-export type Metadata<TAddress extends string = string> = Account<
-  MetadataAccountData,
-  TAddress
->;
-
-export type MaybeMetadata<TAddress extends string = string> = MaybeAccount<
-  MetadataAccountData,
-  TAddress
->;
-
-export type MetadataAccountData = {
+export type Metadata = {
   key: TmKey;
   updateAuthority: Address;
   mint: Address;
@@ -116,7 +106,7 @@ export type MetadataAccountData = {
   delegateState: Option<DelegateState>;
 };
 
-export type MetadataAccountDataArgs = {
+export type MetadataArgs = {
   updateAuthority: Address;
   mint: Address;
   name: string;
@@ -135,7 +125,7 @@ export type MetadataAccountDataArgs = {
   delegateState: OptionOrNullable<DelegateStateArgs>;
 };
 
-export function getMetadataAccountDataEncoder(): Encoder<MetadataAccountDataArgs> {
+export function getMetadataEncoder(): Encoder<MetadataArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -160,7 +150,7 @@ export function getMetadataAccountDataEncoder(): Encoder<MetadataAccountDataArgs
   );
 }
 
-export function getMetadataAccountDataDecoder(): Decoder<MetadataAccountData> {
+export function getMetadataDecoder(): Decoder<Metadata> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['updateAuthority', getAddressDecoder()],
@@ -182,28 +172,22 @@ export function getMetadataAccountDataDecoder(): Decoder<MetadataAccountData> {
   ]);
 }
 
-export function getMetadataAccountDataCodec(): Codec<
-  MetadataAccountDataArgs,
-  MetadataAccountData
-> {
-  return combineCodec(
-    getMetadataAccountDataEncoder(),
-    getMetadataAccountDataDecoder()
-  );
+export function getMetadataCodec(): Codec<MetadataArgs, Metadata> {
+  return combineCodec(getMetadataEncoder(), getMetadataDecoder());
 }
 
 export function decodeMetadata<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): Metadata<TAddress>;
+): Account<Metadata, TAddress>;
 export function decodeMetadata<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeMetadata<TAddress>;
+): MaybeAccount<Metadata, TAddress>;
 export function decodeMetadata<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): Metadata<TAddress> | MaybeMetadata<TAddress> {
+): Account<Metadata, TAddress> | MaybeAccount<Metadata, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getMetadataAccountDataDecoder()
+    getMetadataDecoder()
   );
 }
 
@@ -211,7 +195,7 @@ export async function fetchMetadata<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<Metadata<TAddress>> {
+): Promise<Account<Metadata, TAddress>> {
   const maybeAccount = await fetchMaybeMetadata(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -221,7 +205,7 @@ export async function fetchMaybeMetadata<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeMetadata<TAddress>> {
+): Promise<MaybeAccount<Metadata, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeMetadata(maybeAccount);
 }
@@ -230,7 +214,7 @@ export async function fetchAllMetadata(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<Metadata[]> {
+): Promise<Account<Metadata>[]> {
   const maybeAccounts = await fetchAllMaybeMetadata(rpc, addresses, config);
   assertAccountsExist(maybeAccounts);
   return maybeAccounts;
@@ -240,7 +224,7 @@ export async function fetchAllMaybeMetadata(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeMetadata[]> {
+): Promise<MaybeAccount<Metadata>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) => decodeMetadata(maybeAccount));
 }
@@ -253,7 +237,7 @@ export async function fetchMetadataFromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: MetadataSeeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<Metadata> {
+): Promise<Account<Metadata>> {
   const maybeAccount = await fetchMaybeMetadataFromSeeds(rpc, seeds, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -263,7 +247,7 @@ export async function fetchMaybeMetadataFromSeeds(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   seeds: MetadataSeeds,
   config: FetchAccountConfig & { programAddress?: Address } = {}
-): Promise<MaybeMetadata> {
+): Promise<MaybeAccount<Metadata>> {
   const { programAddress, ...fetchConfig } = config;
   const [address] = await findMetadataPda(seeds, { programAddress });
   return await fetchMaybeMetadata(rpc, address, fetchConfig);

--- a/test/packages/js-experimental/src/generated/accounts/reservationListV1.ts
+++ b/test/packages/js-experimental/src/generated/accounts/reservationListV1.ts
@@ -20,19 +20,22 @@ import {
   fetchEncodedAccounts,
 } from '@solana/accounts';
 import { Address } from '@solana/addresses';
-import { getReservationListV1AccountDataDecoder } from '../../hooked';
+import {
+  ReservationListV1AccountData,
+  getReservationListV1AccountDataDecoder,
+} from '../../hooked';
 
 export function decodeReservationListV1<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): Account<ReservationListV1, TAddress>;
+): Account<ReservationListV1AccountData, TAddress>;
 export function decodeReservationListV1<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeAccount<ReservationListV1, TAddress>;
+): MaybeAccount<ReservationListV1AccountData, TAddress>;
 export function decodeReservationListV1<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
 ):
-  | Account<ReservationListV1, TAddress>
-  | MaybeAccount<ReservationListV1, TAddress> {
+  | Account<ReservationListV1AccountData, TAddress>
+  | MaybeAccount<ReservationListV1AccountData, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
     getReservationListV1AccountDataDecoder()
@@ -43,7 +46,7 @@ export async function fetchReservationListV1<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<Account<ReservationListV1, TAddress>> {
+): Promise<Account<ReservationListV1AccountData, TAddress>> {
   const maybeAccount = await fetchMaybeReservationListV1(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -55,7 +58,7 @@ export async function fetchMaybeReservationListV1<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeAccount<ReservationListV1, TAddress>> {
+): Promise<MaybeAccount<ReservationListV1AccountData, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeReservationListV1(maybeAccount);
 }
@@ -64,7 +67,7 @@ export async function fetchAllReservationListV1(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<Account<ReservationListV1>[]> {
+): Promise<Account<ReservationListV1AccountData>[]> {
   const maybeAccounts = await fetchAllMaybeReservationListV1(
     rpc,
     addresses,
@@ -78,7 +81,7 @@ export async function fetchAllMaybeReservationListV1(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeAccount<ReservationListV1>[]> {
+): Promise<MaybeAccount<ReservationListV1AccountData>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeReservationListV1(maybeAccount)

--- a/test/packages/js-experimental/src/generated/accounts/reservationListV1.ts
+++ b/test/packages/js-experimental/src/generated/accounts/reservationListV1.ts
@@ -20,28 +20,19 @@ import {
   fetchEncodedAccounts,
 } from '@solana/accounts';
 import { Address } from '@solana/addresses';
-import {
-  ReservationListV1AccountData,
-  getReservationListV1AccountDataDecoder,
-} from '../../hooked';
-
-export type ReservationListV1<TAddress extends string = string> = Account<
-  ReservationListV1AccountData,
-  TAddress
->;
-
-export type MaybeReservationListV1<TAddress extends string = string> =
-  MaybeAccount<ReservationListV1AccountData, TAddress>;
+import { getReservationListV1AccountDataDecoder } from '../../hooked';
 
 export function decodeReservationListV1<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): ReservationListV1<TAddress>;
+): Account<ReservationListV1, TAddress>;
 export function decodeReservationListV1<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeReservationListV1<TAddress>;
+): MaybeAccount<ReservationListV1, TAddress>;
 export function decodeReservationListV1<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): ReservationListV1<TAddress> | MaybeReservationListV1<TAddress> {
+):
+  | Account<ReservationListV1, TAddress>
+  | MaybeAccount<ReservationListV1, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
     getReservationListV1AccountDataDecoder()
@@ -52,7 +43,7 @@ export async function fetchReservationListV1<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<ReservationListV1<TAddress>> {
+): Promise<Account<ReservationListV1, TAddress>> {
   const maybeAccount = await fetchMaybeReservationListV1(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -64,7 +55,7 @@ export async function fetchMaybeReservationListV1<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeReservationListV1<TAddress>> {
+): Promise<MaybeAccount<ReservationListV1, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeReservationListV1(maybeAccount);
 }
@@ -73,7 +64,7 @@ export async function fetchAllReservationListV1(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<ReservationListV1[]> {
+): Promise<Account<ReservationListV1>[]> {
   const maybeAccounts = await fetchAllMaybeReservationListV1(
     rpc,
     addresses,
@@ -87,7 +78,7 @@ export async function fetchAllMaybeReservationListV1(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeReservationListV1[]> {
+): Promise<MaybeAccount<ReservationListV1>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeReservationListV1(maybeAccount)

--- a/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
+++ b/test/packages/js-experimental/src/generated/accounts/reservationListV2.ts
@@ -51,15 +51,7 @@ import {
   getTmKeyEncoder,
 } from '../types';
 
-export type ReservationListV2<TAddress extends string = string> = Account<
-  ReservationListV2AccountData,
-  TAddress
->;
-
-export type MaybeReservationListV2<TAddress extends string = string> =
-  MaybeAccount<ReservationListV2AccountData, TAddress>;
-
-export type ReservationListV2AccountData = {
+export type ReservationListV2 = {
   key: TmKey;
   masterEdition: Address;
   supplySnapshot: Option<bigint>;
@@ -68,7 +60,7 @@ export type ReservationListV2AccountData = {
   currentReservationSpots: bigint;
 };
 
-export type ReservationListV2AccountDataArgs = {
+export type ReservationListV2Args = {
   masterEdition: Address;
   supplySnapshot: OptionOrNullable<number | bigint>;
   reservations: Array<ReservationArgs>;
@@ -76,7 +68,7 @@ export type ReservationListV2AccountDataArgs = {
   currentReservationSpots: number | bigint;
 };
 
-export function getReservationListV2AccountDataEncoder(): Encoder<ReservationListV2AccountDataArgs> {
+export function getReservationListV2Encoder(): Encoder<ReservationListV2Args> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -90,7 +82,7 @@ export function getReservationListV2AccountDataEncoder(): Encoder<ReservationLis
   );
 }
 
-export function getReservationListV2AccountDataDecoder(): Decoder<ReservationListV2AccountData> {
+export function getReservationListV2Decoder(): Decoder<ReservationListV2> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['masterEdition', getAddressDecoder()],
@@ -101,28 +93,30 @@ export function getReservationListV2AccountDataDecoder(): Decoder<ReservationLis
   ]);
 }
 
-export function getReservationListV2AccountDataCodec(): Codec<
-  ReservationListV2AccountDataArgs,
-  ReservationListV2AccountData
+export function getReservationListV2Codec(): Codec<
+  ReservationListV2Args,
+  ReservationListV2
 > {
   return combineCodec(
-    getReservationListV2AccountDataEncoder(),
-    getReservationListV2AccountDataDecoder()
+    getReservationListV2Encoder(),
+    getReservationListV2Decoder()
   );
 }
 
 export function decodeReservationListV2<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): ReservationListV2<TAddress>;
+): Account<ReservationListV2, TAddress>;
 export function decodeReservationListV2<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeReservationListV2<TAddress>;
+): MaybeAccount<ReservationListV2, TAddress>;
 export function decodeReservationListV2<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): ReservationListV2<TAddress> | MaybeReservationListV2<TAddress> {
+):
+  | Account<ReservationListV2, TAddress>
+  | MaybeAccount<ReservationListV2, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getReservationListV2AccountDataDecoder()
+    getReservationListV2Decoder()
   );
 }
 
@@ -130,7 +124,7 @@ export async function fetchReservationListV2<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<ReservationListV2<TAddress>> {
+): Promise<Account<ReservationListV2, TAddress>> {
   const maybeAccount = await fetchMaybeReservationListV2(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -142,7 +136,7 @@ export async function fetchMaybeReservationListV2<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeReservationListV2<TAddress>> {
+): Promise<MaybeAccount<ReservationListV2, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeReservationListV2(maybeAccount);
 }
@@ -151,7 +145,7 @@ export async function fetchAllReservationListV2(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<ReservationListV2[]> {
+): Promise<Account<ReservationListV2>[]> {
   const maybeAccounts = await fetchAllMaybeReservationListV2(
     rpc,
     addresses,
@@ -165,7 +159,7 @@ export async function fetchAllMaybeReservationListV2(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeReservationListV2[]> {
+): Promise<MaybeAccount<ReservationListV2>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeReservationListV2(maybeAccount)

--- a/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
+++ b/test/packages/js-experimental/src/generated/accounts/tokenOwnedEscrow.ts
@@ -45,28 +45,20 @@ import {
   getTmKeyEncoder,
 } from '../types';
 
-export type TokenOwnedEscrow<TAddress extends string = string> = Account<
-  TokenOwnedEscrowAccountData,
-  TAddress
->;
-
-export type MaybeTokenOwnedEscrow<TAddress extends string = string> =
-  MaybeAccount<TokenOwnedEscrowAccountData, TAddress>;
-
-export type TokenOwnedEscrowAccountData = {
+export type TokenOwnedEscrow = {
   key: TmKey;
   baseToken: Address;
   authority: EscrowAuthority;
   bump: number;
 };
 
-export type TokenOwnedEscrowAccountDataArgs = {
+export type TokenOwnedEscrowArgs = {
   baseToken: Address;
   authority: EscrowAuthorityArgs;
   bump: number;
 };
 
-export function getTokenOwnedEscrowAccountDataEncoder(): Encoder<TokenOwnedEscrowAccountDataArgs> {
+export function getTokenOwnedEscrowEncoder(): Encoder<TokenOwnedEscrowArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -78,7 +70,7 @@ export function getTokenOwnedEscrowAccountDataEncoder(): Encoder<TokenOwnedEscro
   );
 }
 
-export function getTokenOwnedEscrowAccountDataDecoder(): Decoder<TokenOwnedEscrowAccountData> {
+export function getTokenOwnedEscrowDecoder(): Decoder<TokenOwnedEscrow> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['baseToken', getAddressDecoder()],
@@ -87,28 +79,30 @@ export function getTokenOwnedEscrowAccountDataDecoder(): Decoder<TokenOwnedEscro
   ]);
 }
 
-export function getTokenOwnedEscrowAccountDataCodec(): Codec<
-  TokenOwnedEscrowAccountDataArgs,
-  TokenOwnedEscrowAccountData
+export function getTokenOwnedEscrowCodec(): Codec<
+  TokenOwnedEscrowArgs,
+  TokenOwnedEscrow
 > {
   return combineCodec(
-    getTokenOwnedEscrowAccountDataEncoder(),
-    getTokenOwnedEscrowAccountDataDecoder()
+    getTokenOwnedEscrowEncoder(),
+    getTokenOwnedEscrowDecoder()
   );
 }
 
 export function decodeTokenOwnedEscrow<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): TokenOwnedEscrow<TAddress>;
+): Account<TokenOwnedEscrow, TAddress>;
 export function decodeTokenOwnedEscrow<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeTokenOwnedEscrow<TAddress>;
+): MaybeAccount<TokenOwnedEscrow, TAddress>;
 export function decodeTokenOwnedEscrow<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): TokenOwnedEscrow<TAddress> | MaybeTokenOwnedEscrow<TAddress> {
+):
+  | Account<TokenOwnedEscrow, TAddress>
+  | MaybeAccount<TokenOwnedEscrow, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getTokenOwnedEscrowAccountDataDecoder()
+    getTokenOwnedEscrowDecoder()
   );
 }
 
@@ -116,7 +110,7 @@ export async function fetchTokenOwnedEscrow<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<TokenOwnedEscrow<TAddress>> {
+): Promise<Account<TokenOwnedEscrow, TAddress>> {
   const maybeAccount = await fetchMaybeTokenOwnedEscrow(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -128,7 +122,7 @@ export async function fetchMaybeTokenOwnedEscrow<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeTokenOwnedEscrow<TAddress>> {
+): Promise<MaybeAccount<TokenOwnedEscrow, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeTokenOwnedEscrow(maybeAccount);
 }
@@ -137,7 +131,7 @@ export async function fetchAllTokenOwnedEscrow(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<TokenOwnedEscrow[]> {
+): Promise<Account<TokenOwnedEscrow>[]> {
   const maybeAccounts = await fetchAllMaybeTokenOwnedEscrow(
     rpc,
     addresses,
@@ -151,7 +145,7 @@ export async function fetchAllMaybeTokenOwnedEscrow(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeTokenOwnedEscrow[]> {
+): Promise<MaybeAccount<TokenOwnedEscrow>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeTokenOwnedEscrow(maybeAccount)

--- a/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
+++ b/test/packages/js-experimental/src/generated/accounts/useAuthorityRecord.ts
@@ -35,26 +35,18 @@ import {
 } from '@solana/codecs';
 import { TmKey, getTmKeyDecoder, getTmKeyEncoder } from '../types';
 
-export type UseAuthorityRecord<TAddress extends string = string> = Account<
-  UseAuthorityRecordAccountData,
-  TAddress
->;
-
-export type MaybeUseAuthorityRecord<TAddress extends string = string> =
-  MaybeAccount<UseAuthorityRecordAccountData, TAddress>;
-
-export type UseAuthorityRecordAccountData = {
+export type UseAuthorityRecord = {
   key: TmKey;
   allowedUses: bigint;
   bump: number;
 };
 
-export type UseAuthorityRecordAccountDataArgs = {
+export type UseAuthorityRecordArgs = {
   allowedUses: number | bigint;
   bump: number;
 };
 
-export function getUseAuthorityRecordAccountDataEncoder(): Encoder<UseAuthorityRecordAccountDataArgs> {
+export function getUseAuthorityRecordEncoder(): Encoder<UseAuthorityRecordArgs> {
   return transformEncoder(
     getStructEncoder([
       ['key', getTmKeyEncoder()],
@@ -65,7 +57,7 @@ export function getUseAuthorityRecordAccountDataEncoder(): Encoder<UseAuthorityR
   );
 }
 
-export function getUseAuthorityRecordAccountDataDecoder(): Decoder<UseAuthorityRecordAccountData> {
+export function getUseAuthorityRecordDecoder(): Decoder<UseAuthorityRecord> {
   return getStructDecoder([
     ['key', getTmKeyDecoder()],
     ['allowedUses', getU64Decoder()],
@@ -73,28 +65,30 @@ export function getUseAuthorityRecordAccountDataDecoder(): Decoder<UseAuthorityR
   ]);
 }
 
-export function getUseAuthorityRecordAccountDataCodec(): Codec<
-  UseAuthorityRecordAccountDataArgs,
-  UseAuthorityRecordAccountData
+export function getUseAuthorityRecordCodec(): Codec<
+  UseAuthorityRecordArgs,
+  UseAuthorityRecord
 > {
   return combineCodec(
-    getUseAuthorityRecordAccountDataEncoder(),
-    getUseAuthorityRecordAccountDataDecoder()
+    getUseAuthorityRecordEncoder(),
+    getUseAuthorityRecordDecoder()
   );
 }
 
 export function decodeUseAuthorityRecord<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress>
-): UseAuthorityRecord<TAddress>;
+): Account<UseAuthorityRecord, TAddress>;
 export function decodeUseAuthorityRecord<TAddress extends string = string>(
   encodedAccount: MaybeEncodedAccount<TAddress>
-): MaybeUseAuthorityRecord<TAddress>;
+): MaybeAccount<UseAuthorityRecord, TAddress>;
 export function decodeUseAuthorityRecord<TAddress extends string = string>(
   encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>
-): UseAuthorityRecord<TAddress> | MaybeUseAuthorityRecord<TAddress> {
+):
+  | Account<UseAuthorityRecord, TAddress>
+  | MaybeAccount<UseAuthorityRecord, TAddress> {
   return decodeAccount(
     encodedAccount as MaybeEncodedAccount<TAddress>,
-    getUseAuthorityRecordAccountDataDecoder()
+    getUseAuthorityRecordDecoder()
   );
 }
 
@@ -102,7 +96,7 @@ export async function fetchUseAuthorityRecord<TAddress extends string = string>(
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<UseAuthorityRecord<TAddress>> {
+): Promise<Account<UseAuthorityRecord, TAddress>> {
   const maybeAccount = await fetchMaybeUseAuthorityRecord(rpc, address, config);
   assertAccountExists(maybeAccount);
   return maybeAccount;
@@ -114,7 +108,7 @@ export async function fetchMaybeUseAuthorityRecord<
   rpc: Parameters<typeof fetchEncodedAccount>[0],
   address: Address<TAddress>,
   config?: FetchAccountConfig
-): Promise<MaybeUseAuthorityRecord<TAddress>> {
+): Promise<MaybeAccount<UseAuthorityRecord, TAddress>> {
   const maybeAccount = await fetchEncodedAccount(rpc, address, config);
   return decodeUseAuthorityRecord(maybeAccount);
 }
@@ -123,7 +117,7 @@ export async function fetchAllUseAuthorityRecord(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<UseAuthorityRecord[]> {
+): Promise<Account<UseAuthorityRecord>[]> {
   const maybeAccounts = await fetchAllMaybeUseAuthorityRecord(
     rpc,
     addresses,
@@ -137,7 +131,7 @@ export async function fetchAllMaybeUseAuthorityRecord(
   rpc: Parameters<typeof fetchEncodedAccounts>[0],
   addresses: Array<Address>,
   config?: FetchAccountsConfig
-): Promise<MaybeUseAuthorityRecord[]> {
+): Promise<MaybeAccount<UseAuthorityRecord>[]> {
   const maybeAccounts = await fetchEncodedAccounts(rpc, addresses, config);
   return maybeAccounts.map((maybeAccount) =>
     decodeUseAuthorityRecord(maybeAccount)


### PR DESCRIPTION
Assuming an `AccountNode` named `Token`, this PR makes the following changes to the generated client for the new web3.js:

```ts
// Before.
export type TokenAccountData = { ... }; // Data.
export type Token = Account<TokenAccountData>;
export type MaybeToken = MaybeAccount<TokenAccountData>;

// After.
export type Token = { ... }; // Data.
// Just use `Account<Token>` and `MaybeAccount<Token>` directly when needed.
```