### PR TITLE
Change instruction data struct visibility

### DIFF
--- a/.changeset/giant-chefs-shave.md
+++ b/.changeset/giant-chefs-shave.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Change instruction data struct visibility on Rust client

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -117,7 +117,7 @@ pub struct {{ instruction.name | pascalCase }}InstructionData {
 }
 
 impl {{ instruction.name | pascalCase }}InstructionData {
-  fn new() -> Self {
+  pub fn new() -> Self {
     Self {
       {% for arg in instructionArgs %}
         {% if arg.default %}

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -108,7 +108,7 @@ impl {{ instruction.name | pascalCase }} {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct {{ instruction.name | pascalCase }}InstructionData {
+pub struct {{ instruction.name | pascalCase }}InstructionData {
   {% for arg in instructionArgs %}
     {% if arg.default %}
       {{ arg.name | snakeCase }}: {{ arg.type }},

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -58,7 +58,7 @@ pub struct AddConfigLinesInstructionData {
 }
 
 impl AddConfigLinesInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [223, 50, 224, 227, 151, 8, 115, 106],
         }

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -53,7 +53,7 @@ impl AddConfigLines {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct AddConfigLinesInstructionData {
+pub struct AddConfigLinesInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/add_memo.rs
+++ b/test/packages/rust/src/generated/instructions/add_memo.rs
@@ -42,7 +42,7 @@ impl AddMemo {
 pub struct AddMemoInstructionData {}
 
 impl AddMemoInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {}
     }
 }

--- a/test/packages/rust/src/generated/instructions/add_memo.rs
+++ b/test/packages/rust/src/generated/instructions/add_memo.rs
@@ -39,7 +39,7 @@ impl AddMemo {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct AddMemoInstructionData {}
+pub struct AddMemoInstructionData {}
 
 impl AddMemoInstructionData {
     fn new() -> Self {

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -93,7 +93,7 @@ pub struct ApproveCollectionAuthorityInstructionData {
 }
 
 impl ApproveCollectionAuthorityInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 23 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -88,7 +88,7 @@ impl ApproveCollectionAuthority {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct ApproveCollectionAuthorityInstructionData {
+pub struct ApproveCollectionAuthorityInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -110,7 +110,7 @@ impl ApproveUseAuthority {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct ApproveUseAuthorityInstructionData {
+pub struct ApproveUseAuthorityInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -115,7 +115,7 @@ pub struct ApproveUseAuthorityInstructionData {
 }
 
 impl ApproveUseAuthorityInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 20 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -80,7 +80,7 @@ impl BubblegumSetCollectionSize {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct BubblegumSetCollectionSizeInstructionData {
+pub struct BubblegumSetCollectionSizeInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -85,7 +85,7 @@ pub struct BubblegumSetCollectionSizeInstructionData {
 }
 
 impl BubblegumSetCollectionSizeInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 36 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -114,7 +114,7 @@ impl Burn {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct BurnInstructionData {
+pub struct BurnInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -119,7 +119,7 @@ pub struct BurnInstructionData {
 }
 
 impl BurnInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 44 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -93,7 +93,7 @@ impl BurnEditionNft {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct BurnEditionNftInstructionData {
+pub struct BurnEditionNftInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -98,7 +98,7 @@ pub struct BurnEditionNftInstructionData {
 }
 
 impl BurnEditionNftInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 37 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -81,7 +81,7 @@ impl BurnNft {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct BurnNftInstructionData {
+pub struct BurnNftInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -86,7 +86,7 @@ pub struct BurnNftInstructionData {
 }
 
 impl BurnNftInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 29 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -87,7 +87,7 @@ pub struct CloseEscrowAccountInstructionData {
 }
 
 impl CloseEscrowAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 39 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -82,7 +82,7 @@ impl CloseEscrowAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CloseEscrowAccountInstructionData {
+pub struct CloseEscrowAccountInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -54,7 +54,7 @@ impl ConvertMasterEditionV1ToV2 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct ConvertMasterEditionV1ToV2InstructionData {
+pub struct ConvertMasterEditionV1ToV2InstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -59,7 +59,7 @@ pub struct ConvertMasterEditionV1ToV2InstructionData {
 }
 
 impl ConvertMasterEditionV1ToV2InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 12 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_account.rs
@@ -56,7 +56,7 @@ pub struct CreateAccountInstructionData {
 }
 
 impl CreateAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 0 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_account.rs
@@ -51,7 +51,7 @@ impl CreateAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateAccountInstructionData {
+pub struct CreateAccountInstructionData {
     discriminator: u32,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -94,7 +94,7 @@ impl CreateEscrowAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateEscrowAccountInstructionData {
+pub struct CreateEscrowAccountInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -99,7 +99,7 @@ pub struct CreateEscrowAccountInstructionData {
 }
 
 impl CreateEscrowAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 38 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -64,7 +64,7 @@ pub struct CreateFrequencyRuleInstructionData {
 }
 
 impl CreateFrequencyRuleInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 2 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -59,7 +59,7 @@ impl CreateFrequencyRule {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateFrequencyRuleInstructionData {
+pub struct CreateFrequencyRuleInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -99,7 +99,7 @@ pub struct CreateMasterEditionInstructionData {
 }
 
 impl CreateMasterEditionInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 10 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -94,7 +94,7 @@ impl CreateMasterEdition {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateMasterEditionInstructionData {
+pub struct CreateMasterEditionInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -106,7 +106,7 @@ pub struct CreateMasterEditionV3InstructionData {
 }
 
 impl CreateMasterEditionV3InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 17 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -101,7 +101,7 @@ impl CreateMasterEditionV3 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateMasterEditionV3InstructionData {
+pub struct CreateMasterEditionV3InstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -87,7 +87,7 @@ pub struct CreateMetadataAccountInstructionData {
 }
 
 impl CreateMetadataAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 0 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -82,7 +82,7 @@ impl CreateMetadataAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateMetadataAccountInstructionData {
+pub struct CreateMetadataAccountInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -94,7 +94,7 @@ pub struct CreateMetadataAccountV2InstructionData {
 }
 
 impl CreateMetadataAccountV2InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 16 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -89,7 +89,7 @@ impl CreateMetadataAccountV2 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateMetadataAccountV2InstructionData {
+pub struct CreateMetadataAccountV2InstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -95,7 +95,7 @@ pub struct CreateMetadataAccountV3InstructionData {
 }
 
 impl CreateMetadataAccountV3InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 33 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -90,7 +90,7 @@ impl CreateMetadataAccountV3 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateMetadataAccountV3InstructionData {
+pub struct CreateMetadataAccountV3InstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -82,7 +82,7 @@ impl CreateReservationList {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateReservationListInstructionData {
+pub struct CreateReservationListInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -87,7 +87,7 @@ pub struct CreateReservationListInstructionData {
 }
 
 impl CreateReservationListInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 6 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -63,7 +63,7 @@ pub struct CreateRuleSetInstructionData {
 }
 
 impl CreateRuleSetInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 0 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -58,7 +58,7 @@ impl CreateRuleSet {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateRuleSetInstructionData {
+pub struct CreateRuleSetInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -107,7 +107,7 @@ pub struct CreateV1InstructionData {
 }
 
 impl CreateV1InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: 41,
             create_v1_discriminator: 0,

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -101,7 +101,7 @@ impl CreateV1 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateV1InstructionData {
+pub struct CreateV1InstructionData {
     discriminator: u8,
     create_v1_discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -101,7 +101,7 @@ impl CreateV2 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct CreateV2InstructionData {
+pub struct CreateV2InstructionData {
     discriminator: u8,
     create_v2_discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -107,7 +107,7 @@ pub struct CreateV2InstructionData {
 }
 
 impl CreateV2InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: 41,
             create_v2_discriminator: 1,

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -154,7 +154,7 @@ pub struct DelegateInstructionData {
 }
 
 impl DelegateInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 48 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -149,7 +149,7 @@ impl Delegate {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DelegateInstructionData {
+pub struct DelegateInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -118,7 +118,7 @@ impl DeprecatedCreateMasterEdition {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DeprecatedCreateMasterEditionInstructionData {
+pub struct DeprecatedCreateMasterEditionInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -123,7 +123,7 @@ pub struct DeprecatedCreateMasterEditionInstructionData {
 }
 
 impl DeprecatedCreateMasterEditionInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 2 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -136,7 +136,7 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
+pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -141,7 +141,7 @@ pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionD
 }
 
 impl DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 3 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -84,7 +84,7 @@ impl DeprecatedMintPrintingTokens {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DeprecatedMintPrintingTokensInstructionData {
+pub struct DeprecatedMintPrintingTokensInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -89,7 +89,7 @@ pub struct DeprecatedMintPrintingTokensInstructionData {
 }
 
 impl DeprecatedMintPrintingTokensInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 9 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -100,7 +100,7 @@ pub struct DeprecatedMintPrintingTokensViaTokenInstructionData {
 }
 
 impl DeprecatedMintPrintingTokensViaTokenInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 8 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -95,7 +95,7 @@ impl DeprecatedMintPrintingTokensViaToken {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DeprecatedMintPrintingTokensViaTokenInstructionData {
+pub struct DeprecatedMintPrintingTokensViaTokenInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -61,7 +61,7 @@ impl DeprecatedSetReservationList {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DeprecatedSetReservationListInstructionData {
+pub struct DeprecatedSetReservationListInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -66,7 +66,7 @@ pub struct DeprecatedSetReservationListInstructionData {
 }
 
 impl DeprecatedSetReservationListInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 5 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -119,7 +119,7 @@ pub struct DummyInstructionData {
 }
 
 impl DummyInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [167, 117, 211, 79, 251, 254, 47, 135],
         }

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -114,7 +114,7 @@ impl Dummy {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct DummyInstructionData {
+pub struct DummyInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -70,7 +70,7 @@ pub struct FreezeDelegatedAccountInstructionData {
 }
 
 impl FreezeDelegatedAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 26 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -65,7 +65,7 @@ impl FreezeDelegatedAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct FreezeDelegatedAccountInstructionData {
+pub struct FreezeDelegatedAccountInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -105,7 +105,7 @@ impl Initialize {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct InitializeInstructionData {
+pub struct InitializeInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -110,7 +110,7 @@ pub struct InitializeInstructionData {
 }
 
 impl InitializeInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [175, 175, 109, 31, 13, 152, 155, 237],
         }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -112,7 +112,7 @@ pub struct MigrateInstructionData {
 }
 
 impl MigrateInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 50 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -107,7 +107,7 @@ impl Migrate {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct MigrateInstructionData {
+pub struct MigrateInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -131,7 +131,7 @@ impl Mint {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct MintInstructionData {
+pub struct MintInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -136,7 +136,7 @@ pub struct MintInstructionData {
 }
 
 impl MintInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 42 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -136,7 +136,7 @@ impl MintFromCandyMachine {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct MintFromCandyMachineInstructionData {
+pub struct MintFromCandyMachineInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -141,7 +141,7 @@ pub struct MintFromCandyMachineInstructionData {
 }
 
 impl MintFromCandyMachineInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [51, 57, 225, 47, 182, 146, 137, 166],
         }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -137,7 +137,7 @@ pub struct MintNewEditionFromMasterEditionViaTokenInstructionData {
 }
 
 impl MintNewEditionFromMasterEditionViaTokenInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 11 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -132,7 +132,7 @@ impl MintNewEditionFromMasterEditionViaToken {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct MintNewEditionFromMasterEditionViaTokenInstructionData {
+pub struct MintNewEditionFromMasterEditionViaTokenInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -154,7 +154,7 @@ pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
 }
 
 impl MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 13 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -149,7 +149,7 @@ impl MintNewEditionFromMasterEditionViaVaultProxy {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
+pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -45,7 +45,7 @@ pub struct PuffMetadataInstructionData {
 }
 
 impl PuffMetadataInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 14 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -40,7 +40,7 @@ impl PuffMetadata {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct PuffMetadataInstructionData {
+pub struct PuffMetadataInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -53,7 +53,7 @@ pub struct RemoveCreatorVerificationInstructionData {
 }
 
 impl RemoveCreatorVerificationInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 28 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -48,7 +48,7 @@ impl RemoveCreatorVerification {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct RemoveCreatorVerificationInstructionData {
+pub struct RemoveCreatorVerificationInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -149,7 +149,7 @@ impl Revoke {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct RevokeInstructionData {
+pub struct RevokeInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -154,7 +154,7 @@ pub struct RevokeInstructionData {
 }
 
 impl RevokeInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 49 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -65,7 +65,7 @@ impl RevokeCollectionAuthority {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct RevokeCollectionAuthorityInstructionData {
+pub struct RevokeCollectionAuthorityInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -70,7 +70,7 @@ pub struct RevokeCollectionAuthorityInstructionData {
 }
 
 impl RevokeCollectionAuthorityInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 24 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -98,7 +98,7 @@ pub struct RevokeUseAuthorityInstructionData {
 }
 
 impl RevokeUseAuthorityInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 21 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -93,7 +93,7 @@ impl RevokeUseAuthority {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct RevokeUseAuthorityInstructionData {
+pub struct RevokeUseAuthorityInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -95,7 +95,7 @@ pub struct SetAndVerifyCollectionInstructionData {
 }
 
 impl SetAndVerifyCollectionInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 25 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -90,7 +90,7 @@ impl SetAndVerifyCollection {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetAndVerifyCollectionInstructionData {
+pub struct SetAndVerifyCollectionInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -95,7 +95,7 @@ pub struct SetAndVerifySizedCollectionItemInstructionData {
 }
 
 impl SetAndVerifySizedCollectionItemInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 32 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -90,7 +90,7 @@ impl SetAndVerifySizedCollectionItem {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetAndVerifySizedCollectionItemInstructionData {
+pub struct SetAndVerifySizedCollectionItemInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -52,7 +52,7 @@ impl SetAuthority {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetAuthorityInstructionData {
+pub struct SetAuthorityInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -57,7 +57,7 @@ pub struct SetAuthorityInstructionData {
 }
 
 impl SetAuthorityInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [133, 250, 37, 21, 110, 163, 26, 121],
         }

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -121,7 +121,7 @@ pub struct SetCollectionInstructionData {
 }
 
 impl SetCollectionInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [192, 254, 206, 76, 168, 182, 59, 223],
         }

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -116,7 +116,7 @@ impl SetCollection {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetCollectionInstructionData {
+pub struct SetCollectionInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -79,7 +79,7 @@ pub struct SetCollectionSizeInstructionData {
 }
 
 impl SetCollectionSizeInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 34 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -74,7 +74,7 @@ impl SetCollectionSize {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetCollectionSizeInstructionData {
+pub struct SetCollectionSizeInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -56,7 +56,7 @@ pub struct SetMintAuthorityInstructionData {
 }
 
 impl SetMintAuthorityInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [67, 127, 155, 187, 100, 174, 103, 121],
         }

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -51,7 +51,7 @@ impl SetMintAuthority {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetMintAuthorityInstructionData {
+pub struct SetMintAuthorityInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -63,7 +63,7 @@ impl SetTokenStandard {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SetTokenStandardInstructionData {
+pub struct SetTokenStandardInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -68,7 +68,7 @@ pub struct SetTokenStandardInstructionData {
 }
 
 impl SetTokenStandardInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 35 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -46,7 +46,7 @@ impl SignMetadata {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct SignMetadataInstructionData {
+pub struct SignMetadataInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -51,7 +51,7 @@ pub struct SignMetadataInstructionData {
 }
 
 impl SignMetadataInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 7 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -70,7 +70,7 @@ pub struct ThawDelegatedAccountInstructionData {
 }
 
 impl ThawDelegatedAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 27 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -65,7 +65,7 @@ impl ThawDelegatedAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct ThawDelegatedAccountInstructionData {
+pub struct ThawDelegatedAccountInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -157,7 +157,7 @@ impl Transfer {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct TransferInstructionData {
+pub struct TransferInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -162,7 +162,7 @@ pub struct TransferInstructionData {
 }
 
 impl TransferInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 46 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -125,7 +125,7 @@ impl TransferOutOfEscrow {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct TransferOutOfEscrowInstructionData {
+pub struct TransferOutOfEscrowInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -130,7 +130,7 @@ pub struct TransferOutOfEscrowInstructionData {
 }
 
 impl TransferOutOfEscrowInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 40 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/transfer_sol.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_sol.rs
@@ -56,7 +56,7 @@ pub struct TransferSolInstructionData {
 }
 
 impl TransferSolInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 2 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/transfer_sol.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_sol.rs
@@ -51,7 +51,7 @@ impl TransferSol {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct TransferSolInstructionData {
+pub struct TransferSolInstructionData {
     discriminator: u32,
 }
 

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -79,7 +79,7 @@ impl UnverifyCollection {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UnverifyCollectionInstructionData {
+pub struct UnverifyCollectionInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -84,7 +84,7 @@ pub struct UnverifyCollectionInstructionData {
 }
 
 impl UnverifyCollectionInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 22 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -84,7 +84,7 @@ impl UnverifySizedCollectionItem {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UnverifySizedCollectionItemInstructionData {
+pub struct UnverifySizedCollectionItemInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -89,7 +89,7 @@ pub struct UnverifySizedCollectionItemInstructionData {
 }
 
 impl UnverifySizedCollectionItemInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 31 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -54,7 +54,7 @@ impl UpdateCandyMachine {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UpdateCandyMachineInstructionData {
+pub struct UpdateCandyMachineInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -59,7 +59,7 @@ pub struct UpdateCandyMachineInstructionData {
 }
 
 impl UpdateCandyMachineInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [219, 200, 88, 176, 158, 63, 253, 127],
         }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -61,7 +61,7 @@ pub struct UpdateMetadataAccountInstructionData {
 }
 
 impl UpdateMetadataAccountInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 1 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -56,7 +56,7 @@ impl UpdateMetadataAccount {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UpdateMetadataAccountInstructionData {
+pub struct UpdateMetadataAccountInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -61,7 +61,7 @@ pub struct UpdateMetadataAccountV2InstructionData {
 }
 
 impl UpdateMetadataAccountV2InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 15 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -56,7 +56,7 @@ impl UpdateMetadataAccountV2 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UpdateMetadataAccountV2InstructionData {
+pub struct UpdateMetadataAccountV2InstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -52,7 +52,7 @@ impl UpdatePrimarySaleHappenedViaToken {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UpdatePrimarySaleHappenedViaTokenInstructionData {
+pub struct UpdatePrimarySaleHappenedViaTokenInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -57,7 +57,7 @@ pub struct UpdatePrimarySaleHappenedViaTokenInstructionData {
 }
 
 impl UpdatePrimarySaleHappenedViaTokenInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 4 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -143,7 +143,7 @@ impl UpdateV1 {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UpdateV1InstructionData {
+pub struct UpdateV1InstructionData {
     discriminator: u8,
     update_v1_discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -149,7 +149,7 @@ pub struct UpdateV1InstructionData {
 }
 
 impl UpdateV1InstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: 43,
             update_v1_discriminator: 0,

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -131,7 +131,7 @@ pub struct UseAssetInstructionData {
 }
 
 impl UseAssetInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 45 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -126,7 +126,7 @@ impl UseAsset {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UseAssetInstructionData {
+pub struct UseAssetInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -116,7 +116,7 @@ impl Utilize {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct UtilizeInstructionData {
+pub struct UtilizeInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -121,7 +121,7 @@ pub struct UtilizeInstructionData {
 }
 
 impl UtilizeInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 19 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -144,7 +144,7 @@ pub struct ValidateInstructionData {
 }
 
 impl ValidateInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 1 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -139,7 +139,7 @@ impl Validate {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct ValidateInstructionData {
+pub struct ValidateInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -84,7 +84,7 @@ impl Verify {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct VerifyInstructionData {
+pub struct VerifyInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -89,7 +89,7 @@ pub struct VerifyInstructionData {
 }
 
 impl VerifyInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 47 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -74,7 +74,7 @@ pub struct VerifyCollectionInstructionData {
 }
 
 impl VerifyCollectionInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 18 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -69,7 +69,7 @@ impl VerifyCollection {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct VerifyCollectionInstructionData {
+pub struct VerifyCollectionInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -84,7 +84,7 @@ impl VerifySizedCollectionItem {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct VerifySizedCollectionItemInstructionData {
+pub struct VerifySizedCollectionItemInstructionData {
     discriminator: u8,
 }
 

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -89,7 +89,7 @@ pub struct VerifySizedCollectionItemInstructionData {
 }
 
 impl VerifySizedCollectionItemInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { discriminator: 30 }
     }
 }

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -50,7 +50,7 @@ pub struct WithdrawInstructionData {
 }
 
 impl WithdrawInstructionData {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             discriminator: [183, 18, 70, 156, 148, 109, 161, 34],
         }

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -45,7 +45,7 @@ impl Withdraw {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-struct WithdrawInstructionData {
+pub struct WithdrawInstructionData {
     discriminator: [u8; 8],
 }
 

--- a/test/renderers/rust/instructionsPage.test.ts
+++ b/test/renderers/rust/instructionsPage.test.ts
@@ -1,0 +1,21 @@
+import test from 'ava';
+import { instructionNode, programNode, visit } from '../../../src';
+import { getRenderMapVisitor } from '../../../src/renderers/rust/getRenderMapVisitor';
+import { codeContains } from './_setup';
+
+test('it renders a public instruction data struct', (t) => {
+  // Given the following program with 1 instruction.
+  const node = programNode({
+    name: 'splToken',
+    publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    instructions: [instructionNode({ name: 'mintTokens' })],
+  });
+
+  // When we render it.
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Then we expect the following pub struct.
+  codeContains(t, renderMap.get('instructions/mint_tokens.rs'), [
+    `pub struct MintTokensInstructionData`,
+  ]);
+});

--- a/test/renderers/rust/instructionsPage.test.ts
+++ b/test/renderers/rust/instructionsPage.test.ts
@@ -17,5 +17,6 @@ test('it renders a public instruction data struct', (t) => {
   // Then we expect the following pub struct.
   codeContains(t, renderMap.get('instructions/mint_tokens.rs'), [
     `pub struct MintTokensInstructionData`,
+    `pub fn new(`,
   ]);
 });


### PR DESCRIPTION
This PR changes the visibility of the generated instruction data struct to public on the generated Rust clients so client code can make use of it – this struct represents the instruction discriminator.