### PR TITLE
Add lifetime specifier to str types

### DIFF
--- a/.changeset/fifty-colts-crash.md
+++ b/.changeset/fifty-colts-crash.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Add lifetime specifier to str types in Rust client

--- a/src/renderers/rust/getRenderMapVisitor.ts
+++ b/src/renderers/rust/getRenderMapVisitor.ts
@@ -282,6 +282,7 @@ export function getRenderMapVisitor(options: GetRustRenderMapOptions = {}) {
               hasOptional,
               program,
               typeManifest,
+              lifetimes: typeManifest.lifetimes.map((l) => `'${l}`).join(', '),
             })
           );
         },

--- a/src/renderers/rust/templates/instructionsCpiPage.njk
+++ b/src/renderers/rust/templates/instructionsCpiPage.njk
@@ -22,7 +22,7 @@
 {% endif %}
 
 /// `{{ instruction.name | snakeCase }}` CPI instruction.
-pub struct {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
+pub struct {{ instruction.name | pascalCase }}Cpi{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {
   /// The program to invoke.
   pub __program: &'b solana_program::account_info::AccountInfo<'a>,
   {% for account in instruction.accounts %}
@@ -44,18 +44,18 @@ pub struct {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
   {% endfor %}
   {% if hasArgs %}
     /// The arguments for the instruction.
-    pub __args: {{ instruction.name | pascalCase }}InstructionArgs,
+    pub __args: {{ instruction.name | pascalCase }}InstructionArgs{{ '<' + lifetimes + '>' if lifetimes.length > 0 }},
   {% endif %}
 }
 
-impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
+impl{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {{ instruction.name | pascalCase }}Cpi{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {
   pub fn new(
     program: &'b solana_program::account_info::AccountInfo<'a>,
     {% if instruction.accounts.length > 0 %}
       accounts: {{ instruction.name | pascalCase }}CpiAccounts<'a, 'b>,
     {% endif %}
     {% if hasArgs %}
-      args: {{ instruction.name | pascalCase }}InstructionArgs,
+      args: {{ instruction.name | pascalCase }}InstructionArgs{{ '<' + lifetimes + '>' if lifetimes.length > 0 }},
     {% endif %}
   ) -> Self {
     Self {

--- a/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsCpiPageBuilder.njk
@@ -15,11 +15,11 @@
   {% endif %}
   {{ '///   ' + loop.index0 + '. `[' + modifiers + ']` ' + account.name | snakeCase }}
 {% endfor %}
-pub struct {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
-  instruction: Box<{{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b>>,
+pub struct {{ instruction.name | pascalCase }}CpiBuilder{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {
+  instruction: Box<{{ instruction.name | pascalCase }}CpiBuilderInstruction{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }}>,
 }
 
-impl<'a, 'b> {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
+impl{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {{ instruction.name | pascalCase }}CpiBuilder{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {
   pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
     let instruction = Box::new({{ instruction.name | pascalCase }}CpiBuilderInstruction {
       __program: program,
@@ -124,7 +124,7 @@ impl<'a, 'b> {{ instruction.name | pascalCase }}CpiBuilder<'a, 'b> {
   }
 }
 
-struct {{ instruction.name | pascalCase }}CpiBuilderInstruction<'a, 'b> {
+struct {{ instruction.name | pascalCase }}CpiBuilderInstruction{{ '<\'a, \'b, ' + lifetimes + '>' if lifetimes.length > 0 else '<\'a, \'b>' }} {
   __program: &'b solana_program::account_info::AccountInfo<'a>,
   {% for account in instruction.accounts %}
     {% if account.isSigner === 'either' %}

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -131,7 +131,7 @@ impl {{ instruction.name | pascalCase }}InstructionData {
 {% if hasArgs %}
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct {{ instruction.name | pascalCase }}InstructionArgs {
+pub struct {{ instruction.name | pascalCase }}InstructionArgs{{ '<' + lifetimes + '>' if lifetimes.length > 0  }} {
   {% for arg in instructionArgs %}
     {% if not arg.default %}
       pub {{ arg.name | snakeCase }}: {{ arg.type }},

--- a/src/renderers/rust/templates/instructionsPageBuilder.njk
+++ b/src/renderers/rust/templates/instructionsPageBuilder.njk
@@ -17,7 +17,7 @@
   {{- " (default to `" + account.defaultValue.publicKey + "`)" if account.defaultValue.kind === 'publicKeyValueNode' }}
 {% endfor %}
 #[derive(Default)]
-pub struct {{ instruction.name | pascalCase }}Builder {
+pub struct {{ instruction.name | pascalCase }}Builder{{ '<' + lifetimes + '>' if lifetimes.length > 0  }} {
   {% for account in instruction.accounts %}
     {% if account.isSigner === 'either' %}
       {{ account.name | snakeCase }}: Option<(solana_program::pubkey::Pubkey, bool)>,
@@ -33,7 +33,7 @@ pub struct {{ instruction.name | pascalCase }}Builder {
   __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
-impl {{ instruction.name | pascalCase }}Builder {
+impl{{ '<' + lifetimes + '>' if lifetimes.length > 0  }} {{ instruction.name | pascalCase }}Builder {
   pub fn new() -> Self {
     Self::default()
   }

--- a/test/renderers/rust/instructionsPage.test.ts
+++ b/test/renderers/rust/instructionsPage.test.ts
@@ -1,5 +1,12 @@
 import test from 'ava';
-import { instructionNode, programNode, visit } from '../../../src';
+import {
+  instructionArgumentNode,
+  instructionNode,
+  programNode,
+  remainderSizeNode,
+  stringTypeNode,
+  visit,
+} from '../../../src';
 import { getRenderMapVisitor } from '../../../src/renderers/rust/getRenderMapVisitor';
 import { codeContains } from './_setup';
 
@@ -18,5 +25,33 @@ test('it renders a public instruction data struct', (t) => {
   codeContains(t, renderMap.get('instructions/mint_tokens.rs'), [
     `pub struct MintTokensInstructionData`,
     `pub fn new(`,
+  ]);
+});
+
+test('it renders an instruction with a str reference', (t) => {
+  // Given the following program with 1 instruction.
+  const node = programNode({
+    name: 'splToken',
+    publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    instructions: [
+      instructionNode({
+        name: 'addMemo',
+        arguments: [
+          instructionArgumentNode({
+            name: 'memo',
+            type: stringTypeNode({ size: remainderSizeNode() }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  // When we render it.
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Then we expect the following pub struct.
+  codeContains(t, renderMap.get('instructions/add_memo.rs'), [
+    `pub struct AddMemoInstructionArgs<'z>`,
+    `pub memo: &'z str`,
   ]);
 });


### PR DESCRIPTION
This PR adds a lifetime specifier when a `&str` type is used.