### PR TITLE
Nested structs

### DIFF
--- a/src/renderers/js/getRenderMapVisitor.ts
+++ b/src/renderers/js/getRenderMapVisitor.ts
@@ -19,6 +19,7 @@ import {
 import {
   camelCase,
   getGpaFieldsFromAccount,
+  getNestedGpaFieldsFromAccount,
   ImportFrom,
   LinkableDictionary,
   logWarn,
@@ -341,19 +342,15 @@ export function getRenderMapVisitor(
           }
 
           // GPA Fields.
-          const gpaFields = getGpaFieldsFromAccount(node, byteSizeVisitor).map(
-            (gpaField) => {
-              const gpaFieldManifest = visit(
-                gpaField.type,
-                typeManifestVisitor
-              );
-              imports.mergeWith(
-                gpaFieldManifest.looseImports,
-                gpaFieldManifest.serializerImports
-              );
-              return { ...gpaField, manifest: gpaFieldManifest };
-            }
-          );
+          const rawGpaFields = getGpaFieldsFromAccount(node, byteSizeVisitor);
+          const gpaFields = rawGpaFields.map((gpaField) => {
+            const gpaFieldManifest = visit(gpaField.type, typeManifestVisitor);
+            imports.mergeWith(
+              gpaFieldManifest.looseImports,
+              gpaFieldManifest.serializerImports
+            );
+            return { ...gpaField, manifest: gpaFieldManifest };
+          });
           let resolvedGpaFields: { type: string; argument: string } | null =
             null;
           if (gpaFields.length > 0) {
@@ -370,6 +367,36 @@ export function getRenderMapVisitor(
                 .join(', ')} }`,
             };
           }
+
+          // Nested GPA Fields for registerNestedFieldsFromStruct.
+          const nestedGpaFields = getNestedGpaFieldsFromAccount(
+            rawGpaFields,
+            linkables
+          );
+          const resolvedNestedGpaFields = nestedGpaFields.map((nested) => {
+            const processedFields = nested.fields.map((field) => {
+              const fieldManifest = visit(field.type, typeManifestVisitor);
+              imports.mergeWith(
+                fieldManifest.looseImports,
+                fieldManifest.serializerImports
+              );
+              return {
+                name: field.name,
+                looseType: fieldManifest.looseType,
+                serializer: fieldManifest.serializer,
+              };
+            });
+
+            return {
+              parentFieldName: nested.parentFieldName,
+              parentOffset:
+                nested.parentOffset === null ? 'null' : `${nested.parentOffset}`,
+              structTypeName: pascalCase(nested.structTypeName),
+              fieldsArgument: `[${processedFields
+                .map((f) => `['${f.name}', ${f.serializer}]`)
+                .join(', ')}]`,
+            };
+          });
 
           // Seeds.
           const pda = node.pda ? linkables.get(node.pda) : undefined;
@@ -412,6 +439,7 @@ export function getRenderMapVisitor(
               typeManifest,
               discriminator: resolvedDiscriminator,
               gpaFields: resolvedGpaFields,
+              nestedGpaFields: resolvedNestedGpaFields,
               seeds,
               hasVariableSeeds,
               customData,

--- a/src/renderers/js/templates/accountsPage.njk
+++ b/src/renderers/js/templates/accountsPage.njk
@@ -68,6 +68,9 @@ export function get{{ account.name | pascalCase }}GpaBuilder(context: Pick<Conte
   const programId = context.programs.getPublicKey('{{ program.name | camelCase }}', '{{ program.publicKey }}');
   return gpaBuilder(context, programId)
     .registerFields<{{ gpaFields.type }}>({{ gpaFields.argument }})
+    {%- for nested in nestedGpaFields %}
+    .registerNestedFieldsFromStruct<{{ nested.structTypeName }}Args>('{{ nested.parentFieldName }}', {{ nested.parentOffset }}, {{ nested.fieldsArgument }})
+    {%- endfor %}
     .deserializeUsing<{{ account.name | pascalCase }}>((account) => deserialize{{ account.name | pascalCase }}(account))
     {%- if discriminator.kind === 'fieldDiscriminatorNode' %}
       .whereField('{{ discriminator.name }}', {{ discriminator.value }})

--- a/src/shared/GpaField.ts
+++ b/src/shared/GpaField.ts
@@ -1,10 +1,30 @@
-import type { AccountNode, RegisteredTypeNodeKind, TypeNode } from '../nodes';
+import {
+  isNode,
+  type AccountNode,
+  type DefinedTypeLinkNode,
+  type DefinedTypeNode,
+  type RegisteredTypeNodeKind,
+  type StructFieldTypeNode,
+  type StructTypeNode,
+  type TypeNode,
+} from '../nodes';
 import { Visitor, visit } from '../visitors';
+import { LinkableDictionary } from './LinkableDictionary';
 
 export type GpaField = {
   name: string;
   offset: number | null;
   type: TypeNode;
+};
+
+export type NestedGpaField = {
+  parentFieldName: string;
+  parentOffset: number | null;
+  structTypeName: string;
+  fields: Array<{
+    name: string;
+    type: TypeNode;
+  }>;
 };
 
 export function getGpaFieldsFromAccount(
@@ -23,4 +43,55 @@ export function getGpaFieldsFromAccount(
     }
     return { name: field.name, offset: fieldOffset, type: field.type };
   });
+}
+
+/**
+ * Extracts nested struct fields from GPA fields for generating
+ * registerNestedFieldsFromStruct calls.
+ */
+export function getNestedGpaFieldsFromAccount(
+  gpaFields: GpaField[],
+  linkables: LinkableDictionary
+): NestedGpaField[] {
+  const nestedFields: NestedGpaField[] = [];
+
+  for (const gpaField of gpaFields) {
+    // Check if this field is a defined type link
+    if (!isNode(gpaField.type, 'definedTypeLinkNode')) {
+      continue;
+    }
+
+    const linkNode = gpaField.type as DefinedTypeLinkNode;
+
+    // Skip if it's an imported type (external)
+    if (linkNode.importFrom) {
+      continue;
+    }
+
+    // Look up the defined type
+    const definedType = linkables.get(linkNode) as DefinedTypeNode | undefined;
+    if (!definedType) {
+      continue;
+    }
+
+    // Check if the defined type is a struct
+    if (!isNode(definedType.type, 'structTypeNode')) {
+      continue;
+    }
+
+    const structType = definedType.type as StructTypeNode;
+
+    // Extract the struct fields
+    nestedFields.push({
+      parentFieldName: gpaField.name,
+      parentOffset: gpaField.offset,
+      structTypeName: definedType.name,
+      fields: structType.fields.map((field: StructFieldTypeNode) => ({
+        name: field.name,
+        type: field.type,
+      })),
+    });
+  }
+
+  return nestedFields;
 }


### PR DESCRIPTION
This change adds support for generating `registerNestedFieldsFromStruct` calls in the JavaScript renderer when an account has fields that are direct references to struct types.

The feature allows users to filter on nested struct fields using dot-notation paths (e.g., 'data.itemsAvailable', 'data.isMutable') when querying accounts via GPA builders.

Changes:
- Add `getNestedGpaFieldsFromAccount` function to extract nested struct field information from GPA fields
- Add `NestedGpaField` type for representing nested struct metadata
- Update `getRenderMapVisitor.ts` to process nested struct fields and pass them to the template
- Update `accountsPage.njk` template to render `registerNestedFieldsFromStruct` calls for each nested struct field

This integrates with the umi commit 5bf24455d1b42f338d675ac22a87e2d3b9f48668 which added the `registerNestedFieldsFromStruct` method to the GpaBuilder class.