### PR TITLE
Support for Anchor Types in the Rust renderer

### DIFF
--- a/.changeset/rich-bats-invite.md
+++ b/.changeset/rich-bats-invite.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/kinobi": patch
+---
+
+Support for Anchor Types in the Rust renderer

--- a/src/renderers/rust/getRenderMapVisitor.ts
+++ b/src/renderers/rust/getRenderMapVisitor.ts
@@ -185,7 +185,6 @@ export function getRenderMapVisitor(options: GetRustRenderMapOptions = {}) {
         visitInstruction(node) {
           // Imports.
           const imports = new RustImportMap();
-          imports.add(['borsh::BorshDeserialize', 'borsh::BorshSerialize']);
 
           // canMergeAccountsAndArgs
           const accountsAndArgsConflicts =
@@ -193,11 +192,11 @@ export function getRenderMapVisitor(options: GetRustRenderMapOptions = {}) {
           if (accountsAndArgsConflicts.length > 0) {
             logWarn(
               `[Rust] Accounts and args of instruction [${node.name}] have the following ` +
-                `conflicting attributes [${accountsAndArgsConflicts.join(
-                  ', '
-                )}]. ` +
-                `Thus, the conflicting arguments will be suffixed with "_arg". ` +
-                'You may want to rename the conflicting attributes.'
+              `conflicting attributes [${accountsAndArgsConflicts.join(
+                ', '
+              )}]. ` +
+              `Thus, the conflicting arguments will be suffixed with "_arg". ` +
+              'You may want to rename the conflicting attributes.'
             );
           }
 

--- a/src/renderers/rust/getTypeManifestVisitor.ts
+++ b/src/renderers/rust/getTypeManifestVisitor.ts
@@ -39,16 +39,14 @@ export function getTypeManifestVisitor() {
         visitAccount(account, { self }) {
           parentName = pascalCase(account.name);
           const manifest = visit(account.data, self);
-          manifest.imports.add([
-            'borsh::BorshSerialize',
-            'borsh::BorshDeserialize',
-          ]);
           parentName = null;
           return {
             ...manifest,
             type:
-              '#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]\n' +
+              `#[derive(Clone, Debug, Eq, PartialEq)]\n` +
+              '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
               '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
+              '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
               `${manifest.type}`,
           };
         },
@@ -57,13 +55,7 @@ export function getTypeManifestVisitor() {
           parentName = pascalCase(definedType.name);
           const manifest = visit(definedType.type, self);
           parentName = null;
-          manifest.imports.add([
-            'borsh::BorshSerialize',
-            'borsh::BorshDeserialize',
-          ]);
           const traits = [
-            'BorshSerialize',
-            'BorshDeserialize',
             'Clone',
             'Debug',
             'Eq',
@@ -80,12 +72,14 @@ export function getTypeManifestVisitor() {
             ...manifest,
             type:
               `#[derive(${traits.join(', ')})]\n` +
-              '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
+              '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
+              '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
               `${manifest.type}`,
             nestedStructs: manifest.nestedStructs.map(
               (struct) =>
                 `#[derive(${traits.join(', ')})]\n` +
-                '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
+                '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
+                '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
                 `${struct}`
             ),
           };

--- a/src/renderers/rust/getTypeManifestVisitor.ts
+++ b/src/renderers/rust/getTypeManifestVisitor.ts
@@ -43,10 +43,10 @@ export function getTypeManifestVisitor() {
           return {
             ...manifest,
             type:
-              `#[derive(Clone, Debug, Eq, PartialEq)]\n` +
               '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
               '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
               '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
+              `#[derive(Clone, Debug, Eq, PartialEq)]\n` +
               `${manifest.type}`,
           };
         },
@@ -71,17 +71,17 @@ export function getTypeManifestVisitor() {
           return {
             ...manifest,
             type:
-              `#[derive(${traits.join(', ')})]\n` +
               '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
               '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
               '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
+              `#[derive(${traits.join(', ')})]\n` +
               `${manifest.type}`,
             nestedStructs: manifest.nestedStructs.map(
               (struct) =>
-                `#[derive(${traits.join(', ')})]\n` +
                 '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
                 '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
                 '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
+                `#[derive(${traits.join(', ')})]\n` +
                 `${struct}`
             ),
           };

--- a/src/renderers/rust/getTypeManifestVisitor.ts
+++ b/src/renderers/rust/getTypeManifestVisitor.ts
@@ -72,12 +72,14 @@ export function getTypeManifestVisitor() {
             ...manifest,
             type:
               `#[derive(${traits.join(', ')})]\n` +
+              '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
               '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
               '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
               `${manifest.type}`,
             nestedStructs: manifest.nestedStructs.map(
               (struct) =>
                 `#[derive(${traits.join(', ')})]\n` +
+                '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
                 '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
                 '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
                 `${struct}`

--- a/src/renderers/rust/getTypeManifestVisitor.ts
+++ b/src/renderers/rust/getTypeManifestVisitor.ts
@@ -43,9 +43,9 @@ export function getTypeManifestVisitor() {
           return {
             ...manifest,
             type:
-              '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
-              '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
-              '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
+              '#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]\n' +
+              '#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]\n' +
+              '#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]\n' +
               `#[derive(Clone, Debug, Eq, PartialEq)]\n` +
               `${manifest.type}`,
           };
@@ -71,16 +71,16 @@ export function getTypeManifestVisitor() {
           return {
             ...manifest,
             type:
-              '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
-              '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
-              '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
+              '#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]\n' +
+              '#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]\n' +
+              '#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]\n' +
               `#[derive(${traits.join(', ')})]\n` +
               `${manifest.type}`,
             nestedStructs: manifest.nestedStructs.map(
               (struct) =>
-                '#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]\n' +
-                '#[cfg_attr(not(feature = "anchor"), derive(borsh::BorshSerialize, borsh::BorshDeserialize))]\n' +
-                '#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]\n' +
+                '#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]\n' +
+                '#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]\n' +
+                '#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]\n' +
                 `#[derive(${traits.join(', ')})]\n` +
                 `${struct}`
             ),

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -4,6 +4,10 @@
 {% block main %}
 
 {{ imports }}
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
+use borsh::BorshDeserialize;
 
 {{ macros.docblock(account.docs) }}
 {{ typeManifest.type }}

--- a/src/renderers/rust/templates/accountsPage.njk
+++ b/src/renderers/rust/templates/accountsPage.njk
@@ -5,9 +5,11 @@
 
 {{ imports }}
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 {{ macros.docblock(account.docs) }}
 {{ typeManifest.type }}

--- a/src/renderers/rust/templates/definedTypesPage.njk
+++ b/src/renderers/rust/templates/definedTypesPage.njk
@@ -4,6 +4,12 @@
 {% block main %}
 
 {{ imports }}
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 {{ macros.docblock(definedType.docs) }}
 {{- typeManifest.type }}

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -129,10 +129,10 @@ impl {{ instruction.name | pascalCase }}InstructionData {
 }
 
 {% if hasArgs %}
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct {{ instruction.name | pascalCase }}InstructionArgs {
   {% for arg in instructionArgs %}
     {% if not arg.default %}
@@ -143,10 +143,10 @@ pub struct {{ instruction.name | pascalCase }}InstructionArgs {
 {% endif %}
 
 {% for nestedStruct in typeManifest.nestedStructs %}
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 {{ nestedStruct }}
 {% endfor %}
 

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -129,7 +129,9 @@ impl {{ instruction.name | pascalCase }}InstructionData {
 }
 
 {% if hasArgs %}
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct {{ instruction.name | pascalCase }}InstructionArgs {
   {% for arg in instructionArgs %}
@@ -141,7 +143,9 @@ pub struct {{ instruction.name | pascalCase }}InstructionArgs {
 {% endif %}
 
 {% for nestedStruct in typeManifest.nestedStructs %}
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 {{ nestedStruct }}
 {% endfor %}

--- a/src/renderers/rust/templates/instructionsPage.njk
+++ b/src/renderers/rust/templates/instructionsPage.njk
@@ -4,6 +4,12 @@
 {% block main %}
 
 {{ imports }}
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct {{ instruction.name | pascalCase }} {
@@ -107,7 +113,8 @@ impl {{ instruction.name | pascalCase }} {
   }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct {{ instruction.name | pascalCase }}InstructionData {
   {% for arg in instructionArgs %}
     {% if arg.default %}
@@ -130,8 +137,8 @@ impl {{ instruction.name | pascalCase }}InstructionData {
 
 {% if hasArgs %}
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct {{ instruction.name | pascalCase }}InstructionArgs {
   {% for arg in instructionArgs %}
@@ -144,8 +151,8 @@ pub struct {{ instruction.name | pascalCase }}InstructionArgs {
 
 {% for nestedStruct in typeManifest.nestedStructs %}
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(feature = "anchor", derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 {{ nestedStruct }}
 {% endfor %}

--- a/test/packages/js-experimental/src/generated/programs/pubkeyTests.ts
+++ b/test/packages/js-experimental/src/generated/programs/pubkeyTests.ts
@@ -10,10 +10,10 @@ import { Address } from '@solana/addresses';
 import { Program } from '@solana/programs';
 
 export const PUBKEY_TESTS_PROGRAM_ADDRESS =
-  'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d' as Address<'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'>;
+  'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7' as Address<'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7'>;
 
 export type PubkeyTestsProgram =
-  Program<'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'>;
+  Program<'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7'>;
 
 export function getPubkeyTestsProgram(): PubkeyTestsProgram {
   return {

--- a/test/packages/js/src/generated/programs/pubkeyTests.ts
+++ b/test/packages/js/src/generated/programs/pubkeyTests.ts
@@ -18,7 +18,7 @@ import {
 } from '../errors';
 
 export const PUBKEY_TESTS_PROGRAM_ID =
-  'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d' as PublicKey<'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'>;
+  'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7' as PublicKey<'PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7'>;
 
 export function createPubkeyTestsProgram(): Program {
   return {

--- a/test/packages/rust/Cargo.lock
+++ b/test/packages/rust/Cargo.lock
@@ -27,6 +27,171 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-attribute-access-control"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7368e171b3a317885dc08ec0f74eed9d0ad6c726cc819593aed81440dca926"
+dependencies = [
+ "anchor-syn",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f527df85a8cba3f2bea04e46ed71b66e525ea378c7fec538aa205f4520b73e31"
+dependencies = [
+ "anchor-syn",
+ "bs58 0.5.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb1dc1845cf8636c2e046a274ca074dabd3884ac8ed11cc4ed64b7e8ef5a318"
+dependencies = [
+ "anchor-syn",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f382e41514c59a77ffa7bb1a47df9a0359564a749b6934485c742c11962e540"
+dependencies = [
+ "anchor-syn",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473a122aeed3f6b666438236338d2ef7833ee5fdc5688e1baa80185d61088a53"
+dependencies = [
+ "anchor-syn",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f88c7ffe2eb40aeac43ffd0d74a6671581158aedfaa0552330a2ef92fa5c889"
+dependencies = [
+ "anchor-lang-idl",
+ "anchor-syn",
+ "anyhow",
+ "bs58 0.5.1",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9b97c99dcec135aae0ff908c14bcfcd3e78cfc16a0c6f245135038f0e6d390"
+dependencies = [
+ "anchor-syn",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-serde"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbece98f6ad9c37070edc0841326c9623a249346cd74f433e7cef69b14f7f31d"
+dependencies = [
+ "anchor-syn",
+ "borsh-derive-internal 0.10.3",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-space"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8badbe2648bc99a85ee05a7a5f9512e5e2af8ffac71476a69350cb278057ac53"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e41feb9c1cd9f4b0fad1c004fc8f289183f3ce27e9db38fa6e434470c716fb1e"
+dependencies = [
+ "anchor-attribute-access-control",
+ "anchor-attribute-account",
+ "anchor-attribute-constant",
+ "anchor-attribute-error",
+ "anchor-attribute-event",
+ "anchor-attribute-program",
+ "anchor-derive-accounts",
+ "anchor-derive-serde",
+ "anchor-derive-space",
+ "arrayref",
+ "base64 0.21.5",
+ "bincode",
+ "borsh 0.10.3",
+ "bytemuck",
+ "getrandom 0.2.10",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-lang-idl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29da81eae478b1bb846749b06b8a2cb9c6f9ed26ca793b0c916793fdf36adab"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac53f2378bc08e89e20c2b893c01986ffd34cfbc69a17e35bd6f754753e9fdad"
+dependencies = [
+ "anyhow",
+ "bs58 0.5.1",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +519,15 @@ name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -708,6 +882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1040,7 @@ dependencies = [
 name = "kinobi-dummy-generated"
 version = "0.1.0"
 dependencies = [
+ "anchor-lang",
  "borsh 0.10.3",
  "kaigan",
  "num-derive",
@@ -1378,7 +1562,7 @@ dependencies = [
  "ahash 0.8.6",
  "blake3",
  "block-buffer 0.10.4",
- "bs58",
+ "bs58 0.4.0",
  "bv",
  "byteorder",
  "cc",
@@ -1427,7 +1611,7 @@ dependencies = [
  "blake3",
  "borsh 0.10.3",
  "borsh 0.9.3",
- "bs58",
+ "bs58 0.4.0",
  "bv",
  "bytemuck",
  "cc",
@@ -1471,7 +1655,7 @@ version = "1.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97dce8e347d73bcd9a6fe0b37bf830a20d0a4913ac58046c79959d5e15bbbed3"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1624,6 +1808,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "version_check"

--- a/test/packages/rust/Cargo.toml
+++ b/test/packages/rust/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib"]
 
 [features]
 serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
+anchor = ["dep:anchor-lang"]
 
 [dependencies]
 borsh = "0.10"
@@ -19,3 +20,4 @@ serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
 solana-program = "^1.16"
 thiserror = "^1.0"
+anchor-lang = { version = "0.30.0", optional = true }

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -14,7 +14,6 @@ use solana_program::pubkey::Pubkey;
 
 /// Candy machine state and config data.
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -24,6 +23,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandyMachine {
     pub discriminator: [u8; 8],
     /// Features versioning flags.

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -6,14 +6,24 @@
 //!
 
 use crate::generated::types::CandyMachineData;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 /// Candy machine state and config data.
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct CandyMachine {
     pub discriminator: [u8; 8],
     /// Features versioning flags.

--- a/test/packages/rust/src/generated/accounts/candy_machine.rs
+++ b/test/packages/rust/src/generated/accounts/candy_machine.rs
@@ -7,22 +7,18 @@
 
 use crate::generated::types::CandyMachineData;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// Candy machine state and config data.
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandyMachine {
     pub discriminator: [u8; 8],

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -6,12 +6,22 @@
 //!
 
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct CollectionAuthorityRecord {
     pub key: TmKey,
     pub bump: u8,

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -12,7 +12,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -22,6 +21,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CollectionAuthorityRecord {
     pub key: TmKey,
     pub bump: u8,

--- a/test/packages/rust/src/generated/accounts/collection_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/collection_authority_record.rs
@@ -7,20 +7,16 @@
 
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CollectionAuthorityRecord {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -8,19 +8,15 @@
 use crate::generated::types::DelegateRole;
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelegateRecord {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -7,11 +7,21 @@
 
 use crate::generated::types::DelegateRole;
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct DelegateRecord {
     pub key: TmKey,
     pub role: DelegateRole,

--- a/test/packages/rust/src/generated/accounts/delegate_record.rs
+++ b/test/packages/rust/src/generated/accounts/delegate_record.rs
@@ -12,7 +12,6 @@ use anchor_lang::AnchorDeserialize;
 #[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -22,6 +21,7 @@ use borsh::BorshDeserialize;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelegateRecord {
     pub key: TmKey,
     pub role: DelegateRole,

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -12,7 +12,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -22,6 +21,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Edition {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -7,20 +7,16 @@
 
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Edition {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/edition.rs
+++ b/test/packages/rust/src/generated/accounts/edition.rs
@@ -6,12 +6,22 @@
 //!
 
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Edition {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -11,7 +11,6 @@ use anchor_lang::AnchorDeserialize;
 #[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -21,6 +20,7 @@ use borsh::BorshDeserialize;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EditionMarker {
     pub key: TmKey,
     #[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -7,19 +7,15 @@
 
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EditionMarker {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/edition_marker.rs
+++ b/test/packages/rust/src/generated/accounts/edition_marker.rs
@@ -6,11 +6,21 @@
 //!
 
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct EditionMarker {
     pub key: TmKey,
     #[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -6,19 +6,15 @@
 //!
 
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FrequencyAccount {
     /// Test with only one line.

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -10,7 +10,6 @@ use anchor_lang::AnchorDeserialize;
 #[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -20,6 +19,7 @@ use borsh::BorshDeserialize;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FrequencyAccount {
     /// Test with only one line.
     pub key: u64,

--- a/test/packages/rust/src/generated/accounts/frequency_account.rs
+++ b/test/packages/rust/src/generated/accounts/frequency_account.rs
@@ -5,11 +5,21 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct FrequencyAccount {
     /// Test with only one line.
     pub key: u64,

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -7,12 +7,22 @@
 
 use crate::generated::types::DelegateRole;
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct MasterEditionV1 {
     pub key: TmKey,
     pub supply: u64,

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -13,7 +13,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -23,6 +22,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MasterEditionV1 {
     pub key: TmKey,
     pub supply: u64,

--- a/test/packages/rust/src/generated/accounts/master_edition_v1.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v1.rs
@@ -8,20 +8,16 @@
 use crate::generated::types::DelegateRole;
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MasterEditionV1 {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -12,7 +12,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -22,6 +21,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MasterEditionV2 {
     pub key: TmKey,
     pub supply: u64,

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -6,12 +6,22 @@
 //!
 
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct MasterEditionV2 {
     pub key: TmKey,
     pub supply: u64,

--- a/test/packages/rust/src/generated/accounts/master_edition_v2.rs
+++ b/test/packages/rust/src/generated/accounts/master_edition_v2.rs
@@ -7,20 +7,16 @@
 
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MasterEditionV2 {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -13,12 +13,22 @@ use crate::generated::types::ProgrammableConfig;
 use crate::generated::types::TmKey;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Metadata {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -19,7 +19,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -29,6 +28,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Metadata {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/metadata.rs
+++ b/test/packages/rust/src/generated/accounts/metadata.rs
@@ -14,20 +14,16 @@ use crate::generated::types::TmKey;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Metadata {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -8,20 +8,16 @@
 use crate::generated::types::ReservationV1;
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReservationListV1 {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -13,7 +13,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -23,6 +22,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReservationListV1 {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v1.rs
@@ -7,12 +7,22 @@
 
 use crate::generated::types::ReservationV1;
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ReservationListV1 {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -13,7 +13,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -23,6 +22,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReservationListV2 {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -7,12 +7,22 @@
 
 use crate::generated::types::Reservation;
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ReservationListV2 {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
+++ b/test/packages/rust/src/generated/accounts/reservation_list_v2.rs
@@ -8,20 +8,16 @@
 use crate::generated::types::Reservation;
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReservationListV2 {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -8,20 +8,16 @@
 use crate::generated::types::EscrowAuthority;
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokenOwnedEscrow {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -7,12 +7,22 @@
 
 use crate::generated::types::EscrowAuthority;
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct TokenOwnedEscrow {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
+++ b/test/packages/rust/src/generated/accounts/token_owned_escrow.rs
@@ -13,7 +13,6 @@ use anchor_lang::AnchorDeserialize;
 use borsh::BorshDeserialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -23,6 +22,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokenOwnedEscrow {
     pub key: TmKey,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -6,11 +6,21 @@
 //!
 
 use crate::generated::types::TmKey;
+#[cfg(feature = "anchor")]
+use anchor_lang::AnchorDeserialize;
+#[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct UseAuthorityRecord {
     pub key: TmKey,
     pub allowed_uses: u64,

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -11,7 +11,6 @@ use anchor_lang::AnchorDeserialize;
 #[cfg(not(feature = "anchor"))]
 use borsh::BorshDeserialize;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -21,6 +20,7 @@ use borsh::BorshDeserialize;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UseAuthorityRecord {
     pub key: TmKey,
     pub allowed_uses: u64,

--- a/test/packages/rust/src/generated/accounts/use_authority_record.rs
+++ b/test/packages/rust/src/generated/accounts/use_authority_record.rs
@@ -7,19 +7,15 @@
 
 use crate::generated::types::TmKey;
 #[cfg(feature = "anchor")]
-use anchor_lang::AnchorDeserialize;
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UseAuthorityRecord {
     pub key: TmKey,

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -65,13 +65,13 @@ impl AddConfigLinesInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AddConfigLinesInstructionArgs {
     pub index: u32,
     pub config_lines: Vec<ConfigLine>,

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -6,9 +6,13 @@
 //!
 
 use crate::generated::types::ConfigLine;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaigan::types::U64PrefixVec;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct AddConfigLines {
@@ -52,7 +56,8 @@ impl AddConfigLines {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct AddConfigLinesInstructionData {
     discriminator: [u8; 8],
 }
@@ -66,11 +71,8 @@ impl AddConfigLinesInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AddConfigLinesInstructionArgs {
     pub index: u32,

--- a/test/packages/rust/src/generated/instructions/add_config_lines.rs
+++ b/test/packages/rust/src/generated/instructions/add_config_lines.rs
@@ -65,7 +65,12 @@ impl AddConfigLinesInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddConfigLinesInstructionArgs {
     pub index: u32,

--- a/test/packages/rust/src/generated/instructions/add_memo.rs
+++ b/test/packages/rust/src/generated/instructions/add_memo.rs
@@ -47,7 +47,12 @@ impl AddMemoInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddMemoInstructionArgs {
     pub memo: String,

--- a/test/packages/rust/src/generated/instructions/add_memo.rs
+++ b/test/packages/rust/src/generated/instructions/add_memo.rs
@@ -47,13 +47,13 @@ impl AddMemoInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AddMemoInstructionArgs {
     pub memo: String,
 }

--- a/test/packages/rust/src/generated/instructions/add_memo.rs
+++ b/test/packages/rust/src/generated/instructions/add_memo.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct AddMemo {}
@@ -38,7 +42,8 @@ impl AddMemo {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct AddMemoInstructionData {}
 
 impl AddMemoInstructionData {
@@ -48,11 +53,8 @@ impl AddMemoInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AddMemoInstructionArgs {
     pub memo: String,

--- a/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_collection_authority.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct ApproveCollectionAuthority {
@@ -87,7 +91,8 @@ impl ApproveCollectionAuthority {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct ApproveCollectionAuthorityInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -120,7 +120,12 @@ impl ApproveUseAuthorityInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ApproveUseAuthorityInstructionArgs {
     pub number_of_uses: u64,

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -120,13 +120,13 @@ impl ApproveUseAuthorityInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ApproveUseAuthorityInstructionArgs {
     pub number_of_uses: u64,
 }

--- a/test/packages/rust/src/generated/instructions/approve_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/approve_use_authority.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct ApproveUseAuthority {
@@ -109,7 +113,8 @@ impl ApproveUseAuthority {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct ApproveUseAuthorityInstructionData {
     discriminator: u8,
 }
@@ -121,11 +126,8 @@ impl ApproveUseAuthorityInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ApproveUseAuthorityInstructionArgs {
     pub number_of_uses: u64,

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -90,13 +90,13 @@ impl BubblegumSetCollectionSizeInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BubblegumSetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -90,7 +90,12 @@ impl BubblegumSetCollectionSizeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BubblegumSetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,

--- a/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/bubblegum_set_collection_size.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::SetCollectionSizeArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct BubblegumSetCollectionSize {
@@ -79,7 +83,8 @@ impl BubblegumSetCollectionSize {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct BubblegumSetCollectionSizeInstructionData {
     discriminator: u8,
 }
@@ -91,11 +96,8 @@ impl BubblegumSetCollectionSizeInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BubblegumSetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -124,7 +124,12 @@ impl BurnInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BurnInstructionArgs {
     pub burn_args: BurnArgs,

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::BurnArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Burn {
@@ -113,7 +117,8 @@ impl Burn {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct BurnInstructionData {
     discriminator: u8,
 }
@@ -125,11 +130,8 @@ impl BurnInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BurnInstructionArgs {
     pub burn_args: BurnArgs,

--- a/test/packages/rust/src/generated/instructions/burn.rs
+++ b/test/packages/rust/src/generated/instructions/burn.rs
@@ -124,13 +124,13 @@ impl BurnInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BurnInstructionArgs {
     pub burn_args: BurnArgs,
 }

--- a/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_edition_nft.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct BurnEditionNft {
@@ -92,7 +96,8 @@ impl BurnEditionNft {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct BurnEditionNftInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/burn_nft.rs
+++ b/test/packages/rust/src/generated/instructions/burn_nft.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct BurnNft {
@@ -80,7 +84,8 @@ impl BurnNft {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct BurnNftInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/close_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/close_escrow_account.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CloseEscrowAccount {
@@ -81,7 +85,8 @@ impl CloseEscrowAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CloseEscrowAccountInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
+++ b/test/packages/rust/src/generated/instructions/convert_master_edition_v1_to_v2.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct ConvertMasterEditionV1ToV2 {
@@ -53,7 +57,8 @@ impl ConvertMasterEditionV1ToV2 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct ConvertMasterEditionV1ToV2InstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/create_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_account.rs
@@ -61,7 +61,12 @@ impl CreateAccountInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAccountInstructionArgs {
     pub lamports: u64,

--- a/test/packages/rust/src/generated/instructions/create_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_account.rs
@@ -61,13 +61,13 @@ impl CreateAccountInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateAccountInstructionArgs {
     pub lamports: u64,
     pub space: u64,

--- a/test/packages/rust/src/generated/instructions/create_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_account.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// Accounts.
@@ -50,7 +54,8 @@ impl CreateAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateAccountInstructionData {
     discriminator: u32,
 }
@@ -62,11 +67,8 @@ impl CreateAccountInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateAccountInstructionArgs {
     pub lamports: u64,

--- a/test/packages/rust/src/generated/instructions/create_escrow_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_escrow_account.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateEscrowAccount {
@@ -93,7 +97,8 @@ impl CreateEscrowAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateEscrowAccountInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateFrequencyRule {
@@ -58,7 +62,8 @@ impl CreateFrequencyRule {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateFrequencyRuleInstructionData {
     discriminator: u8,
 }
@@ -70,11 +75,8 @@ impl CreateFrequencyRuleInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateFrequencyRuleInstructionArgs {
     pub rule_set_name: String,

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -69,7 +69,12 @@ impl CreateFrequencyRuleInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateFrequencyRuleInstructionArgs {
     pub rule_set_name: String,

--- a/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
+++ b/test/packages/rust/src/generated/instructions/create_frequency_rule.rs
@@ -69,13 +69,13 @@ impl CreateFrequencyRuleInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateFrequencyRuleInstructionArgs {
     pub rule_set_name: String,
     pub freq_rule_name: String,

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -104,13 +104,13 @@ impl CreateMasterEditionInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -104,7 +104,12 @@ impl CreateMasterEditionInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,

--- a/test/packages/rust/src/generated/instructions/create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::CreateMasterEditionArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateMasterEdition {
@@ -93,7 +97,8 @@ impl CreateMasterEdition {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateMasterEditionInstructionData {
     discriminator: u8,
 }
@@ -105,11 +110,8 @@ impl CreateMasterEditionInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -111,7 +111,12 @@ impl CreateMasterEditionV3InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMasterEditionV3InstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::CreateMasterEditionArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateMasterEditionV3 {
@@ -100,7 +104,8 @@ impl CreateMasterEditionV3 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateMasterEditionV3InstructionData {
     discriminator: u8,
 }
@@ -112,11 +117,8 @@ impl CreateMasterEditionV3InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMasterEditionV3InstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,

--- a/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_master_edition_v3.rs
@@ -111,13 +111,13 @@ impl CreateMasterEditionV3InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMasterEditionV3InstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::Creator;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateMetadataAccount {
@@ -81,7 +85,8 @@ impl CreateMetadataAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateMetadataAccountInstructionData {
     discriminator: u8,
 }
@@ -93,11 +98,8 @@ impl CreateMetadataAccountInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountInstructionArgs {
     pub data: CreateMetadataAccountInstructionDataData,
@@ -106,11 +108,8 @@ pub struct CreateMetadataAccountInstructionArgs {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountInstructionDataData {
     pub name: String,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -92,7 +92,12 @@ impl CreateMetadataAccountInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountInstructionArgs {
     pub data: CreateMetadataAccountInstructionDataData,
@@ -100,7 +105,12 @@ pub struct CreateMetadataAccountInstructionArgs {
     pub metadata_bump: u8,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountInstructionDataData {
     pub name: String,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account.rs
@@ -92,26 +92,26 @@ impl CreateMetadataAccountInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountInstructionArgs {
     pub data: CreateMetadataAccountInstructionDataData,
     pub is_mutable: bool,
     pub metadata_bump: u8,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountInstructionDataData {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::DataV2;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateMetadataAccountV2 {
@@ -88,7 +92,8 @@ impl CreateMetadataAccountV2 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateMetadataAccountV2InstructionData {
     discriminator: u8,
 }
@@ -100,11 +105,8 @@ impl CreateMetadataAccountV2InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountV2InstructionArgs {
     pub data: DataV2,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -99,7 +99,12 @@ impl CreateMetadataAccountV2InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountV2InstructionArgs {
     pub data: DataV2,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v2.rs
@@ -99,13 +99,13 @@ impl CreateMetadataAccountV2InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountV2InstructionArgs {
     pub data: DataV2,
     pub is_mutable: bool,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -100,7 +100,12 @@ impl CreateMetadataAccountV3InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateMetadataAccountV3InstructionArgs {
     pub data: DataV2,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -7,8 +7,12 @@
 
 use crate::generated::types::CollectionDetails;
 use crate::generated::types::DataV2;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateMetadataAccountV3 {
@@ -89,7 +93,8 @@ impl CreateMetadataAccountV3 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateMetadataAccountV3InstructionData {
     discriminator: u8,
 }
@@ -101,11 +106,8 @@ impl CreateMetadataAccountV3InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountV3InstructionArgs {
     pub data: DataV2,

--- a/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
+++ b/test/packages/rust/src/generated/instructions/create_metadata_account_v3.rs
@@ -100,13 +100,13 @@ impl CreateMetadataAccountV3InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMetadataAccountV3InstructionArgs {
     pub data: DataV2,
     pub is_mutable: bool,

--- a/test/packages/rust/src/generated/instructions/create_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/create_reservation_list.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateReservationList {
@@ -81,7 +85,8 @@ impl CreateReservationList {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateReservationListInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -68,13 +68,13 @@ impl CreateRuleSetInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateRuleSetInstructionArgs {
     pub create_args: TaCreateArgs,
     pub rule_set_bump: u8,

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -68,7 +68,12 @@ impl CreateRuleSetInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRuleSetInstructionArgs {
     pub create_args: TaCreateArgs,

--- a/test/packages/rust/src/generated/instructions/create_rule_set.rs
+++ b/test/packages/rust/src/generated/instructions/create_rule_set.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::TaCreateArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateRuleSet {
@@ -57,7 +61,8 @@ impl CreateRuleSet {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateRuleSetInstructionData {
     discriminator: u8,
 }
@@ -69,11 +74,8 @@ impl CreateRuleSetInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateRuleSetInstructionArgs {
     pub create_args: TaCreateArgs,

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::AssetData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateV1 {
@@ -100,7 +104,8 @@ impl CreateV1 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateV1InstructionData {
     discriminator: u8,
     create_v1_discriminator: u8,
@@ -116,11 +121,8 @@ impl CreateV1InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateV1InstructionArgs {
     pub asset_data: AssetData,

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -115,13 +115,13 @@ impl CreateV1InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateV1InstructionArgs {
     pub asset_data: AssetData,
     pub decimals: Option<u8>,

--- a/test/packages/rust/src/generated/instructions/create_v1.rs
+++ b/test/packages/rust/src/generated/instructions/create_v1.rs
@@ -115,7 +115,12 @@ impl CreateV1InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateV1InstructionArgs {
     pub asset_data: AssetData,

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::AssetData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct CreateV2 {
@@ -100,7 +104,8 @@ impl CreateV2 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct CreateV2InstructionData {
     discriminator: u8,
     create_v2_discriminator: u8,
@@ -116,11 +121,8 @@ impl CreateV2InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateV2InstructionArgs {
     pub asset_data: AssetData,

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -115,7 +115,12 @@ impl CreateV2InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateV2InstructionArgs {
     pub asset_data: AssetData,

--- a/test/packages/rust/src/generated/instructions/create_v2.rs
+++ b/test/packages/rust/src/generated/instructions/create_v2.rs
@@ -115,13 +115,13 @@ impl CreateV2InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateV2InstructionArgs {
     pub asset_data: AssetData,
     pub max_supply: Option<u64>,

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -159,13 +159,13 @@ impl DelegateInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelegateInstructionArgs {
     pub delegate_args: DelegateArgs,
 }

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::DelegateArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Delegate {
@@ -148,7 +152,8 @@ impl Delegate {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DelegateInstructionData {
     discriminator: u8,
 }
@@ -160,11 +165,8 @@ impl DelegateInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelegateInstructionArgs {
     pub delegate_args: DelegateArgs,

--- a/test/packages/rust/src/generated/instructions/delegate.rs
+++ b/test/packages/rust/src/generated/instructions/delegate.rs
@@ -159,7 +159,12 @@ impl DelegateInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DelegateInstructionArgs {
     pub delegate_args: DelegateArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -128,7 +128,12 @@ impl DeprecatedCreateMasterEditionInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedCreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::CreateMasterEditionArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct DeprecatedCreateMasterEdition {
@@ -117,7 +121,8 @@ impl DeprecatedCreateMasterEdition {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DeprecatedCreateMasterEditionInstructionData {
     discriminator: u8,
 }
@@ -129,11 +134,8 @@ impl DeprecatedCreateMasterEditionInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedCreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_create_master_edition.rs
@@ -128,13 +128,13 @@ impl DeprecatedCreateMasterEditionInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedCreateMasterEditionInstructionArgs {
     pub create_master_edition_args: CreateMasterEditionArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_new_edition_from_master_edition_via_printing_token.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {
@@ -135,7 +139,8 @@ impl DeprecatedMintNewEditionFromMasterEditionViaPrintingToken {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DeprecatedMintNewEditionFromMasterEditionViaPrintingTokenInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::MintPrintingTokensViaTokenArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct DeprecatedMintPrintingTokens {
@@ -83,7 +87,8 @@ impl DeprecatedMintPrintingTokens {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DeprecatedMintPrintingTokensInstructionData {
     discriminator: u8,
 }
@@ -95,11 +100,8 @@ impl DeprecatedMintPrintingTokensInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedMintPrintingTokensInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -94,7 +94,12 @@ impl DeprecatedMintPrintingTokensInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedMintPrintingTokensInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens.rs
@@ -94,13 +94,13 @@ impl DeprecatedMintPrintingTokensInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedMintPrintingTokensInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::MintPrintingTokensViaTokenArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct DeprecatedMintPrintingTokensViaToken {
@@ -94,7 +98,8 @@ impl DeprecatedMintPrintingTokensViaToken {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionData {
     discriminator: u8,
 }
@@ -106,11 +111,8 @@ impl DeprecatedMintPrintingTokensViaTokenInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -105,7 +105,12 @@ impl DeprecatedMintPrintingTokensViaTokenInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_mint_printing_tokens_via_token.rs
@@ -105,13 +105,13 @@ impl DeprecatedMintPrintingTokensViaTokenInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedMintPrintingTokensViaTokenInstructionArgs {
     pub mint_printing_tokens_via_token_args: MintPrintingTokensViaTokenArgs,
 }

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -71,7 +71,12 @@ impl DeprecatedSetReservationListInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeprecatedSetReservationListInstructionArgs {
     pub reservations: Vec<Reservation>,

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -71,13 +71,13 @@ impl DeprecatedSetReservationListInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedSetReservationListInstructionArgs {
     pub reservations: Vec<Reservation>,
     pub total_reservation_spots: Option<u64>,

--- a/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
+++ b/test/packages/rust/src/generated/instructions/deprecated_set_reservation_list.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::Reservation;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct DeprecatedSetReservationList {
@@ -60,7 +64,8 @@ impl DeprecatedSetReservationList {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DeprecatedSetReservationListInstructionData {
     discriminator: u8,
 }
@@ -72,11 +77,8 @@ impl DeprecatedSetReservationListInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeprecatedSetReservationListInstructionArgs {
     pub reservations: Vec<Reservation>,

--- a/test/packages/rust/src/generated/instructions/dummy.rs
+++ b/test/packages/rust/src/generated/instructions/dummy.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Dummy {
@@ -113,7 +117,8 @@ impl Dummy {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct DummyInstructionData {
     discriminator: [u8; 8],
 }

--- a/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/freeze_delegated_account.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct FreezeDelegatedAccount {
@@ -64,7 +68,8 @@ impl FreezeDelegatedAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct FreezeDelegatedAccountInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::CandyMachineData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Initialize {
@@ -104,7 +108,8 @@ impl Initialize {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct InitializeInstructionData {
     discriminator: [u8; 8],
 }
@@ -118,11 +123,8 @@ impl InitializeInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InitializeInstructionArgs {
     pub data: CandyMachineData,

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -117,7 +117,12 @@ impl InitializeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeInstructionArgs {
     pub data: CandyMachineData,

--- a/test/packages/rust/src/generated/instructions/initialize.rs
+++ b/test/packages/rust/src/generated/instructions/initialize.rs
@@ -117,13 +117,13 @@ impl InitializeInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InitializeInstructionArgs {
     pub data: CandyMachineData,
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::MigrateArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Migrate {
@@ -106,7 +110,8 @@ impl Migrate {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct MigrateInstructionData {
     discriminator: u8,
 }
@@ -118,11 +123,8 @@ impl MigrateInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MigrateInstructionArgs {
     pub migrate_args: MigrateArgs,

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -117,13 +117,13 @@ impl MigrateInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MigrateInstructionArgs {
     pub migrate_args: MigrateArgs,
 }

--- a/test/packages/rust/src/generated/instructions/migrate.rs
+++ b/test/packages/rust/src/generated/instructions/migrate.rs
@@ -117,7 +117,12 @@ impl MigrateInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MigrateInstructionArgs {
     pub migrate_args: MigrateArgs,

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -141,13 +141,13 @@ impl MintInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintInstructionArgs {
     pub mint_args: MintArgs,
 }

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -141,7 +141,12 @@ impl MintInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintInstructionArgs {
     pub mint_args: MintArgs,

--- a/test/packages/rust/src/generated/instructions/mint.rs
+++ b/test/packages/rust/src/generated/instructions/mint.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::MintArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Mint {
@@ -130,7 +134,8 @@ impl Mint {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct MintInstructionData {
     discriminator: u8,
 }
@@ -142,11 +147,8 @@ impl MintInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintInstructionArgs {
     pub mint_args: MintArgs,

--- a/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/mint_from_candy_machine.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct MintFromCandyMachine {
@@ -135,7 +139,8 @@ impl MintFromCandyMachine {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct MintFromCandyMachineInstructionData {
     discriminator: [u8; 8],
 }

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -142,13 +142,13 @@ impl MintNewEditionFromMasterEditionViaTokenInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:
         MintNewEditionFromMasterEditionViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -142,7 +142,12 @@ impl MintNewEditionFromMasterEditionViaTokenInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_token.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::MintNewEditionFromMasterEditionViaTokenArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct MintNewEditionFromMasterEditionViaToken {
@@ -131,7 +135,8 @@ impl MintNewEditionFromMasterEditionViaToken {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionData {
     discriminator: u8,
 }
@@ -143,11 +148,8 @@ impl MintNewEditionFromMasterEditionViaTokenInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintNewEditionFromMasterEditionViaTokenInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -159,7 +159,12 @@ impl MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::MintNewEditionFromMasterEditionViaTokenArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct MintNewEditionFromMasterEditionViaVaultProxy {
@@ -148,7 +152,8 @@ impl MintNewEditionFromMasterEditionViaVaultProxy {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
     discriminator: u8,
 }
@@ -160,11 +165,8 @@ impl MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:

--- a/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/test/packages/rust/src/generated/instructions/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -159,13 +159,13 @@ impl MintNewEditionFromMasterEditionViaVaultProxyInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintNewEditionFromMasterEditionViaVaultProxyInstructionArgs {
     pub mint_new_edition_from_master_edition_via_token_args:
         MintNewEditionFromMasterEditionViaTokenArgs,

--- a/test/packages/rust/src/generated/instructions/puff_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/puff_metadata.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct PuffMetadata {
@@ -39,7 +43,8 @@ impl PuffMetadata {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct PuffMetadataInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
+++ b/test/packages/rust/src/generated/instructions/remove_creator_verification.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct RemoveCreatorVerification {
@@ -47,7 +51,8 @@ impl RemoveCreatorVerification {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct RemoveCreatorVerificationInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -159,7 +159,12 @@ impl RevokeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RevokeInstructionArgs {
     pub revoke_args: RevokeArgs,

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -159,13 +159,13 @@ impl RevokeInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RevokeInstructionArgs {
     pub revoke_args: RevokeArgs,
 }

--- a/test/packages/rust/src/generated/instructions/revoke.rs
+++ b/test/packages/rust/src/generated/instructions/revoke.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::RevokeArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Revoke {
@@ -148,7 +152,8 @@ impl Revoke {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct RevokeInstructionData {
     discriminator: u8,
 }
@@ -160,11 +165,8 @@ impl RevokeInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RevokeInstructionArgs {
     pub revoke_args: RevokeArgs,

--- a/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_collection_authority.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct RevokeCollectionAuthority {
@@ -64,7 +68,8 @@ impl RevokeCollectionAuthority {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct RevokeCollectionAuthorityInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
+++ b/test/packages/rust/src/generated/instructions/revoke_use_authority.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct RevokeUseAuthority {
@@ -92,7 +96,8 @@ impl RevokeUseAuthority {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct RevokeUseAuthorityInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_collection.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SetAndVerifyCollection {
@@ -89,7 +93,8 @@ impl SetAndVerifyCollection {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetAndVerifyCollectionInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/set_and_verify_sized_collection_item.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SetAndVerifySizedCollectionItem {
@@ -89,7 +93,8 @@ impl SetAndVerifySizedCollectionItem {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetAndVerifySizedCollectionItemInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// Accounts.
@@ -51,7 +55,8 @@ impl SetAuthority {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetAuthorityInstructionData {
     discriminator: [u8; 8],
 }
@@ -65,11 +70,8 @@ impl SetAuthorityInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetAuthorityInstructionArgs {
     pub new_authority: Pubkey,

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -64,7 +64,12 @@ impl SetAuthorityInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAuthorityInstructionArgs {
     pub new_authority: Pubkey,

--- a/test/packages/rust/src/generated/instructions/set_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_authority.rs
@@ -64,13 +64,13 @@ impl SetAuthorityInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetAuthorityInstructionArgs {
     pub new_authority: Pubkey,
 }

--- a/test/packages/rust/src/generated/instructions/set_collection.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SetCollection {
@@ -115,7 +119,8 @@ impl SetCollection {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetCollectionInstructionData {
     discriminator: [u8; 8],
 }

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -84,7 +84,12 @@ impl SetCollectionSizeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::SetCollectionSizeArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SetCollectionSize {
@@ -73,7 +77,8 @@ impl SetCollectionSize {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetCollectionSizeInstructionData {
     discriminator: u8,
 }
@@ -85,11 +90,8 @@ impl SetCollectionSizeInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,

--- a/test/packages/rust/src/generated/instructions/set_collection_size.rs
+++ b/test/packages/rust/src/generated/instructions/set_collection_size.rs
@@ -84,13 +84,13 @@ impl SetCollectionSizeInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetCollectionSizeInstructionArgs {
     pub set_collection_size_args: SetCollectionSizeArgs,
 }

--- a/test/packages/rust/src/generated/instructions/set_mint_authority.rs
+++ b/test/packages/rust/src/generated/instructions/set_mint_authority.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SetMintAuthority {
@@ -50,7 +54,8 @@ impl SetMintAuthority {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetMintAuthorityInstructionData {
     discriminator: [u8; 8],
 }

--- a/test/packages/rust/src/generated/instructions/set_token_standard.rs
+++ b/test/packages/rust/src/generated/instructions/set_token_standard.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SetTokenStandard {
@@ -62,7 +66,8 @@ impl SetTokenStandard {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SetTokenStandardInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/sign_metadata.rs
+++ b/test/packages/rust/src/generated/instructions/sign_metadata.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct SignMetadata {
@@ -45,7 +49,8 @@ impl SignMetadata {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct SignMetadataInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
+++ b/test/packages/rust/src/generated/instructions/thaw_delegated_account.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct ThawDelegatedAccount {
@@ -64,7 +68,8 @@ impl ThawDelegatedAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct ThawDelegatedAccountInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::TransferArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Transfer {
@@ -156,7 +160,8 @@ impl Transfer {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct TransferInstructionData {
     discriminator: u8,
 }
@@ -168,11 +173,8 @@ impl TransferInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferInstructionArgs {
     pub transfer_args: TransferArgs,

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -167,13 +167,13 @@ impl TransferInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferInstructionArgs {
     pub transfer_args: TransferArgs,
 }

--- a/test/packages/rust/src/generated/instructions/transfer.rs
+++ b/test/packages/rust/src/generated/instructions/transfer.rs
@@ -167,7 +167,12 @@ impl TransferInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferInstructionArgs {
     pub transfer_args: TransferArgs,

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -135,13 +135,13 @@ impl TransferOutOfEscrowInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferOutOfEscrowInstructionArgs {
     pub amount: u64,
 }

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -135,7 +135,12 @@ impl TransferOutOfEscrowInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferOutOfEscrowInstructionArgs {
     pub amount: u64,

--- a/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_out_of_escrow.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct TransferOutOfEscrow {
@@ -124,7 +128,8 @@ impl TransferOutOfEscrow {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct TransferOutOfEscrowInstructionData {
     discriminator: u8,
 }
@@ -136,11 +141,8 @@ impl TransferOutOfEscrowInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferOutOfEscrowInstructionArgs {
     pub amount: u64,

--- a/test/packages/rust/src/generated/instructions/transfer_sol.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_sol.rs
@@ -61,13 +61,13 @@ impl TransferSolInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferSolInstructionArgs {
     pub amount: u64,
 }

--- a/test/packages/rust/src/generated/instructions/transfer_sol.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_sol.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct TransferSol {
@@ -50,7 +54,8 @@ impl TransferSol {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct TransferSolInstructionData {
     discriminator: u32,
 }
@@ -62,11 +67,8 @@ impl TransferSolInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransferSolInstructionArgs {
     pub amount: u64,

--- a/test/packages/rust/src/generated/instructions/transfer_sol.rs
+++ b/test/packages/rust/src/generated/instructions/transfer_sol.rs
@@ -61,7 +61,12 @@ impl TransferSolInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransferSolInstructionArgs {
     pub amount: u64,

--- a/test/packages/rust/src/generated/instructions/unverify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_collection.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct UnverifyCollection {
@@ -78,7 +82,8 @@ impl UnverifyCollection {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UnverifyCollectionInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/unverify_sized_collection_item.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct UnverifySizedCollectionItem {
@@ -83,7 +87,8 @@ impl UnverifySizedCollectionItem {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UnverifySizedCollectionItemInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -66,7 +66,12 @@ impl UpdateCandyMachineInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateCandyMachineInstructionArgs {
     pub data: CandyMachineData,

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -66,13 +66,13 @@ impl UpdateCandyMachineInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateCandyMachineInstructionArgs {
     pub data: CandyMachineData,
 }

--- a/test/packages/rust/src/generated/instructions/update_candy_machine.rs
+++ b/test/packages/rust/src/generated/instructions/update_candy_machine.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::CandyMachineData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct UpdateCandyMachine {
@@ -53,7 +57,8 @@ impl UpdateCandyMachine {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UpdateCandyMachineInstructionData {
     discriminator: [u8; 8],
 }
@@ -67,11 +72,8 @@ impl UpdateCandyMachineInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateCandyMachineInstructionArgs {
     pub data: CandyMachineData,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -66,7 +66,12 @@ impl UpdateMetadataAccountInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateMetadataAccountInstructionArgs {
     pub data: Option<UpdateMetadataAccountInstructionDataData>,
@@ -74,7 +79,12 @@ pub struct UpdateMetadataAccountInstructionArgs {
     pub primary_sale_happened: Option<bool>,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateMetadataAccountInstructionDataData {
     pub name: String,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -66,26 +66,26 @@ impl UpdateMetadataAccountInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateMetadataAccountInstructionArgs {
     pub data: Option<UpdateMetadataAccountInstructionDataData>,
     pub update_authority_arg: Option<Pubkey>,
     pub primary_sale_happened: Option<bool>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateMetadataAccountInstructionDataData {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::Creator;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// Accounts.
@@ -55,7 +59,8 @@ impl UpdateMetadataAccount {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UpdateMetadataAccountInstructionData {
     discriminator: u8,
 }
@@ -67,11 +72,8 @@ impl UpdateMetadataAccountInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateMetadataAccountInstructionArgs {
     pub data: Option<UpdateMetadataAccountInstructionDataData>,
@@ -80,11 +82,8 @@ pub struct UpdateMetadataAccountInstructionArgs {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateMetadataAccountInstructionDataData {
     pub name: String,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -66,7 +66,12 @@ impl UpdateMetadataAccountV2InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateMetadataAccountV2InstructionArgs {
     pub data: Option<DataV2>,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::DataV2;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// Accounts.
@@ -55,7 +59,8 @@ impl UpdateMetadataAccountV2 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UpdateMetadataAccountV2InstructionData {
     discriminator: u8,
 }
@@ -67,11 +72,8 @@ impl UpdateMetadataAccountV2InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateMetadataAccountV2InstructionArgs {
     pub data: Option<DataV2>,

--- a/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
+++ b/test/packages/rust/src/generated/instructions/update_metadata_account_v2.rs
@@ -66,13 +66,13 @@ impl UpdateMetadataAccountV2InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateMetadataAccountV2InstructionArgs {
     pub data: Option<DataV2>,
     pub update_authority_arg: Option<Pubkey>,

--- a/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
+++ b/test/packages/rust/src/generated/instructions/update_primary_sale_happened_via_token.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct UpdatePrimarySaleHappenedViaToken {
@@ -51,7 +55,8 @@ impl UpdatePrimarySaleHappenedViaToken {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UpdatePrimarySaleHappenedViaTokenInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -14,8 +14,12 @@ use crate::generated::types::DelegateState;
 use crate::generated::types::ProgrammableConfig;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// Accounts.
@@ -142,7 +146,8 @@ impl UpdateV1 {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UpdateV1InstructionData {
     discriminator: u8,
     update_v1_discriminator: u8,
@@ -158,11 +163,8 @@ impl UpdateV1InstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateV1InstructionArgs {
     pub authorization_data: Option<AuthorizationData>,
@@ -180,11 +182,8 @@ pub struct UpdateV1InstructionArgs {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateV1InstructionDataData {
     pub name: String,

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -157,7 +157,12 @@ impl UpdateV1InstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateV1InstructionArgs {
     pub authorization_data: Option<AuthorizationData>,
@@ -174,7 +179,12 @@ pub struct UpdateV1InstructionArgs {
     pub authority_type: AuthorityType,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateV1InstructionDataData {
     pub name: String,

--- a/test/packages/rust/src/generated/instructions/update_v1.rs
+++ b/test/packages/rust/src/generated/instructions/update_v1.rs
@@ -157,13 +157,13 @@ impl UpdateV1InstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateV1InstructionArgs {
     pub authorization_data: Option<AuthorizationData>,
     pub new_update_authority: Option<Pubkey>,
@@ -179,13 +179,13 @@ pub struct UpdateV1InstructionArgs {
     pub authority_type: AuthorityType,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateV1InstructionDataData {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::UseAssetArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct UseAsset {
@@ -125,7 +129,8 @@ impl UseAsset {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UseAssetInstructionData {
     discriminator: u8,
 }
@@ -137,11 +142,8 @@ impl UseAssetInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UseAssetInstructionArgs {
     pub use_asset_args: UseAssetArgs,

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -136,13 +136,13 @@ impl UseAssetInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UseAssetInstructionArgs {
     pub use_asset_args: UseAssetArgs,
 }

--- a/test/packages/rust/src/generated/instructions/use_asset.rs
+++ b/test/packages/rust/src/generated/instructions/use_asset.rs
@@ -136,7 +136,12 @@ impl UseAssetInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseAssetInstructionArgs {
     pub use_asset_args: UseAssetArgs,

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -126,7 +126,12 @@ impl UtilizeInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UtilizeInstructionArgs {
     pub number_of_uses: u64,

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -126,13 +126,13 @@ impl UtilizeInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UtilizeInstructionArgs {
     pub number_of_uses: u64,
 }

--- a/test/packages/rust/src/generated/instructions/utilize.rs
+++ b/test/packages/rust/src/generated/instructions/utilize.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Utilize {
@@ -115,7 +119,8 @@ impl Utilize {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct UtilizeInstructionData {
     discriminator: u8,
 }
@@ -127,11 +132,8 @@ impl UtilizeInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UtilizeInstructionArgs {
     pub number_of_uses: u64,

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -7,8 +7,12 @@
 
 use crate::generated::types::Operation;
 use crate::generated::types::Payload;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Validate {
@@ -138,7 +142,8 @@ impl Validate {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct ValidateInstructionData {
     discriminator: u8,
 }
@@ -150,11 +155,8 @@ impl ValidateInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValidateInstructionArgs {
     pub rule_set_name: String,

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -149,13 +149,13 @@ impl ValidateInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValidateInstructionArgs {
     pub rule_set_name: String,
     pub operation: Operation,

--- a/test/packages/rust/src/generated/instructions/validate.rs
+++ b/test/packages/rust/src/generated/instructions/validate.rs
@@ -149,7 +149,12 @@ impl ValidateInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidateInstructionArgs {
     pub rule_set_name: String,

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -6,8 +6,12 @@
 //!
 
 use crate::generated::types::VerifyArgs;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Verify {
@@ -83,7 +87,8 @@ impl Verify {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct VerifyInstructionData {
     discriminator: u8,
 }
@@ -95,11 +100,8 @@ impl VerifyInstructionData {
 }
 
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifyInstructionArgs {
     pub verify_args: VerifyArgs,

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -94,7 +94,12 @@ impl VerifyInstructionData {
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerifyInstructionArgs {
     pub verify_args: VerifyArgs,

--- a/test/packages/rust/src/generated/instructions/verify.rs
+++ b/test/packages/rust/src/generated/instructions/verify.rs
@@ -94,13 +94,13 @@ impl VerifyInstructionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifyInstructionArgs {
     pub verify_args: VerifyArgs,
 }

--- a/test/packages/rust/src/generated/instructions/verify_collection.rs
+++ b/test/packages/rust/src/generated/instructions/verify_collection.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct VerifyCollection {
@@ -68,7 +72,8 @@ impl VerifyCollection {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct VerifyCollectionInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
+++ b/test/packages/rust/src/generated/instructions/verify_sized_collection_item.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct VerifySizedCollectionItem {
@@ -83,7 +87,8 @@ impl VerifySizedCollectionItem {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct VerifySizedCollectionItemInstructionData {
     discriminator: u8,
 }

--- a/test/packages/rust/src/generated/instructions/withdraw.rs
+++ b/test/packages/rust/src/generated/instructions/withdraw.rs
@@ -5,8 +5,12 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Accounts.
 pub struct Withdraw {
@@ -44,7 +48,8 @@ impl Withdraw {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 pub struct WithdrawInstructionData {
     discriminator: [u8; 8],
 }

--- a/test/packages/rust/src/generated/programs.rs
+++ b/test/packages/rust/src/generated/programs.rs
@@ -18,7 +18,7 @@ pub const MPL_TOKEN_AUTH_RULES_ID: Pubkey = pubkey!("auth9SigNpDKz4sJJ1DfCTuZrZN
 pub const MPL_TOKEN_METADATA_ID: Pubkey = pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
 
 /// `pubkey_tests` program ID.
-pub const PUBKEY_TESTS_ID: Pubkey = pubkey!("PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d");
+pub const PUBKEY_TESTS_ID: Pubkey = pubkey!("PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7");
 
 /// `spl_memo` program ID.
 pub const SPL_MEMO_ID: Pubkey = pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr");

--- a/test/packages/rust/src/generated/types/asset_data.rs
+++ b/test/packages/rust/src/generated/types/asset_data.rs
@@ -12,17 +12,17 @@ use crate::generated::types::DelegateState;
 use crate::generated::types::ProgrammableConfig;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetData {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/asset_data.rs
+++ b/test/packages/rust/src/generated/types/asset_data.rs
@@ -15,6 +15,7 @@ use crate::generated::types::Uses;
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/asset_data.rs
+++ b/test/packages/rust/src/generated/types/asset_data.rs
@@ -14,7 +14,6 @@ use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -24,6 +23,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetData {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/asset_data.rs
+++ b/test/packages/rust/src/generated/types/asset_data.rs
@@ -12,12 +12,17 @@ use crate::generated::types::DelegateState;
 use crate::generated::types::ProgrammableConfig;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct AssetData {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/authority_type.rs
+++ b/test/packages/rust/src/generated/types/authority_type.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum AuthorityType {
     Metadata,
     Delegate,

--- a/test/packages/rust/src/generated/types/authority_type.rs
+++ b/test/packages/rust/src/generated/types/authority_type.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/authority_type.rs
+++ b/test/packages/rust/src/generated/types/authority_type.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum AuthorityType {
     Metadata,
     Delegate,

--- a/test/packages/rust/src/generated/types/authority_type.rs
+++ b/test/packages/rust/src/generated/types/authority_type.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum AuthorityType {
     Metadata,

--- a/test/packages/rust/src/generated/types/authorization_data.rs
+++ b/test/packages/rust/src/generated/types/authorization_data.rs
@@ -6,11 +6,16 @@
 //!
 
 use crate::generated::types::Payload;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct AuthorizationData {
     pub payload: Payload,
 }

--- a/test/packages/rust/src/generated/types/authorization_data.rs
+++ b/test/packages/rust/src/generated/types/authorization_data.rs
@@ -6,16 +6,16 @@
 //!
 
 use crate::generated::types::Payload;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuthorizationData {
     pub payload: Payload,

--- a/test/packages/rust/src/generated/types/authorization_data.rs
+++ b/test/packages/rust/src/generated/types/authorization_data.rs
@@ -8,6 +8,7 @@
 use crate::generated::types::Payload;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/authorization_data.rs
+++ b/test/packages/rust/src/generated/types/authorization_data.rs
@@ -7,7 +7,6 @@
 
 use crate::generated::types::Payload;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use crate::generated::types::Payload;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuthorizationData {
     pub payload: Payload,
 }

--- a/test/packages/rust/src/generated/types/burn_args.rs
+++ b/test/packages/rust/src/generated/types/burn_args.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/burn_args.rs
+++ b/test/packages/rust/src/generated/types/burn_args.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum BurnArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/burn_args.rs
+++ b/test/packages/rust/src/generated/types/burn_args.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum BurnArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/burn_args.rs
+++ b/test/packages/rust/src/generated/types/burn_args.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum BurnArgs {
     V1,

--- a/test/packages/rust/src/generated/types/candy_machine_data.rs
+++ b/test/packages/rust/src/generated/types/candy_machine_data.rs
@@ -8,17 +8,17 @@
 use crate::generated::types::CmCreator;
 use crate::generated::types::ConfigLineSettings;
 use crate::generated::types::HiddenSettings;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Candy machine configuration data.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandyMachineData {
     /// Number of assets available

--- a/test/packages/rust/src/generated/types/candy_machine_data.rs
+++ b/test/packages/rust/src/generated/types/candy_machine_data.rs
@@ -11,6 +11,7 @@ use crate::generated::types::HiddenSettings;
 
 /// Candy machine configuration data.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/candy_machine_data.rs
+++ b/test/packages/rust/src/generated/types/candy_machine_data.rs
@@ -10,7 +10,6 @@ use crate::generated::types::ConfigLineSettings;
 use crate::generated::types::HiddenSettings;
 
 /// Candy machine configuration data.
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -20,6 +19,7 @@ use crate::generated::types::HiddenSettings;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CandyMachineData {
     /// Number of assets available
     pub items_available: u64,

--- a/test/packages/rust/src/generated/types/candy_machine_data.rs
+++ b/test/packages/rust/src/generated/types/candy_machine_data.rs
@@ -8,12 +8,17 @@
 use crate::generated::types::CmCreator;
 use crate::generated::types::ConfigLineSettings;
 use crate::generated::types::HiddenSettings;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
 /// Candy machine configuration data.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct CandyMachineData {
     /// Number of assets available
     pub items_available: u64,

--- a/test/packages/rust/src/generated/types/cm_creator.rs
+++ b/test/packages/rust/src/generated/types/cm_creator.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CmCreator {
     /// Pubkey address

--- a/test/packages/rust/src/generated/types/cm_creator.rs
+++ b/test/packages/rust/src/generated/types/cm_creator.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CmCreator {
     /// Pubkey address
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/cm_creator.rs
+++ b/test/packages/rust/src/generated/types/cm_creator.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct CmCreator {
     /// Pubkey address
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/cm_creator.rs
+++ b/test/packages/rust/src/generated/types/cm_creator.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/collection.rs
+++ b/test/packages/rust/src/generated/types/collection.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Collection {
     pub verified: bool,

--- a/test/packages/rust/src/generated/types/collection.rs
+++ b/test/packages/rust/src/generated/types/collection.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Collection {
     pub verified: bool,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/collection.rs
+++ b/test/packages/rust/src/generated/types/collection.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Collection {
     pub verified: bool,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/collection.rs
+++ b/test/packages/rust/src/generated/types/collection.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/collection_details.rs
+++ b/test/packages/rust/src/generated/types/collection_details.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CollectionDetails {
     V1 { size: u64 },
 }

--- a/test/packages/rust/src/generated/types/collection_details.rs
+++ b/test/packages/rust/src/generated/types/collection_details.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum CollectionDetails {
     V1 { size: u64 },
 }

--- a/test/packages/rust/src/generated/types/collection_details.rs
+++ b/test/packages/rust/src/generated/types/collection_details.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CollectionDetails {
     V1 { size: u64 },

--- a/test/packages/rust/src/generated/types/collection_details.rs
+++ b/test/packages/rust/src/generated/types/collection_details.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/config_line.rs
+++ b/test/packages/rust/src/generated/types/config_line.rs
@@ -7,6 +7,7 @@
 
 /// Config line struct for storing asset (NFT) data pre-mint.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/config_line.rs
+++ b/test/packages/rust/src/generated/types/config_line.rs
@@ -5,16 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Config line struct for storing asset (NFT) data pre-mint.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConfigLine {
     /// Name of the asset.

--- a/test/packages/rust/src/generated/types/config_line.rs
+++ b/test/packages/rust/src/generated/types/config_line.rs
@@ -6,7 +6,6 @@
 //!
 
 /// Config line struct for storing asset (NFT) data pre-mint.
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -16,6 +15,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConfigLine {
     /// Name of the asset.
     pub name: String,

--- a/test/packages/rust/src/generated/types/config_line.rs
+++ b/test/packages/rust/src/generated/types/config_line.rs
@@ -5,12 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
 /// Config line struct for storing asset (NFT) data pre-mint.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ConfigLine {
     /// Name of the asset.
     pub name: String,

--- a/test/packages/rust/src/generated/types/config_line_settings.rs
+++ b/test/packages/rust/src/generated/types/config_line_settings.rs
@@ -7,6 +7,7 @@
 
 /// Config line settings to allocate space for individual name + URI.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/config_line_settings.rs
+++ b/test/packages/rust/src/generated/types/config_line_settings.rs
@@ -5,16 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Config line settings to allocate space for individual name + URI.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConfigLineSettings {
     /// Common name prefix

--- a/test/packages/rust/src/generated/types/config_line_settings.rs
+++ b/test/packages/rust/src/generated/types/config_line_settings.rs
@@ -6,7 +6,6 @@
 //!
 
 /// Config line settings to allocate space for individual name + URI.
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -16,6 +15,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConfigLineSettings {
     /// Common name prefix
     pub prefix_name: String,

--- a/test/packages/rust/src/generated/types/config_line_settings.rs
+++ b/test/packages/rust/src/generated/types/config_line_settings.rs
@@ -5,12 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
 /// Config line settings to allocate space for individual name + URI.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ConfigLineSettings {
     /// Common name prefix
     pub prefix_name: String,

--- a/test/packages/rust/src/generated/types/create_master_edition_args.rs
+++ b/test/packages/rust/src/generated/types/create_master_edition_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMasterEditionArgs {
     pub max_supply: Option<u64>,

--- a/test/packages/rust/src/generated/types/create_master_edition_args.rs
+++ b/test/packages/rust/src/generated/types/create_master_edition_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CreateMasterEditionArgs {
     pub max_supply: Option<u64>,
 }

--- a/test/packages/rust/src/generated/types/create_master_edition_args.rs
+++ b/test/packages/rust/src/generated/types/create_master_edition_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct CreateMasterEditionArgs {
     pub max_supply: Option<u64>,
 }

--- a/test/packages/rust/src/generated/types/create_master_edition_args.rs
+++ b/test/packages/rust/src/generated/types/create_master_edition_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/creator.rs
+++ b/test/packages/rust/src/generated/types/creator.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Creator {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/creator.rs
+++ b/test/packages/rust/src/generated/types/creator.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Creator {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/creator.rs
+++ b/test/packages/rust/src/generated/types/creator.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/creator.rs
+++ b/test/packages/rust/src/generated/types/creator.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Creator {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/data_v2.rs
+++ b/test/packages/rust/src/generated/types/data_v2.rs
@@ -10,6 +10,7 @@ use crate::generated::types::Creator;
 use crate::generated::types::Uses;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/data_v2.rs
+++ b/test/packages/rust/src/generated/types/data_v2.rs
@@ -9,7 +9,6 @@ use crate::generated::types::Collection;
 use crate::generated::types::Creator;
 use crate::generated::types::Uses;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -19,6 +18,7 @@ use crate::generated::types::Uses;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DataV2 {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/data_v2.rs
+++ b/test/packages/rust/src/generated/types/data_v2.rs
@@ -8,11 +8,16 @@
 use crate::generated::types::Collection;
 use crate::generated::types::Creator;
 use crate::generated::types::Uses;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct DataV2 {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/data_v2.rs
+++ b/test/packages/rust/src/generated/types/data_v2.rs
@@ -8,16 +8,16 @@
 use crate::generated::types::Collection;
 use crate::generated::types::Creator;
 use crate::generated::types::Uses;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DataV2 {
     pub name: String,

--- a/test/packages/rust/src/generated/types/delegate_args.rs
+++ b/test/packages/rust/src/generated/types/delegate_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DelegateArgs {
     CollectionV1,

--- a/test/packages/rust/src/generated/types/delegate_args.rs
+++ b/test/packages/rust/src/generated/types/delegate_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DelegateArgs {
     CollectionV1,
     SaleV1 { amount: u64 },

--- a/test/packages/rust/src/generated/types/delegate_args.rs
+++ b/test/packages/rust/src/generated/types/delegate_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum DelegateArgs {
     CollectionV1,
     SaleV1 { amount: u64 },

--- a/test/packages/rust/src/generated/types/delegate_args.rs
+++ b/test/packages/rust/src/generated/types/delegate_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/delegate_role.rs
+++ b/test/packages/rust/src/generated/types/delegate_role.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum DelegateRole {
     Authority,

--- a/test/packages/rust/src/generated/types/delegate_role.rs
+++ b/test/packages/rust/src/generated/types/delegate_role.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum DelegateRole {
     Authority,
     Collection,

--- a/test/packages/rust/src/generated/types/delegate_role.rs
+++ b/test/packages/rust/src/generated/types/delegate_role.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/delegate_role.rs
+++ b/test/packages/rust/src/generated/types/delegate_role.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum DelegateRole {
     Authority,
     Collection,

--- a/test/packages/rust/src/generated/types/delegate_state.rs
+++ b/test/packages/rust/src/generated/types/delegate_state.rs
@@ -9,6 +9,7 @@ use crate::generated::types::DelegateRole;
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/delegate_state.rs
+++ b/test/packages/rust/src/generated/types/delegate_state.rs
@@ -6,17 +6,17 @@
 //!
 
 use crate::generated::types::DelegateRole;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelegateState {
     pub role: DelegateRole,

--- a/test/packages/rust/src/generated/types/delegate_state.rs
+++ b/test/packages/rust/src/generated/types/delegate_state.rs
@@ -8,7 +8,6 @@
 use crate::generated::types::DelegateRole;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -18,6 +17,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DelegateState {
     pub role: DelegateRole,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/delegate_state.rs
+++ b/test/packages/rust/src/generated/types/delegate_state.rs
@@ -6,12 +6,17 @@
 //!
 
 use crate::generated::types::DelegateRole;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct DelegateState {
     pub role: DelegateRole,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/dummy_lines.rs
+++ b/test/packages/rust/src/generated/types/dummy_lines.rs
@@ -9,6 +9,7 @@ use kaigan::types::RemainderVec;
 
 /// Dummy lines.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/dummy_lines.rs
+++ b/test/packages/rust/src/generated/types/dummy_lines.rs
@@ -5,18 +5,18 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaigan::types::RemainderVec;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Dummy lines.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DummyLines {
     /// The dummy lines.

--- a/test/packages/rust/src/generated/types/dummy_lines.rs
+++ b/test/packages/rust/src/generated/types/dummy_lines.rs
@@ -8,7 +8,6 @@
 use kaigan::types::RemainderVec;
 
 /// Dummy lines.
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -18,6 +17,7 @@ use kaigan::types::RemainderVec;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DummyLines {
     /// The dummy lines.
     pub lines: RemainderVec<u64>,

--- a/test/packages/rust/src/generated/types/dummy_lines.rs
+++ b/test/packages/rust/src/generated/types/dummy_lines.rs
@@ -5,13 +5,18 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use kaigan::types::RemainderVec;
 
 /// Dummy lines.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct DummyLines {
     /// The dummy lines.
     pub lines: RemainderVec<u64>,

--- a/test/packages/rust/src/generated/types/escrow_authority.rs
+++ b/test/packages/rust/src/generated/types/escrow_authority.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EscrowAuthority {
     TokenOwner,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/escrow_authority.rs
+++ b/test/packages/rust/src/generated/types/escrow_authority.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EscrowAuthority {
     TokenOwner,

--- a/test/packages/rust/src/generated/types/escrow_authority.rs
+++ b/test/packages/rust/src/generated/types/escrow_authority.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/escrow_authority.rs
+++ b/test/packages/rust/src/generated/types/escrow_authority.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum EscrowAuthority {
     TokenOwner,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/extended_payload.rs
+++ b/test/packages/rust/src/generated/types/extended_payload.rs
@@ -10,6 +10,7 @@ use crate::generated::types::PayloadType;
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/extended_payload.rs
+++ b/test/packages/rust/src/generated/types/extended_payload.rs
@@ -7,17 +7,17 @@
 
 use crate::generated::types::PayloadKey;
 use crate::generated::types::PayloadType;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExtendedPayload {
     pub map: HashMap<PayloadKey, PayloadType>,

--- a/test/packages/rust/src/generated/types/extended_payload.rs
+++ b/test/packages/rust/src/generated/types/extended_payload.rs
@@ -7,12 +7,17 @@
 
 use crate::generated::types::PayloadKey;
 use crate::generated::types::PayloadType;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use std::collections::HashMap;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ExtendedPayload {
     pub map: HashMap<PayloadKey, PayloadType>,
     pub args: (u8, String),

--- a/test/packages/rust/src/generated/types/extended_payload.rs
+++ b/test/packages/rust/src/generated/types/extended_payload.rs
@@ -9,7 +9,6 @@ use crate::generated::types::PayloadKey;
 use crate::generated::types::PayloadType;
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -19,6 +18,7 @@ use std::collections::HashMap;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExtendedPayload {
     pub map: HashMap<PayloadKey, PayloadType>,
     pub args: (u8, String),

--- a/test/packages/rust/src/generated/types/hidden_settings.rs
+++ b/test/packages/rust/src/generated/types/hidden_settings.rs
@@ -7,6 +7,7 @@
 
 /// Hidden settings for large mints used with off-chain data.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/hidden_settings.rs
+++ b/test/packages/rust/src/generated/types/hidden_settings.rs
@@ -5,16 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Hidden settings for large mints used with off-chain data.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HiddenSettings {
     /// Asset prefix name

--- a/test/packages/rust/src/generated/types/hidden_settings.rs
+++ b/test/packages/rust/src/generated/types/hidden_settings.rs
@@ -5,12 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
 /// Hidden settings for large mints used with off-chain data.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct HiddenSettings {
     /// Asset prefix name
     pub name: String,

--- a/test/packages/rust/src/generated/types/hidden_settings.rs
+++ b/test/packages/rust/src/generated/types/hidden_settings.rs
@@ -6,7 +6,6 @@
 //!
 
 /// Hidden settings for large mints used with off-chain data.
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -16,6 +15,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HiddenSettings {
     /// Asset prefix name
     pub name: String,

--- a/test/packages/rust/src/generated/types/migrate_args.rs
+++ b/test/packages/rust/src/generated/types/migrate_args.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/migrate_args.rs
+++ b/test/packages/rust/src/generated/types/migrate_args.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum MigrateArgs {
     V1,

--- a/test/packages/rust/src/generated/types/migrate_args.rs
+++ b/test/packages/rust/src/generated/types/migrate_args.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum MigrateArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/migrate_args.rs
+++ b/test/packages/rust/src/generated/types/migrate_args.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum MigrateArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/mint_args.rs
+++ b/test/packages/rust/src/generated/types/mint_args.rs
@@ -6,16 +6,16 @@
 //!
 
 use crate::generated::types::AuthorizationData;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MintArgs {
     V1 {

--- a/test/packages/rust/src/generated/types/mint_args.rs
+++ b/test/packages/rust/src/generated/types/mint_args.rs
@@ -6,11 +6,16 @@
 //!
 
 use crate::generated::types::AuthorizationData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum MintArgs {
     V1 {
         amount: u64,

--- a/test/packages/rust/src/generated/types/mint_args.rs
+++ b/test/packages/rust/src/generated/types/mint_args.rs
@@ -7,7 +7,6 @@
 
 use crate::generated::types::AuthorizationData;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use crate::generated::types::AuthorizationData;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MintArgs {
     V1 {
         amount: u64,

--- a/test/packages/rust/src/generated/types/mint_args.rs
+++ b/test/packages/rust/src/generated/types/mint_args.rs
@@ -8,6 +8,7 @@
 use crate::generated::types::AuthorizationData;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintNewEditionFromMasterEditionViaTokenArgs {
     pub edition: u64,

--- a/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintNewEditionFromMasterEditionViaTokenArgs {
     pub edition: u64,
 }

--- a/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct MintNewEditionFromMasterEditionViaTokenArgs {
     pub edition: u64,
 }

--- a/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_new_edition_from_master_edition_via_token_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintPrintingTokensViaTokenArgs {
     pub supply: u64,
 }

--- a/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct MintPrintingTokensViaTokenArgs {
     pub supply: u64,
 }

--- a/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MintPrintingTokensViaTokenArgs {
     pub supply: u64,

--- a/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
+++ b/test/packages/rust/src/generated/types/mint_printing_tokens_via_token_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/operation.rs
+++ b/test/packages/rust/src/generated/types/operation.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum Operation {
     Transfer,
     Delegate,

--- a/test/packages/rust/src/generated/types/operation.rs
+++ b/test/packages/rust/src/generated/types/operation.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/operation.rs
+++ b/test/packages/rust/src/generated/types/operation.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum Operation {
     Transfer,

--- a/test/packages/rust/src/generated/types/operation.rs
+++ b/test/packages/rust/src/generated/types/operation.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum Operation {
     Transfer,
     Delegate,

--- a/test/packages/rust/src/generated/types/payload.rs
+++ b/test/packages/rust/src/generated/types/payload.rs
@@ -10,6 +10,7 @@ use crate::generated::types::PayloadType;
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/payload.rs
+++ b/test/packages/rust/src/generated/types/payload.rs
@@ -7,12 +7,17 @@
 
 use crate::generated::types::PayloadKey;
 use crate::generated::types::PayloadType;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use std::collections::HashMap;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Payload {
     pub map: HashMap<PayloadKey, PayloadType>,
 }

--- a/test/packages/rust/src/generated/types/payload.rs
+++ b/test/packages/rust/src/generated/types/payload.rs
@@ -7,17 +7,17 @@
 
 use crate::generated::types::PayloadKey;
 use crate::generated::types::PayloadType;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Payload {
     pub map: HashMap<PayloadKey, PayloadType>,

--- a/test/packages/rust/src/generated/types/payload.rs
+++ b/test/packages/rust/src/generated/types/payload.rs
@@ -9,7 +9,6 @@ use crate::generated::types::PayloadKey;
 use crate::generated::types::PayloadType;
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -19,6 +18,7 @@ use std::collections::HashMap;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Payload {
     pub map: HashMap<PayloadKey, PayloadType>,
 }

--- a/test/packages/rust/src/generated/types/payload_key.rs
+++ b/test/packages/rust/src/generated/types/payload_key.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum PayloadKey {
     Target,
     Holder,

--- a/test/packages/rust/src/generated/types/payload_key.rs
+++ b/test/packages/rust/src/generated/types/payload_key.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/payload_key.rs
+++ b/test/packages/rust/src/generated/types/payload_key.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum PayloadKey {
     Target,
     Holder,

--- a/test/packages/rust/src/generated/types/payload_key.rs
+++ b/test/packages/rust/src/generated/types/payload_key.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum PayloadKey {
     Target,

--- a/test/packages/rust/src/generated/types/payload_type.rs
+++ b/test/packages/rust/src/generated/types/payload_type.rs
@@ -5,18 +5,18 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
 /// This is a union of all the possible payload types.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PayloadType {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/payload_type.rs
+++ b/test/packages/rust/src/generated/types/payload_type.rs
@@ -9,6 +9,7 @@ use solana_program::pubkey::Pubkey;
 
 /// This is a union of all the possible payload types.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/payload_type.rs
+++ b/test/packages/rust/src/generated/types/payload_type.rs
@@ -8,7 +8,6 @@
 use solana_program::pubkey::Pubkey;
 
 /// This is a union of all the possible payload types.
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -18,6 +17,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PayloadType {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/payload_type.rs
+++ b/test/packages/rust/src/generated/types/payload_type.rs
@@ -5,13 +5,18 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
 /// This is a union of all the possible payload types.
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum PayloadType {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/programmable_config.rs
+++ b/test/packages/rust/src/generated/types/programmable_config.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ProgrammableConfig {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/programmable_config.rs
+++ b/test/packages/rust/src/generated/types/programmable_config.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgrammableConfig {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/programmable_config.rs
+++ b/test/packages/rust/src/generated/types/programmable_config.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProgrammableConfig {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/programmable_config.rs
+++ b/test/packages/rust/src/generated/types/programmable_config.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/reservation.rs
+++ b/test/packages/rust/src/generated/types/reservation.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Reservation {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/reservation.rs
+++ b/test/packages/rust/src/generated/types/reservation.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Reservation {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/reservation.rs
+++ b/test/packages/rust/src/generated/types/reservation.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Reservation {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/reservation.rs
+++ b/test/packages/rust/src/generated/types/reservation.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/reservation_v1.rs
+++ b/test/packages/rust/src/generated/types/reservation_v1.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReservationV1 {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/reservation_v1.rs
+++ b/test/packages/rust/src/generated/types/reservation_v1.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReservationV1 {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/reservation_v1.rs
+++ b/test/packages/rust/src/generated/types/reservation_v1.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct ReservationV1 {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/reservation_v1.rs
+++ b/test/packages/rust/src/generated/types/reservation_v1.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/revoke_args.rs
+++ b/test/packages/rust/src/generated/types/revoke_args.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum RevokeArgs {
     CollectionV1,

--- a/test/packages/rust/src/generated/types/revoke_args.rs
+++ b/test/packages/rust/src/generated/types/revoke_args.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum RevokeArgs {
     CollectionV1,
     TransferV1,

--- a/test/packages/rust/src/generated/types/revoke_args.rs
+++ b/test/packages/rust/src/generated/types/revoke_args.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/revoke_args.rs
+++ b/test/packages/rust/src/generated/types/revoke_args.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum RevokeArgs {
     CollectionV1,
     TransferV1,

--- a/test/packages/rust/src/generated/types/rule_set.rs
+++ b/test/packages/rust/src/generated/types/rule_set.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RuleSet {
     None,

--- a/test/packages/rust/src/generated/types/rule_set.rs
+++ b/test/packages/rust/src/generated/types/rule_set.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum RuleSet {
     None,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/rule_set.rs
+++ b/test/packages/rust/src/generated/types/rule_set.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RuleSet {
     None,
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/rule_set.rs
+++ b/test/packages/rust/src/generated/types/rule_set.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/set_collection_size_args.rs
+++ b/test/packages/rust/src/generated/types/set_collection_size_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct SetCollectionSizeArgs {
     pub size: u64,
 }

--- a/test/packages/rust/src/generated/types/set_collection_size_args.rs
+++ b/test/packages/rust/src/generated/types/set_collection_size_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetCollectionSizeArgs {
     pub size: u64,

--- a/test/packages/rust/src/generated/types/set_collection_size_args.rs
+++ b/test/packages/rust/src/generated/types/set_collection_size_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetCollectionSizeArgs {
     pub size: u64,
 }

--- a/test/packages/rust/src/generated/types/set_collection_size_args.rs
+++ b/test/packages/rust/src/generated/types/set_collection_size_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/ta_create_args.rs
+++ b/test/packages/rust/src/generated/types/ta_create_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TaCreateArgs {
     pub rule_set_name: String,
     pub serialized_rule_set: Vec<u8>,

--- a/test/packages/rust/src/generated/types/ta_create_args.rs
+++ b/test/packages/rust/src/generated/types/ta_create_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TaCreateArgs {
     pub rule_set_name: String,

--- a/test/packages/rust/src/generated/types/ta_create_args.rs
+++ b/test/packages/rust/src/generated/types/ta_create_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct TaCreateArgs {
     pub rule_set_name: String,
     pub serialized_rule_set: Vec<u8>,

--- a/test/packages/rust/src/generated/types/ta_create_args.rs
+++ b/test/packages/rust/src/generated/types/ta_create_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/ta_key.rs
+++ b/test/packages/rust/src/generated/types/ta_key.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum TaKey {
     Uninitialized,

--- a/test/packages/rust/src/generated/types/ta_key.rs
+++ b/test/packages/rust/src/generated/types/ta_key.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum TaKey {
     Uninitialized,
     Frequency,

--- a/test/packages/rust/src/generated/types/ta_key.rs
+++ b/test/packages/rust/src/generated/types/ta_key.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum TaKey {
     Uninitialized,
     Frequency,

--- a/test/packages/rust/src/generated/types/ta_key.rs
+++ b/test/packages/rust/src/generated/types/ta_key.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/tm_create_args.rs
+++ b/test/packages/rust/src/generated/types/tm_create_args.rs
@@ -6,11 +6,16 @@
 //!
 
 use crate::generated::types::AssetData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum TmCreateArgs {
     V1 {
         asset_data: AssetData,

--- a/test/packages/rust/src/generated/types/tm_create_args.rs
+++ b/test/packages/rust/src/generated/types/tm_create_args.rs
@@ -7,7 +7,6 @@
 
 use crate::generated::types::AssetData;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use crate::generated::types::AssetData;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TmCreateArgs {
     V1 {
         asset_data: AssetData,

--- a/test/packages/rust/src/generated/types/tm_create_args.rs
+++ b/test/packages/rust/src/generated/types/tm_create_args.rs
@@ -8,6 +8,7 @@
 use crate::generated::types::AssetData;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/tm_create_args.rs
+++ b/test/packages/rust/src/generated/types/tm_create_args.rs
@@ -6,16 +6,16 @@
 //!
 
 use crate::generated::types::AssetData;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TmCreateArgs {
     V1 {

--- a/test/packages/rust/src/generated/types/tm_key.rs
+++ b/test/packages/rust/src/generated/types/tm_key.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum TmKey {
     Uninitialized,
     EditionV1,

--- a/test/packages/rust/src/generated/types/tm_key.rs
+++ b/test/packages/rust/src/generated/types/tm_key.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum TmKey {
     Uninitialized,
     EditionV1,

--- a/test/packages/rust/src/generated/types/tm_key.rs
+++ b/test/packages/rust/src/generated/types/tm_key.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/tm_key.rs
+++ b/test/packages/rust/src/generated/types/tm_key.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum TmKey {
     Uninitialized,

--- a/test/packages/rust/src/generated/types/token_standard.rs
+++ b/test/packages/rust/src/generated/types/token_standard.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum TokenStandard {
     NonFungible,
     FungibleAsset,

--- a/test/packages/rust/src/generated/types/token_standard.rs
+++ b/test/packages/rust/src/generated/types/token_standard.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum TokenStandard {
     NonFungible,

--- a/test/packages/rust/src/generated/types/token_standard.rs
+++ b/test/packages/rust/src/generated/types/token_standard.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum TokenStandard {
     NonFungible,
     FungibleAsset,

--- a/test/packages/rust/src/generated/types/token_standard.rs
+++ b/test/packages/rust/src/generated/types/token_standard.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/transfer_args.rs
+++ b/test/packages/rust/src/generated/types/transfer_args.rs
@@ -7,7 +7,6 @@
 
 use crate::generated::types::AuthorizationData;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use crate::generated::types::AuthorizationData;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TransferArgs {
     V1 {
         authorization_data: Option<AuthorizationData>,

--- a/test/packages/rust/src/generated/types/transfer_args.rs
+++ b/test/packages/rust/src/generated/types/transfer_args.rs
@@ -6,16 +6,16 @@
 //!
 
 use crate::generated::types::AuthorizationData;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TransferArgs {
     V1 {

--- a/test/packages/rust/src/generated/types/transfer_args.rs
+++ b/test/packages/rust/src/generated/types/transfer_args.rs
@@ -6,11 +6,16 @@
 //!
 
 use crate::generated::types::AuthorizationData;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum TransferArgs {
     V1 {
         authorization_data: Option<AuthorizationData>,

--- a/test/packages/rust/src/generated/types/transfer_args.rs
+++ b/test/packages/rust/src/generated/types/transfer_args.rs
@@ -8,6 +8,7 @@
 use crate::generated::types::AuthorizationData;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/update_args.rs
+++ b/test/packages/rust/src/generated/types/update_args.rs
@@ -14,17 +14,17 @@ use crate::generated::types::DelegateState;
 use crate::generated::types::ProgrammableConfig;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UpdateArgs {
     V1 {
@@ -43,15 +43,9 @@ pub enum UpdateArgs {
     },
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateArgsV1Data {
     pub name: String,

--- a/test/packages/rust/src/generated/types/update_args.rs
+++ b/test/packages/rust/src/generated/types/update_args.rs
@@ -16,7 +16,6 @@ use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -26,6 +25,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UpdateArgs {
     V1 {
         authorization_data: Option<AuthorizationData>,
@@ -43,7 +43,6 @@ pub enum UpdateArgs {
     },
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -53,6 +52,7 @@ pub enum UpdateArgs {
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateArgsV1Data {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/update_args.rs
+++ b/test/packages/rust/src/generated/types/update_args.rs
@@ -17,6 +17,7 @@ use crate::generated::types::Uses;
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
@@ -43,6 +44,7 @@ pub enum UpdateArgs {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/update_args.rs
+++ b/test/packages/rust/src/generated/types/update_args.rs
@@ -14,12 +14,17 @@ use crate::generated::types::DelegateState;
 use crate::generated::types::ProgrammableConfig;
 use crate::generated::types::TokenStandard;
 use crate::generated::types::Uses;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum UpdateArgs {
     V1 {
         authorization_data: Option<AuthorizationData>,
@@ -37,8 +42,15 @@ pub enum UpdateArgs {
     },
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct UpdateArgsV1Data {
     pub name: String,
     pub symbol: String,

--- a/test/packages/rust/src/generated/types/update_delegate.rs
+++ b/test/packages/rust/src/generated/types/update_delegate.rs
@@ -5,12 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct UpdateDelegate {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/update_delegate.rs
+++ b/test/packages/rust/src/generated/types/update_delegate.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use solana_program::pubkey::Pubkey;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateDelegate {
     #[cfg_attr(

--- a/test/packages/rust/src/generated/types/update_delegate.rs
+++ b/test/packages/rust/src/generated/types/update_delegate.rs
@@ -7,7 +7,6 @@
 
 use solana_program::pubkey::Pubkey;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use solana_program::pubkey::Pubkey;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateDelegate {
     #[cfg_attr(
         feature = "serde",

--- a/test/packages/rust/src/generated/types/update_delegate.rs
+++ b/test/packages/rust/src/generated/types/update_delegate.rs
@@ -8,6 +8,7 @@
 use solana_program::pubkey::Pubkey;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/use_asset_args.rs
+++ b/test/packages/rust/src/generated/types/use_asset_args.rs
@@ -5,15 +5,16 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UseAssetArgs {
     V1 { use_count: u64 },

--- a/test/packages/rust/src/generated/types/use_asset_args.rs
+++ b/test/packages/rust/src/generated/types/use_asset_args.rs
@@ -5,11 +5,15 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
-
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum UseAssetArgs {
     V1 { use_count: u64 },
 }

--- a/test/packages/rust/src/generated/types/use_asset_args.rs
+++ b/test/packages/rust/src/generated/types/use_asset_args.rs
@@ -5,7 +5,6 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -15,6 +14,7 @@
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UseAssetArgs {
     V1 { use_count: u64 },
 }

--- a/test/packages/rust/src/generated/types/use_asset_args.rs
+++ b/test/packages/rust/src/generated/types/use_asset_args.rs
@@ -6,6 +6,7 @@
 //!
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/use_method.rs
+++ b/test/packages/rust/src/generated/types/use_method.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum UseMethod {
     Burn,
     Multiple,

--- a/test/packages/rust/src/generated/types/use_method.rs
+++ b/test/packages/rust/src/generated/types/use_method.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/use_method.rs
+++ b/test/packages/rust/src/generated/types/use_method.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum UseMethod {
     Burn,
     Multiple,

--- a/test/packages/rust/src/generated/types/use_method.rs
+++ b/test/packages/rust/src/generated/types/use_method.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum UseMethod {
     Burn,

--- a/test/packages/rust/src/generated/types/uses.rs
+++ b/test/packages/rust/src/generated/types/uses.rs
@@ -6,16 +6,16 @@
 //!
 
 use crate::generated::types::UseMethod;
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Uses {
     pub use_method: UseMethod,

--- a/test/packages/rust/src/generated/types/uses.rs
+++ b/test/packages/rust/src/generated/types/uses.rs
@@ -6,11 +6,16 @@
 //!
 
 use crate::generated::types::UseMethod;
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 
-#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub struct Uses {
     pub use_method: UseMethod,
     pub remaining: u64,

--- a/test/packages/rust/src/generated/types/uses.rs
+++ b/test/packages/rust/src/generated/types/uses.rs
@@ -8,6 +8,7 @@
 use crate::generated::types::UseMethod;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/uses.rs
+++ b/test/packages/rust/src/generated/types/uses.rs
@@ -7,7 +7,6 @@
 
 use crate::generated::types::UseMethod;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use crate::generated::types::UseMethod;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Uses {
     pub use_method: UseMethod,
     pub remaining: u64,

--- a/test/packages/rust/src/generated/types/verify_args.rs
+++ b/test/packages/rust/src/generated/types/verify_args.rs
@@ -8,6 +8,7 @@
 use num_derive::FromPrimitive;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)

--- a/test/packages/rust/src/generated/types/verify_args.rs
+++ b/test/packages/rust/src/generated/types/verify_args.rs
@@ -5,17 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
+#[cfg(feature = "anchor")]
+use anchor_lang::prelude::{AnchorDeserialize, AnchorSerialize};
+#[cfg(not(feature = "anchor"))]
+use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    not(feature = "anchor"),
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-#[cfg_attr(
-    feature = "anchor",
-    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
-)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(not(feature = "anchor"), derive(BorshSerialize, BorshDeserialize))]
+#[cfg_attr(feature = "anchor", derive(AnchorSerialize, AnchorDeserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum VerifyArgs {
     V1,

--- a/test/packages/rust/src/generated/types/verify_args.rs
+++ b/test/packages/rust/src/generated/types/verify_args.rs
@@ -7,7 +7,6 @@
 
 use num_derive::FromPrimitive;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     not(feature = "anchor"),
@@ -17,6 +16,7 @@ use num_derive::FromPrimitive;
     feature = "anchor",
     derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
 )]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
 pub enum VerifyArgs {
     V1,
 }

--- a/test/packages/rust/src/generated/types/verify_args.rs
+++ b/test/packages/rust/src/generated/types/verify_args.rs
@@ -5,14 +5,17 @@
 //! [https://github.com/metaplex-foundation/kinobi]
 //!
 
-use borsh::BorshDeserialize;
-use borsh::BorshSerialize;
 use num_derive::FromPrimitive;
 
-#[derive(
-    BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive,
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, FromPrimitive)]
+#[cfg_attr(
+    not(feature = "anchor"),
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "anchor",
+    derive(anchor_lang::AnchorSerialize, anchor_lang::AnchorDeserialize)
+)]
 pub enum VerifyArgs {
     V1,
 }

--- a/test/pubkey_tests.json
+++ b/test/pubkey_tests.json
@@ -52,7 +52,7 @@
   ],
   "metadata": {
     "origin": "shank",
-    "address": "PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d",
+    "address": "PubkeyTests1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7",
     "binaryVersion": "0.4.2",
     "libVersion": "0.4.2"
   }


### PR DESCRIPTION
With Anchor 0.30.0, IDLs are more dynamically generated using the IDL build trait. This is itself embedded in the AnchorSerialize trait. This PR providers a choice between Anchor and Borsh serialization to make it easier to interface between Anchor and MPL programs.