### PR TITLE
tighten rent account regex

### DIFF
--- a/src/visitors/setInstructionAccountDefaultValuesVisitor.ts
+++ b/src/visitors/setInstructionAccountDefaultValuesVisitor.ts
@@ -131,10 +131,9 @@ export const DEFAULT_INSTRUCTION_ACCOUNT_DEFAULT_RULES: InstructionAccountDefaul
       ignoreIfOptional: true,
     },
     {
-      account: /^rent|rentSysvar|sysvarRent$/,
+      account: /^rent$|rentSysvar|sysvarRent$/,
       defaultValue: publicKeyValueNode(
-        'SysvarRent111111111111111111111111111111111'
-      ),
+        'SysvarRent111111111111111111111111111111111'),
       ignoreIfOptional: true,
     },
     {


### PR DESCRIPTION
The current regex for detecting rent accounts for auto resolving is a bit loose. It would be nice to be able to create accounts with rent in the name without auto resolving as the system program. Example: `rentPayer`. This PR tightens it up a bit.

<img width="1185" alt="Screenshot 2024-04-15 at 6 06 52 PM" src="https://github.com/metaplex-foundation/kinobi/assets/1684605/21555160-35d5-4d9a-8e8a-4f6592cde26b">
