### PR TITLE
Use remainder str type

### DIFF
--- a/.changeset/wicked-apples-tan.md
+++ b/.changeset/wicked-apples-tan.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Use remainder str type in Rust client

--- a/src/renderers/rust/getTypeManifestVisitor.ts
+++ b/src/renderers/rust/getTypeManifestVisitor.ts
@@ -451,8 +451,10 @@ export function getTypeManifestVisitor() {
 
           if (isNode(stringType.size, 'remainderSizeNode')) {
             return {
-              type: `&str`,
-              imports: new RustImportMap(),
+              type: `RemainderStr`,
+              imports: new RustImportMap().add(
+                `kaigan::types::RemainderStr`
+              ),
               nestedStructs: [],
             };
           }

--- a/test/renderers/rust/instructionsPage.test.ts
+++ b/test/renderers/rust/instructionsPage.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { instructionNode, programNode, visit } from '../../../src';
+import { instructionArgumentNode, instructionNode, programNode, remainderSizeNode, stringTypeNode, visit } from '../../../src';
 import { getRenderMapVisitor } from '../../../src/renderers/rust/getRenderMapVisitor';
 import { codeContains } from './_setup';
 
@@ -18,5 +18,33 @@ test('it renders a public instruction data struct', (t) => {
   codeContains(t, renderMap.get('instructions/mint_tokens.rs'), [
     `pub struct MintTokensInstructionData`,
     `pub fn new(`,
+  ]);
+});
+
+test('it renders an instruction with a remainder str', (t) => {
+  // Given the following program with 1 instruction.
+  const node = programNode({
+    name: 'splToken',
+    publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    instructions: [
+      instructionNode({
+        name: 'addMemo',
+        arguments: [
+          instructionArgumentNode({
+            name: 'memo',
+            type: stringTypeNode({ size: remainderSizeNode() }),
+          }),
+        ],
+      }),
+    ],
+  });
+
+  // When we render it.
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Then we expect the following pub struct.
+  codeContains(t, renderMap.get('instructions/add_memo.rs'), [
+    `use kaigan::types::RemainderStr`,
+    `pub memo: RemainderStr`,
   ]);
 });


### PR DESCRIPTION
This PR adds support to unsized string values in the Rust client by using the `RemainderStr` type.