### PR TITLE
Fix missing args variable error in JS Experimental

### DIFF
--- a/.changeset/mighty-swans-rest.md
+++ b/.changeset/mighty-swans-rest.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Fix missing args variable error in JS Experimental

--- a/src/renderers/js-experimental/fragments/instructionFunction.ts
+++ b/src/renderers/js-experimental/fragments/instructionFunction.ts
@@ -1,4 +1,4 @@
-import { InstructionNode, ProgramNode } from '../../../nodes';
+import { InstructionNode, ProgramNode, isNode } from '../../../nodes';
 import { camelCase, pascalCase } from '../../../shared';
 import { ResolvedInstructionInput } from '../../../visitors';
 import { TypeManifest } from '../TypeManifest';
@@ -66,7 +66,11 @@ export function getInstructionFunctionFragment(
     (instructionNode.extraArguments ?? []).filter(
       (field) => !field.defaultValue || field.defaultValueStrategy !== 'omitted'
     ).length > 0;
-  const hasAnyArgs = hasDataArgs || hasExtraArgs;
+  const hasRemainingAccountArgs =
+    (instructionNode.remainingAccounts ?? []).filter(({ value }) =>
+      isNode(value, 'argumentValueNode')
+    ).length > 0;
+  const hasAnyArgs = hasDataArgs || hasExtraArgs || hasRemainingAccountArgs;
   const instructionDataName = nameApi.instructionDataType(instructionNode.name);
   const programAddressConstant = nameApi.programAddressConstant(
     programNode.name


### PR DESCRIPTION
Fix an error in the JS Experimental renderer that causes a `Cannot find name 'args'` error.

This is because when an instruction has no arguments, the `args` variable won't be generated. However, when an instruction has remaining accounts that rely on the `argumentValueNode`, then we need that variable to exist.

The fix is to update the value of the `hasAnyArgs` helper to also include `remainingAccountsNodes` of values `argumentValueNode`.